### PR TITLE
feat(search): add Watch search readiness eval suite

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -121,6 +121,12 @@ A visible search-bar suggestion produced when the typed query appears to be in a
 
 A Search Pipeline Mode that keeps semantic retrieval available while strengthening lexical and title-driven retrieval so exact or near-title matches are not diluted by broad semantic similarity.
 
+### Semantic-Only Search
+
+A diagnostic Search Pipeline Mode for eval runs that isolates semantic/vector retrieval by excluding keyword, title, and full-text candidate retrieval.
+
+Semantic-Only Search is for measuring whether Content Embeddings can find relevant content without lexical retrieval helping the result set. It is not a public Watch search behavior unless a separate product decision makes it one.
+
 ### Search Degradation Signal
 
 The response-side state that says whether semantic retrieval actually contributed to a search response. It reflects runtime embedding availability, not the requested Search Pipeline Mode.

--- a/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
@@ -113,6 +113,7 @@ describe("POST /api/internal/search-eval/search", () => {
       limit: 10,
       offset: undefined,
       mode: "keyword-first",
+      allowInternalEvalModes: true,
       contentTypes: ["video"],
     })
     expect(recordSearchTraceSafely).not.toHaveBeenCalled()
@@ -140,6 +141,7 @@ describe("POST /api/internal/search-eval/search", () => {
         query: "Jesus",
         locale: "es",
         limit: 10,
+        allowInternalEvalModes: true,
       }),
     )
   })

--- a/apps/admin/src/app/api/internal/search-eval/search/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.ts
@@ -237,6 +237,7 @@ export async function POST(request: Request): Promise<Response> {
       limit: params.limit,
       offset: params.offset,
       mode: params.mode,
+      allowInternalEvalModes: true,
       contentTypes: params.contentTypes,
     })
     console.info(

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -244,4 +244,110 @@ describe("HybridSearchService keyword-first branch", () => {
     expect(searchByTrigram).toHaveBeenCalled()
     expect(searchByExactTitle).toHaveBeenCalled()
   })
+
+  it("dispatches semantic retrievers only when semantic-only is enabled for internal eval", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "semantic-only",
+      allowInternalEvalModes: true,
+    })
+
+    expect(searchVideoSemantic).toHaveBeenCalledWith(mockPrisma, {
+      queryEmbedding: "[0.1,0.2,0.3]",
+      locale: "en",
+      limit: 60,
+    })
+    expect(searchExperienceSemantic).toHaveBeenCalledWith(mockPrisma, {
+      queryEmbedding: "[0.1,0.2,0.3]",
+      locale: "en",
+      limit: 60,
+    })
+    expect(searchVideoKeyword).not.toHaveBeenCalled()
+    expect(searchExperienceKeyword).not.toHaveBeenCalled()
+    expect(searchByKeywordWeighted).not.toHaveBeenCalled()
+    expect(searchByTrigram).not.toHaveBeenCalled()
+    expect(searchByExactTitle).not.toHaveBeenCalled()
+  })
+
+  it("keeps semantic-only internal and falls back to hybrid without the eval flag", async () => {
+    const warn = vi.fn()
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn, error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "semantic-only",
+    })
+
+    expect(searchVideoKeyword).toHaveBeenCalled()
+    expect(searchExperienceKeyword).toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("semantic-only"))
+  })
+
+  it("semantic-only video content type skips experience retrievers", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "semantic-only",
+      allowInternalEvalModes: true,
+      contentTypes: ["video"],
+    })
+
+    expect(searchVideoSemantic).toHaveBeenCalled()
+    expect(searchExperienceSemantic).not.toHaveBeenCalled()
+    expect(searchExperienceKeyword).not.toHaveBeenCalled()
+    expect(searchVideoKeyword).not.toHaveBeenCalled()
+    expect(searchByKeywordWeighted).not.toHaveBeenCalled()
+    expect(searchByTrigram).not.toHaveBeenCalled()
+    expect(searchByExactTitle).not.toHaveBeenCalled()
+  })
+
+  it("semantic-only embedding failure returns an empty degraded response without lexical fallback", async () => {
+    const failingEmbedder: QueryEmbedder = vi
+      .fn()
+      .mockRejectedValue(new Error("provider down"))
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: failingEmbedder,
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const result = await service.search({
+      query: "jesus",
+      locale: "en",
+      mode: "semantic-only",
+      allowInternalEvalModes: true,
+    })
+
+    expect(result).toMatchObject({
+      results: [],
+      hasMore: false,
+      query: "jesus",
+      searchMode: "keyword-only",
+    })
+    expect(searchVideoSemantic).not.toHaveBeenCalled()
+    expect(searchExperienceSemantic).not.toHaveBeenCalled()
+    expect(searchVideoKeyword).not.toHaveBeenCalled()
+    expect(searchExperienceKeyword).not.toHaveBeenCalled()
+    expect(searchByKeywordWeighted).not.toHaveBeenCalled()
+    expect(searchByTrigram).not.toHaveBeenCalled()
+    expect(searchByExactTitle).not.toHaveBeenCalled()
+  })
 })

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -785,6 +785,25 @@ describe("normalizeMode", () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it("recognizes 'semantic-only' only for internal eval callers", () => {
+    const warn = vi.fn()
+    expect(
+      normalizeMode(
+        "semantic-only",
+        { warn },
+        { allowInternalEvalModes: true },
+      ),
+    ).toBe("semantic-only")
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it("treats public 'semantic-only' as unknown and falls back to hybrid", () => {
+    const warn = vi.fn()
+    expect(normalizeMode("semantic-only", { warn })).toBe("hybrid")
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain("mode=semantic-only")
+  })
+
   it("is case-sensitive — 'HYBRID' / 'Keyword-First' are unknown", () => {
     const warn = vi.fn()
     expect(normalizeMode("HYBRID", { warn })).toBe("hybrid")

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -104,6 +104,13 @@ export type SearchParams = {
    */
   mode?: string | null
   /**
+   * Internal eval-only escape hatch for diagnostic retrieval modes.
+   * Public REST and GraphQL must not set this; keeping the flag private
+   * lets those boundaries continue forwarding raw `mode` strings while
+   * unknown values safely fall back to hybrid.
+   */
+  allowInternalEvalModes?: boolean
+  /**
    * When true, the orchestrator attaches per-result internal scoring
    * detail under `result.debug` (per-retriever ranks, fused score,
    * dilution-cap state). The boundary is responsible for origin-gating
@@ -134,7 +141,7 @@ export type SearchResultDebug = {
  * stays a nullable string so `normalizeMode` can warn-and-fall-back on
  * unknown values without breaking clients on rollouts of new modes.
  */
-export type SearchPipelineMode = "hybrid" | "keyword-first"
+export type SearchPipelineMode = "hybrid" | "keyword-first" | "semantic-only"
 
 /**
  * Sanitizer for user-supplied values that get interpolated into
@@ -164,9 +171,13 @@ export function sanitizeForLog(raw: unknown): string {
 export function normalizeMode(
   raw: string | null | undefined,
   logger: { warn: (message: string) => void },
+  options: { allowInternalEvalModes?: boolean } = {},
 ): SearchPipelineMode {
   if (raw == null || raw === "" || raw === "hybrid") return "hybrid"
   if (raw === "keyword-first") return "keyword-first"
+  if (raw === "semantic-only" && options.allowInternalEvalModes === true) {
+    return "semantic-only"
+  }
   logger.warn(
     `[search] event=search_unknown_mode mode=${sanitizeForLog(raw)} falling_back=hybrid`,
   )
@@ -220,7 +231,7 @@ export type SearchResult = {
  * Describes which retrieval paths actually contributed to a response.
  *
  * - `"hybrid"`: the query embedding was generated successfully and
- *   semantic retrieval ran alongside keyword. Steady state.
+ *   semantic retrieval ran. Steady state.
  * - `"keyword-only"`: the query embedding call failed (provider outage,
  *   missing/invalid API key, network egress blocked) and the response
  *   was assembled from keyword retrieval alone. Response is still
@@ -611,7 +622,10 @@ export class HybridSearchService {
     // to "hybrid" without throwing — same contract REST + GraphQL
     // surface to clients. Computed once per call so the warn log fires
     // at most once.
-    const pipelineMode = normalizeMode(params.mode, this.logger)
+    const pipelineMode = normalizeMode(params.mode, this.logger, {
+      allowInternalEvalModes: params.allowInternalEvalModes,
+    })
+    const semanticOnly = pipelineMode === "semantic-only"
     const limit = Math.min(
       Math.max(1, params.limit ?? DEFAULT_LIMIT),
       MAX_LIMIT,
@@ -661,8 +675,7 @@ export class HybridSearchService {
     const retrievals: Retrieval[] = []
 
     if (wantsVideos) {
-      // Semantic-video is shared between hybrid and keyword-first —
-      // both pipelines benefit from scene-level vector matches.
+      // Semantic-video is shared by every embedding-backed pipeline.
       retrievals.push({
         label: "semantic-video",
         promise:
@@ -705,7 +718,7 @@ export class HybridSearchService {
             limit: overfetchLimit,
           }) as Promise<RankedItem[]>,
         })
-      } else {
+      } else if (!semanticOnly) {
         // Hybrid path — UNCHANGED from R4. Byte-identity locked in by
         // hybrid-search.regression.test.ts.
         retrievals.push({
@@ -731,14 +744,16 @@ export class HybridSearchService {
               }) as Promise<RankedItem[]>)
             : Promise.resolve([]),
       })
-      retrievals.push({
-        label: "keyword-experience",
-        promise: searchExperienceKeyword(this.prisma, {
-          query,
-          locale,
-          limit: overfetchLimit,
-        }) as Promise<RankedItem[]>,
-      })
+      if (!semanticOnly) {
+        retrievals.push({
+          label: "keyword-experience",
+          promise: searchExperienceKeyword(this.prisma, {
+            query,
+            locale,
+            limit: overfetchLimit,
+          }) as Promise<RankedItem[]>,
+        })
+      }
     }
 
     const outcomes = await Promise.allSettled(retrievals.map((r) => r.promise))
@@ -837,8 +852,9 @@ export class HybridSearchService {
       hasMore,
       query,
       // queryEmbeddingText is non-null iff the embedding call succeeded
-      // and both semantic retrievals were dispatched. If null, the
-      // response is assembled from keyword retrieval alone.
+      // and semantic retrieval could run. If null, public modes assemble
+      // from keyword retrieval alone; internal semantic-only returns an
+      // empty degraded response without lexical fallback.
       searchMode,
     }
 

--- a/apps/mastra/src/mastra/workflows/offline-search-eval.test.ts
+++ b/apps/mastra/src/mastra/workflows/offline-search-eval.test.ts
@@ -44,6 +44,19 @@ describe("offline search eval workflow route", () => {
     ).toBe("experience")
   })
 
+  it("accepts semantic-only as an internal diagnostic search mode", () => {
+    expect(
+      _internal.OfflineSearchEvalInputSchema.parse({
+        searchMode: "semantic-only",
+      }).searchMode,
+    ).toBe("semantic-only")
+    expect(
+      _internal.OfflineSearchEvalInputSchema.safeParse({
+        searchMode: "algolia-backed",
+      }).success,
+    ).toBe(false)
+  })
+
   it("exposes the structured input schema to Studio workflow metadata", () => {
     expect(offlineSearchEvalWorkflow.inputSchema).toBe(
       _internal.OfflineSearchEvalInputSchema,

--- a/apps/mastra/src/mastra/workflows/offline-search-eval.ts
+++ b/apps/mastra/src/mastra/workflows/offline-search-eval.ts
@@ -18,6 +18,11 @@ const WORKFLOW_FAILURE_ERROR_PREFIX = "OFFLINE_SEARCH_EVAL_WORKFLOW_FAILED:"
 const DEFAULT_BASELINE_NAME = "seed-baseline"
 const DEFAULT_SEARCH_MODE = "hybrid"
 const DEFAULT_CONTENT_TYPE = "all"
+const SEARCH_PIPELINE_MODES = [
+  "hybrid",
+  "keyword-first",
+  "semantic-only",
+] as const
 
 const OfflineSearchEvalInputSchema = z
   .object({
@@ -48,10 +53,10 @@ const OfflineSearchEvalInputSchema = z
       .default(20)
       .describe("Admin search results to collect per prompt."),
     searchMode: z
-      .enum(["hybrid", "keyword-first"])
+      .enum(SEARCH_PIPELINE_MODES)
       .default(DEFAULT_SEARCH_MODE)
       .describe(
-        "Search pipeline. Use hybrid for normal search; keyword-first tests the lexical-first candidate strategy.",
+        "Search pipeline. Use hybrid for normal search; keyword-first tests the lexical-first candidate strategy; semantic-only is an internal diagnostic eval mode.",
       ),
     contentType: z
       .enum(["all", "video", "experience"])

--- a/apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-candidate-review.ts
@@ -167,7 +167,7 @@ const nativeDatasetItemShape = {
     source: "seed | generated_* | user_submitted | promoted",
     searchOptions: {
       contentType: "video | experience | all",
-      mode: "hybrid | keyword-first",
+      mode: "hybrid | keyword-first | semantic-only",
     },
   },
   groundTruth: {

--- a/apps/mastra/src/mastra/workflows/search-eval-native-suite.test.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-native-suite.test.ts
@@ -305,19 +305,19 @@ describe("search eval native suite workflow", () => {
         action: "sync-report",
         reportId: "report-1",
         dataset: {
-          name: "search-eval:local:seed-baseline",
+          name: "search-eval:local:seed-baseline:hybrid",
           status: "created",
           itemCount: 1,
         },
         experiment: {
-          name: "search-eval-baseline:local:seed-baseline:report-1",
+          name: "search-eval-baseline:local:seed-baseline:hybrid:report-1",
           status: "created",
         },
         report: {
           mastraEvaluation: {
             integrationStatus: "native_synced",
             dataset: {
-              name: "search-eval:local:seed-baseline",
+              name: "search-eval:local:seed-baseline:hybrid",
               itemCount: 1,
             },
           },

--- a/apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts
@@ -287,6 +287,19 @@ describe("search eval orchestrator workflow", () => {
     )
   })
 
+  it("accepts semantic-only but rejects Algolia-backed search modes", () => {
+    expect(
+      _internal.SearchEvalOrchestratorWorkflowInputSchema.parse({
+        searchMode: "semantic-only",
+      }).searchMode,
+    ).toBe("semantic-only")
+    expect(
+      _internal.SearchEvalOrchestratorWorkflowInputSchema.safeParse({
+        searchMode: "algolia-backed",
+      }).success,
+    ).toBe(false)
+  })
+
   it("runs seed-baseline mode as offline baseline capture plus native report sync", async () => {
     const outputReport = report()
     const launchOffline = vi.fn(async (input) =>

--- a/apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts
+++ b/apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts
@@ -31,6 +31,11 @@ const DEFAULT_BASELINE_NAME = "seed-baseline"
 const DEFAULT_SEARCH_MODE = "hybrid"
 const DEFAULT_CONTENT_TYPE = "all"
 const DEFAULT_MODE = "seed-baseline"
+const SEARCH_PIPELINE_MODES = [
+  "hybrid",
+  "keyword-first",
+  "semantic-only",
+] as const
 
 const SafeNameSchema = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/)
 
@@ -61,9 +66,11 @@ export const SearchEvalOrchestratorWorkflowInputSchema = z
       .default(20)
       .describe("Admin search result limit per prompt."),
     searchMode: z
-      .enum(["hybrid", "keyword-first"])
+      .enum(SEARCH_PIPELINE_MODES)
       .default(DEFAULT_SEARCH_MODE)
-      .describe("Admin search pipeline to evaluate."),
+      .describe(
+        "Admin search pipeline to evaluate. semantic-only is an internal diagnostic eval mode.",
+      ),
     contentType: z
       .enum(["all", "video", "experience"])
       .default(DEFAULT_CONTENT_TYPE)

--- a/apps/mastra/src/services/offline-search-eval/artifacts.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/artifacts.test.ts
@@ -93,7 +93,7 @@ describe("search eval artifact store", () => {
       mastraEvaluation: {
         integrationStatus: "native_synced",
         dataset: {
-          name: "search-eval:local:default",
+          name: "search-eval:local:default:hybrid",
           datasetId: "dataset-1",
           source: "seed_prompt_set",
           version: "seed/v1",
@@ -101,7 +101,7 @@ describe("search eval artifact store", () => {
           targetType: "workflow",
           targetId: "offline-search-eval",
           environmentLabel: "local",
-          nativeKey: "search-eval:local:default:seed/v1",
+          nativeKey: "search-eval:local:default:seed/v1:mode:hybrid",
           status: "created",
         },
         scorers: [
@@ -113,14 +113,15 @@ describe("search eval artifact store", () => {
           },
         ],
         experiment: {
-          name: "search-eval-compare:local:default:run-1",
+          name: "search-eval-compare:local:default:hybrid:run-1",
           experimentId: "experiment-1",
           status: "created",
           mode: "comparison",
           reportId: "run-1",
           baselineName: "default",
           environmentLabel: "local",
-          nativeKey: "search-eval:local:default:seed/v1:report:run-1",
+          nativeKey:
+            "search-eval:local:default:seed/v1:mode:hybrid:report:run-1",
         },
       },
     }

--- a/apps/mastra/src/services/offline-search-eval/artifacts.ts
+++ b/apps/mastra/src/services/offline-search-eval/artifacts.ts
@@ -322,20 +322,43 @@ export const SearchEvalReportSchema = z
       report.mastraEvaluation.integrationStatus === "native_synced"
         ? report.mastraEvaluation.dataset.environmentLabel
         : null
-    const expectedDatasetName =
+    const pipelineMode =
+      report.metadata.search.mode === "semantic-only"
+        ? "semantic-only"
+        : report.metadata.search.mode === "keyword-first"
+          ? "keyword-first"
+          : "hybrid"
+    const legacyDatasetName =
       environmentLabel == null
         ? `search-eval:${report.metadata.baselineName}`
         : `search-eval:${environmentLabel}:${report.metadata.baselineName}`
-    const expectedExperimentName =
+    const modeAwareDatasetName = `${legacyDatasetName}:${pipelineMode}`
+    const expectedDatasetNames = [
+      legacyDatasetName,
+      modeAwareDatasetName,
+    ] as const
+    const legacyExperimentName =
       environmentLabel == null
         ? `search-eval-${expectedExperimentVerb}:${report.metadata.baselineName}:${report.reportId}`
         : `search-eval-${expectedExperimentVerb}:${environmentLabel}:${report.metadata.baselineName}:${report.reportId}`
+    const modeAwareExperimentName =
+      environmentLabel == null
+        ? `search-eval-${expectedExperimentVerb}:${report.metadata.baselineName}:${pipelineMode}:${report.reportId}`
+        : `search-eval-${expectedExperimentVerb}:${environmentLabel}:${report.metadata.baselineName}:${pipelineMode}:${report.reportId}`
+    const expectedExperimentNames = [
+      legacyExperimentName,
+      modeAwareExperimentName,
+    ] as const
 
-    if (report.mastraEvaluation.dataset.name !== expectedDatasetName) {
+    if (
+      !(expectedDatasetNames as readonly string[]).includes(
+        report.mastraEvaluation.dataset.name,
+      )
+    ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["mastraEvaluation", "dataset", "name"],
-        message: "dataset name must match the report baseline name",
+        message: "dataset name must match the report baseline name and mode",
       })
     }
     if (
@@ -355,11 +378,15 @@ export const SearchEvalReportSchema = z
         message: "dataset item count must match report outcome count",
       })
     }
-    if (report.mastraEvaluation.experiment.name !== expectedExperimentName) {
+    if (
+      !(expectedExperimentNames as readonly string[]).includes(
+        report.mastraEvaluation.experiment.name,
+      )
+    ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["mastraEvaluation", "experiment", "name"],
-        message: "experiment name must match the report kind and id",
+        message: "experiment name must match the report kind, mode, and id",
       })
     }
     if (report.mastraEvaluation.experiment.mode !== expectedExperimentMode) {

--- a/apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts
@@ -238,6 +238,81 @@ describe("native search eval projection", () => {
     expect(result.reason).toContain("judge-disagreement")
   })
 
+  it("preserves semantic-only mode and source-key identity in native records", async () => {
+    const mastra = createFakeMastra()
+    const sample = createSampleSearchEvalReport({
+      runId: "sample-run-1",
+      now: new Date("2026-05-28T00:00:00.000Z"),
+    })
+    const report = {
+      ...sample,
+      metadata: {
+        ...sample.metadata,
+        search: {
+          ...sample.metadata.search,
+          mode: "semantic-only",
+        },
+      },
+    }
+
+    await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report,
+      environmentLabel: "local",
+    })
+
+    const item = mastra.datasetsById.get("dataset-1")?.items[0]
+    expect(item?.input).toMatchObject({
+      searchOptions: { mode: "semantic-only" },
+    })
+    expect(item?.metadata).toMatchObject({
+      forgeSearchEval: {
+        sourceKey: expect.stringContaining("mode:semantic-only"),
+      },
+    })
+  })
+
+  it("keeps different requested modes in separate native datasets", async () => {
+    const mastra = createFakeMastra()
+    const hybridReport = createSampleSearchEvalReport({
+      runId: "sample-run-hybrid",
+      now: new Date("2026-05-28T00:00:00.000Z"),
+    })
+    const semanticOnlyReport = {
+      ...createSampleSearchEvalReport({
+        runId: "sample-run-semantic",
+        now: new Date("2026-05-28T00:01:00.000Z"),
+      }),
+      metadata: {
+        ...hybridReport.metadata,
+        mastraRunId: "sample-run-semantic",
+        search: {
+          ...hybridReport.metadata.search,
+          mode: "semantic-only",
+        },
+      },
+    }
+
+    const first = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report: hybridReport,
+      environmentLabel: "local",
+    })
+    const second = await syncSearchEvalReportToNativeEvaluation({
+      mastra,
+      report: semanticOnlyReport,
+      environmentLabel: "local",
+    })
+
+    expect(first.dataset.nativeKey).toContain("mode:hybrid")
+    expect(second.dataset.nativeKey).toContain("mode:semantic-only")
+    expect(second.dataset.datasetId).not.toBe(first.dataset.datasetId)
+    expect(mastra.records.map((record) => record.name)).toEqual([
+      "search-eval:local:local-smoke:hybrid",
+      "search-eval:local:local-smoke:semantic-only",
+    ])
+  })
+
   it("syncs a report into native records idempotently", async () => {
     const mastra = createFakeMastra()
     const report = createSampleSearchEvalReport({

--- a/apps/mastra/src/services/offline-search-eval/native-evaluation.ts
+++ b/apps/mastra/src/services/offline-search-eval/native-evaluation.ts
@@ -24,6 +24,11 @@ const NATIVE_SEARCH_EVAL_TARGET_ID = "offline-search-eval" as const
 const SAMPLE_PROMPT_SET_VERSION = "sample/search-eval/v1"
 const NATIVE_LIST_PAGE_SIZE = 200
 const MAX_NATIVE_LIST_PAGES = 25
+const SEARCH_PIPELINE_MODES = [
+  "hybrid",
+  "keyword-first",
+  "semantic-only",
+] as const
 
 type NativeScorer = MastraScorer<
   string,
@@ -60,7 +65,7 @@ export const NativeSearchEvalInputSchema = z
     searchOptions: z
       .object({
         limit: z.number().int().positive(),
-        mode: z.enum(["hybrid", "keyword-first"]),
+        mode: z.enum(SEARCH_PIPELINE_MODES),
         contentType: z.enum(["all", "video", "experience"]),
       })
       .strict(),
@@ -440,14 +445,18 @@ function nativeReportDatasetName(
   report: SearchEvalReport,
   environmentLabel: string,
 ) {
-  return `search-eval:${environmentLabel}:${report.metadata.baselineName}`
+  return `search-eval:${environmentLabel}:${report.metadata.baselineName}:${searchMode(
+    report.metadata.search.mode,
+  )}`
 }
 
 function nativeReportDatasetKey(
   report: SearchEvalReport,
   environmentLabel: string,
 ) {
-  return `search-eval:${environmentLabel}:${report.metadata.baselineName}:${report.metadata.promptSetVersion}`
+  return `search-eval:${environmentLabel}:${report.metadata.baselineName}:${report.metadata.promptSetVersion}:mode:${searchMode(
+    report.metadata.search.mode,
+  )}`
 }
 
 function nativeReportExperimentName(
@@ -455,7 +464,9 @@ function nativeReportExperimentName(
   environmentLabel: string,
 ) {
   const verb = report.kind === "baseline-report" ? "baseline" : "compare"
-  return `search-eval-${verb}:${environmentLabel}:${report.metadata.baselineName}:${report.reportId}`
+  return `search-eval-${verb}:${environmentLabel}:${report.metadata.baselineName}:${searchMode(
+    report.metadata.search.mode,
+  )}:${report.reportId}`
 }
 
 function nativeReportExperimentKey(
@@ -879,7 +890,9 @@ function reportOutcomeSourceKey(
   report: SearchEvalReport,
   outcome: ComparisonOutcome,
 ) {
-  return `prompt-set:${report.metadata.promptSetVersion}:case:${outcome.caseId}`
+  return `prompt-set:${report.metadata.promptSetVersion}:mode:${searchMode(
+    report.metadata.search.mode,
+  )}:case:${outcome.caseId}`
 }
 
 function nativeResult(result: SearchEvalResult) {
@@ -902,7 +915,10 @@ function resultAnchor(result: SearchEvalResult) {
   }
 }
 
-function searchMode(mode: string | null): "hybrid" | "keyword-first" {
+function searchMode(
+  mode: string | null,
+): "hybrid" | "keyword-first" | "semantic-only" {
+  if (mode === "semantic-only") return "semantic-only"
   return mode === "keyword-first" ? "keyword-first" : "hybrid"
 }
 

--- a/apps/mastra/src/services/offline-search-eval/runner.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/runner.test.ts
@@ -153,6 +153,7 @@ describe("runOfflineSearchEval", () => {
         mode: "capture-baseline",
         baselineName: "default",
         locales: ["en"],
+        searchMode: "semantic-only",
         includeGeneratedCandidates: true,
       },
       {
@@ -190,12 +191,18 @@ describe("runOfflineSearchEval", () => {
     expect(searchClient).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
-          query: "Bible Project",
+          query: "bible project",
           locale: "en",
           languageSlug: "english",
+          mode: "semantic-only",
         }),
       }),
     )
+    expect(
+      searchClient.mock.calls.every(
+        (call) => call[0]?.payload.mode === "semantic-only",
+      ),
+    ).toBe(true)
     for (const call of searchClient.mock.calls) {
       expect(call[0]?.payload).not.toHaveProperty("websiteLocale")
     }

--- a/apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts
@@ -8,41 +8,128 @@ import {
 } from "./seed-prompt-set"
 
 describe("search eval seed prompt set", () => {
-  it("includes the first baseline examples with unique ids", () => {
-    const queries = SEARCH_EVAL_SEED_PROMPTS.map((prompt) => prompt.queryText)
-    for (const required of [
-      "Bible Project",
-      "Jesus",
-      "Who is Jesus?",
-      "videos for teens",
-      "resources for parents",
-      "new believer",
-      "small group Bible study",
-      "church leader training",
-      "películas bíblicas para niños",
-      "यीशु कौन हैं?",
-      "Jesus em português",
-      "Wer ist Jesus?",
-      "Кто такой Иисус?",
-      "من هو يسوع؟",
-    ]) {
-      expect(queries).toContain(required)
-    }
+  it("includes a 100-query launch-readiness suite with unique ids", () => {
+    expect(SEARCH_EVAL_SEED_PROMPTS).toHaveLength(100)
 
     const ids = SEARCH_EVAL_SEED_PROMPTS.map((prompt) => prompt.id)
     expect(new Set(ids).size).toBe(ids.length)
+
+    const queryLocales = SEARCH_EVAL_SEED_PROMPTS.map(
+      (prompt) =>
+        `${prompt.queryText.toLocaleLowerCase()}|${prompt.locale}|${
+          prompt.websiteLocale ?? ""
+        }`,
+    )
+    expect(new Set(queryLocales).size).toBe(queryLocales.length)
+  })
+
+  it("keeps the high-traffic Algolia baseline and legacy smoke prompts", () => {
+    expect(SEARCH_EVAL_SEED_PROMPTS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "seed-jesus",
+          queryText: "jesus",
+          tags: expect.arrayContaining(["algolia-top-search", "product-title"]),
+          operatorNotes: expect.stringContaining("count=88"),
+        }),
+        expect.objectContaining({
+          id: "seed-bible-project",
+          queryText: "bible project",
+          tags: expect.arrayContaining(["brand-intent", "product-title"]),
+          operatorNotes: expect.stringContaining("Bible Project videos"),
+        }),
+        expect.objectContaining({
+          id: "seed-who-is-jesus",
+          queryText: "Who is Jesus?",
+        }),
+        expect.objectContaining({
+          id: "seed-videos-for-teens",
+          queryText: "videos for teens",
+        }),
+        expect.objectContaining({
+          id: "seed-resources-for-parents",
+          queryText: "resources for parents",
+        }),
+        expect.objectContaining({
+          id: "seed-new-believer",
+          queryText: "new believer",
+        }),
+        expect.objectContaining({
+          id: "seed-small-group-bible-study",
+          queryText: "small group Bible study",
+        }),
+        expect.objectContaining({
+          id: "seed-church-leader-training",
+          queryText: "church leader training",
+        }),
+      ]),
+    )
+  })
+
+  it("covers every readiness category called out by the roadmap ticket", () => {
+    const tags = [
+      ...new Set(SEARCH_EVAL_SEED_PROMPTS.flatMap((prompt) => prompt.tags)),
+    ]
+
+    expect(tags).toEqual(
+      expect.arrayContaining([
+        "algolia-top-search",
+        "algolia-no-result",
+        "product-title",
+        "felt-need",
+        "bible-topic",
+        "misspelling",
+        "synonym",
+        "confusing",
+        "multilingual",
+        "scene-like",
+      ]),
+    )
+  })
+
+  it("includes Algolia no-result typo and confusing-query regressions", () => {
+    expect(SEARCH_EVAL_SEED_PROMPTS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "seed-walking-wih-jesus",
+          queryText: "walking wih jesus",
+          tags: expect.arrayContaining(["algolia-no-result", "misspelling"]),
+        }),
+        expect.objectContaining({
+          id: "seed-walking-wth-jesus",
+          queryText: "walking wth jesus",
+          tags: expect.arrayContaining(["algolia-no-result", "misspelling"]),
+        }),
+        expect.objectContaining({
+          id: "seed-jrius-daughter",
+          queryText: "jrius daughter",
+          tags: expect.arrayContaining(["misspelling", "scene-like"]),
+        }),
+        expect.objectContaining({
+          id: "seed-finding-hope-heavy",
+          queryText: "finding hope when life feels heavy",
+          tags: expect.arrayContaining(["algolia-no-result", "felt-need"]),
+        }),
+        expect.objectContaining({
+          id: "seed-world-cup-2026-outreach",
+          queryText: "world cup 2026 outreach",
+          tags: expect.arrayContaining(["algolia-no-result", "confusing"]),
+        }),
+      ]),
+    )
   })
 
   it("keeps prompt metadata non-gating and locale-filterable", () => {
     expect(SEARCH_EVAL_SEED_PROMPT_SET_VERSION).toBe(
-      "search-eval-seed-prompts/v4",
+      "search-eval-seed-prompts/v5",
     )
     expect(
       SEARCH_EVAL_SEED_PROMPTS.every(
         (prompt) =>
           prompt.source === "seed" &&
           /^[a-zA-Z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(prompt.locale) &&
-          /^[a-z0-9]+(-[a-z0-9]+)*$/.test(prompt.languageSlug ?? "") &&
+          (prompt.languageSlug == null ||
+            /^[a-z0-9]+(-[a-z0-9]+)*$/.test(prompt.languageSlug)) &&
           prompt.tags.length > 0,
       ),
     ).toBe(true)
@@ -51,19 +138,23 @@ describe("search eval seed prompt set", () => {
       seedPromptsForLocales(["fr"]).map((prompt) => prompt.locale),
     ).toEqual(["fr"])
 
-    expect(SEARCH_EVAL_SEED_PROMPT_LOCALES).toEqual([
-      "en",
-      "es",
-      "hi",
-      "fr",
-      "pt",
-      "de",
-      "ru",
-      "ar",
-    ])
+    expect(SEARCH_EVAL_SEED_PROMPT_LOCALES).toEqual(
+      expect.arrayContaining([
+        "en",
+        "es",
+        "hi",
+        "fr",
+        "pt",
+        "de",
+        "ru",
+        "ar",
+        "th",
+        "zh",
+      ]),
+    )
   })
 
-  it("includes website/watch locale mismatch cases", () => {
+  it("includes website/watch locale mismatch and non-Latin multilingual cases", () => {
     const mismatches = SEARCH_EVAL_SEED_PROMPTS.filter(
       (prompt) =>
         prompt.websiteLocale != null && prompt.websiteLocale !== prompt.locale,
@@ -82,6 +173,21 @@ describe("search eval seed prompt set", () => {
           locale: "en",
           languageSlug: "english",
           websiteLocale: "fr",
+        }),
+      ]),
+    )
+
+    expect(SEARCH_EVAL_SEED_PROMPTS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "seed-russian-who-is-jesus",
+          locale: "ru",
+          languageSlug: "russian",
+        }),
+        expect.objectContaining({
+          id: "seed-arabic-who-is-jesus",
+          locale: "ar",
+          languageSlug: "arabic-modern-standard",
         }),
       ]),
     )

--- a/apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts
+++ b/apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts
@@ -1,153 +1,803 @@
 import type { SeedPromptCase } from "./types"
 
-export const SEARCH_EVAL_SEED_PROMPT_SET_VERSION = "search-eval-seed-prompts/v4"
+export const SEARCH_EVAL_SEED_PROMPT_SET_VERSION = "search-eval-seed-prompts/v5"
+
+type SeedPromptInput = Omit<SeedPromptCase, "source">
+
+const ENGLISH = {
+  locale: "en",
+  languageSlug: "english",
+} as const
+
+function seedPrompt(input: SeedPromptInput): SeedPromptCase {
+  return {
+    ...input,
+    source: "seed",
+  }
+}
 
 export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
-  {
+  seedPrompt({
     id: "seed-bible-project",
-    locale: "en",
-    languageSlug: "english",
-    queryText: "Bible Project",
-    source: "seed",
-    tags: ["catalog", "brand-intent"],
-    operatorNotes: "Operator comment only; not expected-result truth.",
-  },
-  {
+    ...ENGLISH,
+    queryText: "bible project",
+    tags: ["catalog", "brand-intent", "product-title"],
+    operatorNotes:
+      "Keyword-first brand/product readiness case: should bring Bible Project videos back.",
+  }),
+  seedPrompt({
     id: "seed-jesus",
-    locale: "en",
-    languageSlug: "english",
-    queryText: "Jesus",
-    source: "seed",
-    tags: ["core-title", "catalog"],
-  },
-  {
+    ...ENGLISH,
+    queryText: "jesus",
+    tags: ["catalog", "core-title", "product-title", "algolia-top-search"],
+    operatorNotes:
+      "Algolia top non-empty query for video-variants-prd, 2026-05-22..2026-06-21: count=88, nbHits=395.",
+  }),
+  seedPrompt({
     id: "seed-who-is-jesus",
-    locale: "en",
-    languageSlug: "english",
+    ...ENGLISH,
     queryText: "Who is Jesus?",
-    source: "seed",
-    tags: ["question", "new-believer"],
-  },
-  {
+    tags: ["question", "new-believer", "bible-topic"],
+  }),
+  seedPrompt({
     id: "seed-videos-for-teens",
-    locale: "en",
-    languageSlug: "english",
+    ...ENGLISH,
     queryText: "videos for teens",
-    source: "seed",
-    tags: ["audience", "teens"],
-  },
-  {
+    tags: ["audience", "teens", "felt-need"],
+  }),
+  seedPrompt({
     id: "seed-resources-for-parents",
-    locale: "en",
-    languageSlug: "english",
+    ...ENGLISH,
     queryText: "resources for parents",
-    source: "seed",
-    tags: ["audience", "parents"],
-  },
-  {
+    tags: ["audience", "parents", "felt-need"],
+  }),
+  seedPrompt({
     id: "seed-new-believer",
-    locale: "en",
-    languageSlug: "english",
+    ...ENGLISH,
     queryText: "new believer",
-    source: "seed",
-    tags: ["discipleship", "new-believer"],
-  },
-  {
+    tags: ["discipleship", "new-believer", "felt-need"],
+  }),
+  seedPrompt({
     id: "seed-small-group-bible-study",
-    locale: "en",
-    languageSlug: "english",
+    ...ENGLISH,
     queryText: "small group Bible study",
-    source: "seed",
-    tags: ["ministry", "small-group"],
-  },
-  {
+    tags: ["ministry", "small-group", "felt-need"],
+  }),
+  seedPrompt({
     id: "seed-church-leader-training",
-    locale: "en",
-    languageSlug: "english",
+    ...ENGLISH,
     queryText: "church leader training",
-    source: "seed",
-    tags: ["ministry", "leaders"],
-  },
-  {
+    tags: ["ministry", "leaders", "felt-need"],
+  }),
+  seedPrompt({
+    id: "seed-world-cup",
+    ...ENGLISH,
+    queryText: "world cup",
+    tags: ["algolia-top-search", "confusing", "sports-outreach"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=27, nbHits=6.",
+  }),
+  seedPrompt({
+    id: "seed-walking-with-jesus",
+    ...ENGLISH,
+    queryText: "walking with jesus",
+    tags: ["algolia-top-search", "product-title", "discipleship"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=27, nbHits=5.",
+  }),
+  seedPrompt({
+    id: "seed-jesus-film",
+    ...ENGLISH,
+    queryText: "jesus film",
+    tags: ["algolia-top-search", "product-title", "core-title"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=21, nbHits=98.",
+  }),
+  seedPrompt({
+    id: "seed-lumo",
+    ...ENGLISH,
+    queryText: "lumo",
+    tags: ["algolia-top-search", "product-title"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=20, nbHits=88.",
+  }),
+  seedPrompt({
+    id: "seed-prayer",
+    ...ENGLISH,
+    queryText: "prayer",
+    tags: ["algolia-top-search", "felt-need", "bible-topic"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=17, nbHits=76.",
+  }),
+  seedPrompt({
+    id: "seed-rivka",
+    ...ENGLISH,
+    queryText: "rivka",
+    tags: ["algolia-top-search", "product-title"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=16, nbHits=17.",
+  }),
+  seedPrompt({
+    id: "seed-falling-plates",
+    ...ENGLISH,
+    queryText: "falling plates",
+    tags: ["algolia-top-search", "product-title"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=16, nbHits=1.",
+  }),
+  seedPrompt({
+    id: "seed-children",
+    ...ENGLISH,
+    queryText: "children",
+    tags: ["algolia-top-search", "audience", "children", "synonym"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=16, nbHits=14.",
+  }),
+  seedPrompt({
+    id: "seed-soccer",
+    ...ENGLISH,
+    queryText: "soccer",
+    tags: ["algolia-top-search", "sports-outreach", "synonym"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=16, nbHits=3.",
+  }),
+  seedPrompt({
+    id: "seed-futbol",
+    ...ENGLISH,
+    queryText: "futbol",
+    tags: ["algolia-top-search", "sports-outreach", "synonym", "multilingual"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=13, nbHits=4.",
+  }),
+  seedPrompt({
+    id: "seed-delight",
+    ...ENGLISH,
+    queryText: "delight",
+    tags: ["algolia-top-search", "felt-need", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=13, nbHits=2.",
+  }),
+  seedPrompt({
+    id: "seed-acts",
+    ...ENGLISH,
+    queryText: "acts",
+    tags: ["algolia-top-search", "bible-topic", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=12, nbHits=154.",
+  }),
+  seedPrompt({
+    id: "seed-marathi",
+    ...ENGLISH,
+    queryText: "marathi",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=12, nbHits=306.",
+  }),
+  seedPrompt({
+    id: "seed-pentecost",
+    ...ENGLISH,
+    queryText: "pentecost",
+    tags: ["algolia-top-search", "bible-topic"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=11, nbHits=3.",
+  }),
+  seedPrompt({
+    id: "seed-matthew",
+    ...ENGLISH,
+    queryText: "matthew",
+    tags: ["algolia-top-search", "bible-topic", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=9, nbHits=42.",
+  }),
+  seedPrompt({
+    id: "seed-good-news",
+    ...ENGLISH,
+    queryText: "good news",
+    tags: ["algolia-top-search", "felt-need", "synonym"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=9, nbHits=98.",
+  }),
+  seedPrompt({
+    id: "seed-the-four",
+    ...ENGLISH,
+    queryText: "the four",
+    tags: ["algolia-top-search", "product-title", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=9, nbHits=549.",
+  }),
+  seedPrompt({
+    id: "seed-ninos",
+    locale: "es",
+    languageSlug: "spanish-castilian",
+    websiteLocale: "en",
+    queryText: "ninos",
+    tags: [
+      "algolia-top-search",
+      "multilingual",
+      "audience",
+      "children",
+      "misspelling",
+      "mismatch",
+    ],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=9, nbHits=17.",
+  }),
+  seedPrompt({
+    id: "seed-love",
+    ...ENGLISH,
+    queryText: "love",
+    tags: ["algolia-top-search", "felt-need", "bible-topic"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=8, nbHits=269.",
+  }),
+  seedPrompt({
+    id: "seed-lozi",
+    ...ENGLISH,
+    queryText: "lozi",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=8, nbHits=180.",
+  }),
+  seedPrompt({
+    id: "seed-afrikaans",
+    ...ENGLISH,
+    queryText: "afrikaans",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=8, nbHits=281.",
+  }),
+  seedPrompt({
+    id: "seed-short-films",
+    ...ENGLISH,
+    queryText: "short films",
+    tags: ["algolia-top-search", "catalog", "synonym"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=8, nbHits=41.",
+  }),
+  seedPrompt({
+    id: "seed-birth-of-jesus",
+    ...ENGLISH,
+    queryText: "birth of jesus",
+    tags: ["algolia-top-search", "bible-topic", "scene-like"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=8, nbHits=10.",
+  }),
+  seedPrompt({
+    id: "seed-bible",
+    ...ENGLISH,
+    queryText: "bible",
+    tags: ["algolia-top-search", "catalog", "bible-topic"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=8, nbHits=113.",
+  }),
+  seedPrompt({
+    id: "seed-arabic",
+    locale: "ar",
+    languageSlug: "arabic-modern-standard",
+    websiteLocale: "en",
+    queryText: "arabic",
+    tags: ["algolia-top-search", "multilingual", "language-name", "mismatch"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=444.",
+  }),
+  seedPrompt({
+    id: "seed-reflection-of-hope",
+    ...ENGLISH,
+    queryText: "reflection of hope",
+    tags: ["algolia-top-search", "product-title", "felt-need"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=10.",
+  }),
+  seedPrompt({
+    id: "seed-punjabi",
+    ...ENGLISH,
+    queryText: "punjabi",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=225.",
+  }),
+  seedPrompt({
+    id: "seed-considering-christmas",
+    ...ENGLISH,
+    queryText: "considering christmas",
+    tags: ["algolia-top-search", "product-title", "seasonal"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=1.",
+  }),
+  seedPrompt({
+    id: "seed-nua",
+    ...ENGLISH,
+    queryText: "nua",
+    tags: ["algolia-top-search", "product-title"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=94.",
+  }),
+  seedPrompt({
+    id: "seed-luke",
+    ...ENGLISH,
+    queryText: "luke",
+    tags: ["algolia-top-search", "bible-topic", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=156.",
+  }),
+  seedPrompt({
+    id: "seed-farsi",
+    ...ENGLISH,
+    queryText: "farsi",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=448.",
+  }),
+  seedPrompt({
+    id: "seed-know-god",
+    ...ENGLISH,
+    queryText: "know god",
+    tags: ["algolia-top-search", "felt-need", "new-believer"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=7, nbHits=68.",
+  }),
+  seedPrompt({
+    id: "seed-the-last-supper",
+    ...ENGLISH,
+    queryText: "the last supper",
+    tags: ["algolia-top-search", "bible-topic", "scene-like"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=7.",
+  }),
+  seedPrompt({
+    id: "seed-you-can-talk",
+    ...ENGLISH,
+    queryText: "you can talk",
+    tags: ["algolia-top-search", "product-title", "felt-need"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=16.",
+  }),
+  seedPrompt({
+    id: "seed-bemba",
+    ...ENGLISH,
+    queryText: "bemba",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=316.",
+  }),
+  seedPrompt({
+    id: "seed-sport",
+    ...ENGLISH,
+    queryText: "sport",
+    tags: ["algolia-top-search", "sports-outreach", "synonym"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=187.",
+  }),
+  seedPrompt({
+    id: "seed-wonder",
+    ...ENGLISH,
+    queryText: "wonder",
+    tags: ["algolia-top-search", "product-title", "felt-need"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=75.",
+  }),
+  seedPrompt({
+    id: "seed-magdalena",
+    ...ENGLISH,
+    queryText: "magdalena",
+    tags: ["algolia-top-search", "product-title"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=56.",
+  }),
+  seedPrompt({
+    id: "seed-my-last-day",
+    ...ENGLISH,
+    queryText: "my last day",
+    tags: ["algolia-top-search", "product-title"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=7.",
+  }),
+  seedPrompt({
+    id: "seed-disciples",
+    ...ENGLISH,
+    queryText: "disciples",
+    tags: ["algolia-top-search", "bible-topic"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=134.",
+  }),
+  seedPrompt({
+    id: "seed-abraham",
+    ...ENGLISH,
+    queryText: "abraham",
+    tags: ["algolia-top-search", "bible-topic"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=6, nbHits=1.",
+  }),
+  seedPrompt({
+    id: "seed-bible-stories",
+    ...ENGLISH,
+    queryText: "bible stories",
+    tags: ["algolia-top-search", "catalog", "bible-topic", "synonym"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=9.",
+  }),
+  seedPrompt({
+    id: "seed-zulu",
+    ...ENGLISH,
+    queryText: "zulu",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=313.",
+  }),
+  seedPrompt({
+    id: "seed-english",
+    ...ENGLISH,
+    queryText: "english",
+    tags: ["algolia-top-search", "multilingual", "language-name", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=1053.",
+  }),
+  seedPrompt({
+    id: "seed-joseph",
+    ...ENGLISH,
+    queryText: "joseph",
+    tags: ["algolia-top-search", "bible-topic", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=11.",
+  }),
+  seedPrompt({
+    id: "seed-indonesia",
+    ...ENGLISH,
+    queryText: "indonesia",
+    tags: ["algolia-top-search", "multilingual", "language-name"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=417.",
+  }),
+  seedPrompt({
+    id: "seed-paul",
+    ...ENGLISH,
+    queryText: "paul",
+    tags: ["algolia-top-search", "bible-topic", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=213.",
+  }),
+  seedPrompt({
+    id: "seed-john",
+    ...ENGLISH,
+    queryText: "john",
+    tags: ["algolia-top-search", "bible-topic", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=173.",
+  }),
+  seedPrompt({
+    id: "seed-legion",
+    ...ENGLISH,
+    queryText: "legion",
+    tags: ["algolia-top-search", "bible-topic", "scene-like"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=6.",
+  }),
+  seedPrompt({
+    id: "seed-where-you-belong",
+    ...ENGLISH,
+    queryText: "where you belong",
+    tags: ["algolia-top-search", "product-title", "felt-need"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=2.",
+  }),
+  seedPrompt({
+    id: "seed-christmas",
+    ...ENGLISH,
+    queryText: "christmas",
+    tags: ["algolia-top-search", "seasonal", "bible-topic"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=86.",
+  }),
+  seedPrompt({
+    id: "seed-coach",
+    ...ENGLISH,
+    queryText: "coach",
+    tags: ["algolia-top-search", "sports-outreach", "confusing"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=5, nbHits=156.",
+  }),
+  seedPrompt({
     id: "seed-spanish-jesus",
     locale: "es",
     languageSlug: "spanish-castilian",
     queryText: "Jesus en espanol",
-    source: "seed",
-    tags: ["locale", "core-title"],
-  },
-  {
+    tags: ["locale", "core-title", "product-title", "multilingual"],
+  }),
+  seedPrompt({
     id: "seed-spanish-castilian-children-bible-films",
     locale: "es",
     languageSlug: "spanish-castilian",
     websiteLocale: "en",
     queryText: "películas bíblicas para niños",
-    source: "seed",
-    tags: ["locale", "semantic-language", "children", "mismatch"],
+    tags: [
+      "locale",
+      "semantic-language",
+      "children",
+      "mismatch",
+      "multilingual",
+    ],
     operatorNotes:
       "Exercises Spanish semantic search language selection from an English website/watch route.",
-  },
-  {
+  }),
+  seedPrompt({
     id: "seed-hindi-who-is-jesus",
     locale: "hi",
     languageSlug: "hindi",
     queryText: "यीशु कौन हैं?",
-    source: "seed",
-    tags: ["locale", "semantic-language", "question", "new-believer"],
+    tags: [
+      "locale",
+      "semantic-language",
+      "question",
+      "new-believer",
+      "multilingual",
+    ],
     operatorNotes:
       "Exercises non-Latin typed-query language detection and Hindi semantic search language selection.",
-  },
-  {
+  }),
+  seedPrompt({
     id: "seed-french-route-english-who-is-jesus",
     locale: "en",
     languageSlug: "english",
     websiteLocale: "fr",
     queryText: "Who is Jesus?",
-    source: "seed",
-    tags: ["question", "semantic-language", "mismatch"],
+    tags: ["question", "semantic-language", "mismatch", "multilingual"],
     operatorNotes:
       "Exercises English semantic search language selection from a French website/watch route.",
-  },
-  {
+  }),
+  seedPrompt({
     id: "seed-french-hope-youth",
     locale: "fr",
     languageSlug: "french",
     queryText: "videos d'espoir pour les jeunes",
-    source: "seed",
-    tags: ["locale", "audience", "youth"],
-  },
-  {
+    tags: ["locale", "audience", "youth", "felt-need", "multilingual"],
+  }),
+  seedPrompt({
     id: "seed-portuguese-jesus",
     locale: "pt",
     languageSlug: "portuguese-brazil",
     queryText: "Jesus em português",
-    source: "seed",
-    tags: ["locale", "core-title"],
-  },
-  {
+    tags: ["locale", "core-title", "product-title", "multilingual"],
+  }),
+  seedPrompt({
     id: "seed-german-who-is-jesus",
     locale: "de",
     languageSlug: "german-standard",
     queryText: "Wer ist Jesus?",
-    source: "seed",
-    tags: ["locale", "question", "new-believer"],
-  },
-  {
+    tags: ["locale", "question", "new-believer", "multilingual"],
+  }),
+  seedPrompt({
     id: "seed-russian-who-is-jesus",
     locale: "ru",
     languageSlug: "russian",
     queryText: "Кто такой Иисус?",
-    source: "seed",
-    tags: ["locale", "question", "new-believer"],
-  },
-  {
+    tags: ["locale", "question", "new-believer", "multilingual"],
+  }),
+  seedPrompt({
     id: "seed-arabic-who-is-jesus",
     locale: "ar",
     languageSlug: "arabic-modern-standard",
     queryText: "من هو يسوع؟",
-    source: "seed",
-    tags: ["locale", "question", "new-believer"],
-  },
+    tags: ["locale", "question", "new-believer", "multilingual"],
+  }),
+  seedPrompt({
+    id: "seed-jesus-habla-del-espiritu-santo",
+    locale: "es",
+    languageSlug: "spanish-castilian",
+    websiteLocale: "en",
+    queryText: "jesus habla del espiritu santo",
+    tags: ["algolia-top-search", "multilingual", "bible-topic", "mismatch"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=4, nbHits=4.",
+  }),
+  seedPrompt({
+    id: "seed-lazaro",
+    locale: "es",
+    languageSlug: "spanish-castilian",
+    websiteLocale: "en",
+    queryText: "lazaro",
+    tags: ["algolia-top-search", "multilingual", "bible-topic", "scene-like"],
+    operatorNotes:
+      "Algolia top query, 2026-05-22..2026-06-21: count=3, nbHits=6.",
+  }),
+  seedPrompt({
+    id: "seed-thai-walking-on-water",
+    locale: "th",
+    languageSlug: "thai",
+    websiteLocale: "en",
+    queryText: "เดินบนทะเล",
+    tags: ["algolia-no-result", "multilingual", "scene-like", "mismatch"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=1.",
+  }),
+  seedPrompt({
+    id: "seed-chinese-vegetable-animation",
+    locale: "zh",
+    languageSlug: "chinese-mandarin-simplified",
+    websiteLocale: "en",
+    queryText: "蔬菜总动员",
+    tags: [
+      "algolia-no-result",
+      "multilingual",
+      "children",
+      "confusing",
+      "mismatch",
+    ],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=4.",
+  }),
+  seedPrompt({
+    id: "seed-finding-hope-heavy",
+    ...ENGLISH,
+    queryText: "finding hope when life feels heavy",
+    tags: ["algolia-no-result", "felt-need", "synonym"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=3.",
+  }),
+  seedPrompt({
+    id: "seed-anxiety-and-fear",
+    ...ENGLISH,
+    queryText: "anxiety and fear",
+    tags: ["felt-need", "synonym"],
+  }),
+  seedPrompt({
+    id: "seed-forgiveness-after-failure",
+    ...ENGLISH,
+    queryText: "forgiveness after failure",
+    tags: ["felt-need", "bible-topic", "synonym"],
+  }),
+  seedPrompt({
+    id: "seed-lonely-and-rejected",
+    ...ENGLISH,
+    queryText: "lonely and rejected",
+    tags: ["felt-need", "synonym"],
+  }),
+  seedPrompt({
+    id: "seed-grieving-a-loved-one",
+    ...ENGLISH,
+    queryText: "grieving a loved one",
+    tags: ["felt-need", "synonym"],
+  }),
+  seedPrompt({
+    id: "seed-purpose-in-life",
+    ...ENGLISH,
+    queryText: "purpose in life",
+    tags: ["felt-need", "new-believer"],
+  }),
+  seedPrompt({
+    id: "seed-how-to-pray-numb",
+    ...ENGLISH,
+    queryText: "how to pray when I feel numb",
+    tags: ["felt-need", "question", "prayer"],
+  }),
+  seedPrompt({
+    id: "seed-shame-and-guilt",
+    ...ENGLISH,
+    queryText: "shame and guilt",
+    tags: ["felt-need", "synonym"],
+  }),
+  seedPrompt({
+    id: "seed-prodigal-son",
+    ...ENGLISH,
+    queryText: "prodigal son",
+    tags: ["bible-topic", "scene-like"],
+  }),
+  seedPrompt({
+    id: "seed-woman-at-the-well",
+    ...ENGLISH,
+    queryText: "woman at the well",
+    tags: ["bible-topic", "scene-like"],
+  }),
+  seedPrompt({
+    id: "seed-sermon-on-the-mount",
+    ...ENGLISH,
+    queryText: "sermon on the mount",
+    tags: ["bible-topic", "scene-like"],
+  }),
+  seedPrompt({
+    id: "seed-water-into-wine",
+    ...ENGLISH,
+    queryText: "water into wine",
+    tags: ["bible-topic", "scene-like"],
+  }),
+  seedPrompt({
+    id: "seed-raising-lazarus",
+    ...ENGLISH,
+    queryText: "raising lazarus",
+    tags: ["bible-topic", "scene-like"],
+  }),
+  seedPrompt({
+    id: "seed-garden-of-gethsemane",
+    ...ENGLISH,
+    queryText: "garden of gethsemane",
+    tags: ["bible-topic", "scene-like"],
+  }),
+  seedPrompt({
+    id: "seed-feeding-five-thousand",
+    ...ENGLISH,
+    queryText: "feeding five thousand",
+    tags: ["bible-topic", "scene-like"],
+  }),
+  seedPrompt({
+    id: "seed-walking-wih-jesus",
+    ...ENGLISH,
+    queryText: "walking wih jesus",
+    tags: ["algolia-no-result", "misspelling", "product-title"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=2.",
+  }),
+  seedPrompt({
+    id: "seed-walking-wth-jesus",
+    ...ENGLISH,
+    queryText: "walking wth jesus",
+    tags: ["algolia-no-result", "misspelling", "product-title"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=2.",
+  }),
+  seedPrompt({
+    id: "seed-jrius-daughter",
+    ...ENGLISH,
+    queryText: "jrius daughter",
+    tags: ["algolia-no-result", "misspelling", "bible-topic", "scene-like"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=2.",
+  }),
+  seedPrompt({
+    id: "seed-jesus-feature-ilm",
+    ...ENGLISH,
+    queryText: "jesus feature ilm",
+    tags: ["algolia-no-result", "misspelling", "product-title"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=2.",
+  }),
+  seedPrompt({
+    id: "seed-reflection-of-hpe",
+    ...ENGLISH,
+    queryText: "reflection of hpe",
+    tags: ["algolia-no-result", "misspelling", "product-title", "felt-need"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=1.",
+  }),
+  seedPrompt({
+    id: "seed-matheuw",
+    ...ENGLISH,
+    queryText: "matheuw",
+    tags: ["algolia-no-result", "misspelling", "bible-topic"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=1.",
+  }),
+  seedPrompt({
+    id: "seed-abharam",
+    ...ENGLISH,
+    queryText: "abharam",
+    tags: ["algolia-no-result", "misspelling", "bible-topic"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=1.",
+  }),
+  seedPrompt({
+    id: "seed-ananias-at-saapphira",
+    ...ENGLISH,
+    queryText: "ananias at saapphira",
+    tags: ["algolia-no-result", "misspelling", "bible-topic", "scene-like"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=1.",
+  }),
+  seedPrompt({
+    id: "seed-jeus-our-loving-pusuer",
+    ...ENGLISH,
+    queryText: "jeus our loving pusuer",
+    tags: ["algolia-no-result", "misspelling", "felt-need"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=1.",
+  }),
+  seedPrompt({
+    id: "seed-initiatbirth-of-john",
+    ...ENGLISH,
+    queryText: "initiatbirth of john",
+    tags: ["algolia-no-result", "misspelling", "bible-topic", "scene-like"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=2.",
+  }),
+  seedPrompt({
+    id: "seed-brothers-living-together",
+    ...ENGLISH,
+    queryText: "brothers living together",
+    tags: ["algolia-no-result", "confusing", "bible-topic"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=3.",
+  }),
+  seedPrompt({
+    id: "seed-world-cup-2026-outreach",
+    ...ENGLISH,
+    queryText: "world cup 2026 outreach",
+    tags: ["algolia-no-result", "confusing", "sports-outreach"],
+    operatorNotes: "Algolia no-result query, 2026-05-22..2026-06-21: count=1.",
+  }),
 ] as const
 
 export const SEARCH_EVAL_SEED_PROMPT_LOCALES = [

--- a/docs/brainstorms/2026-06-21-watch-search-readiness-eval-suite-requirements.md
+++ b/docs/brainstorms/2026-06-21-watch-search-readiness-eval-suite-requirements.md
@@ -1,0 +1,214 @@
+---
+date: 2026-06-21
+topic: watch-search-readiness-eval-suite
+---
+
+# Watch Search Readiness Eval Suite
+
+## Summary
+
+`feat-193` creates a reusable Watch search readiness suite that can answer
+whether the current Admin search implementation is launch-ready across
+`hybrid`, `keyword-first`, and `semantic-only` eval modes. The suite combines a
+100-query prompt set with Mastra-run comparison reports so the team can inspect
+ranked results, obvious failures, and summary metrics before shipping.
+
+---
+
+## Problem Frame
+
+The team has been spot-checking search quality while public Watch search has
+multiple possible retrieval behaviors. That creates confusion about whether a
+given result set is good enough to launch, whether a mode improved or regressed,
+and whether semantic retrieval is carrying its own relevance weight or only
+looking acceptable because keyword retrieval rescued it.
+
+Existing Mastra search eval infrastructure already supports seed prompts,
+baseline capture, comparison reports, and release-gate summaries. This ticket
+turns that infrastructure into a readiness suite for the current Watch launch
+question and adds an internal semantic isolation mode for better diagnosis.
+
+---
+
+## Key Decisions
+
+- **Three Admin-owned modes only.** The readiness suite covers `hybrid`,
+  `keyword-first`, and `semantic-only` because they are all retrieval modes of
+  the Admin search stack.
+- **Semantic-only is diagnostic.** `semantic-only` exists to isolate vector and
+  embedding relevance during evals; it is not a public Watch search behavior.
+- **Algolia-backed comparison is out of scope.** This ticket does not create an
+  Algolia parity mode, fallback mode, or follow-up ticket.
+- **Mastra remains offline.** Mastra owns the eval dataset, runner, and report
+  artifacts while Admin remains the search execution authority.
+
+---
+
+## Actors
+
+- A1. **Search owner.** Uses the report to decide whether the current Watch
+  search behavior is good enough to launch.
+- A2. **Implementing engineer or agent.** Runs the suite while iterating on
+  search retrieval, ranking, and embeddings.
+- A3. **Admin search.** Executes each requested eval mode and returns ranked
+  results.
+- A4. **Mastra eval workflow.** Owns the prompt set, baseline comparison, judge
+  output, and saved report artifacts.
+
+---
+
+## Requirements
+
+**Dataset**
+
+- R1. The suite must provide a reusable committed prompt set with 50-100
+  realistic Watch search queries.
+- R2. The prompt set must include product titles, felt needs, Bible topics,
+  misspellings, synonyms, confusing queries, multilingual queries, and
+  scene-like queries.
+- R3. The prompt set must include real Algolia-derived query examples where
+  available, including the highest-traffic query as a baseline case.
+
+**Eval Modes**
+
+- R4. The suite must run the same prompt set against `hybrid`,
+  `keyword-first`, and `semantic-only` modes.
+- R5. `semantic-only` must evaluate semantic/vector retrieval without keyword,
+  title, or full-text retrieval contributing candidates.
+- R6. The eval mode recorded in each report must identify the requested
+  pipeline mode, not only whether semantic retrieval degraded at runtime.
+- R7. `keyword-first` must preserve strong brand and product-title intent, so
+  searches such as `bible project` and `Jesus` return the expected Bible Project
+  and JESUS video results near the top.
+
+**Reporting**
+
+- R8. The report must include ranked results for each query and mode in enough
+  detail that a reviewer can diagnose bad matches.
+- R9. The report must include scored or judged comparison output, obvious
+  failures, no-result cases, and summary metrics.
+- R10. The report must support a human launch-readiness decision without requiring
+  every reviewer to reread every raw result.
+
+**Boundaries**
+
+- R11. Admin must remain the search execution authority; Mastra must call Admin
+  eval contracts rather than importing Admin code or reading Admin search tables.
+- R12. The semantic-only mode must be isolated to internal eval execution unless
+  a later product decision explicitly ships it to public Watch search.
+- R13. The ticket must remove Algolia-backed comparison from its acceptance
+  scope rather than producing an incomplete placeholder mode.
+
+---
+
+## Key Flows
+
+- F1. Dataset-backed readiness run
+  - **Trigger:** A search owner wants to assess whether Watch search is ready to
+    launch.
+  - **Actors:** A1, A3, A4
+  - **Steps:** Mastra loads the committed prompt set, calls Admin search for the
+    requested mode, captures ranked results, and writes a report artifact.
+  - **Outcome:** A mode-specific readiness report exists with query-level
+    evidence and summary metrics.
+  - **Covered by:** R1, R2, R3, R4, R8, R9, R10
+
+- F2. Semantic isolation comparison
+  - **Trigger:** An engineer wants to know whether semantic retrieval is useful
+    on its own.
+  - **Actors:** A2, A3, A4
+  - **Steps:** The suite runs the same prompt set against `semantic-only` and
+    compares those results with another captured mode such as `hybrid` or
+    `keyword-first`.
+  - **Outcome:** The team can see whether vector retrieval finds relevant
+    content without lexical retrieval hiding weaknesses.
+  - **Covered by:** R4, R5, R6, R9
+
+- F3. Launch-readiness review
+  - **Trigger:** The team needs to decide whether to ship current Watch search.
+  - **Actors:** A1, A2
+  - **Steps:** Reviewers inspect summary metrics, high-severity failures,
+    no-result cases, and representative query results across modes.
+  - **Outcome:** The team can make a launch, hold, or iterate decision from the
+    report.
+  - **Covered by:** R8, R9, R10
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3.** Given the readiness suite prompt set, when a
+  reviewer inspects it, then it contains 50-100 realistic prompts across the
+  required query categories and includes the top Algolia-derived query.
+- AE2. **Covers R4, R5.** Given the suite runs in `semantic-only` mode, when
+  Admin executes the search, then keyword, title, and full-text retrieval do not
+  contribute candidates.
+- AE3. **Covers R7.** Given the suite runs in `keyword-first` mode, when it
+  searches `bible project`, then Bible Project videos appear near the top of the
+  ranked results.
+- AE4. **Covers R7.** Given the suite runs in `keyword-first` mode, when it
+  searches `Jesus`, then the JESUS film/video appears near the top of the ranked
+  results.
+- AE5. **Covers R6.** Given a report was produced for `keyword-first`, when the
+  report metadata is inspected, then it records `keyword-first` as the requested
+  pipeline mode even if the response also reports runtime search degradation.
+- AE6. **Covers R8, R9, R10.** Given the suite finishes a comparison run, when
+  the team opens the report, then they can see summary metrics, obvious
+  failures, no-result cases, and per-query ranked results.
+- AE7. **Covers R11, R12, R13.** Given this ticket is complete, when public
+  Watch search runs, then it has not been changed to expose semantic-only search
+  and the ticket has not added an Algolia-backed eval mode.
+
+---
+
+## Success Criteria
+
+- The committed prompt set is broad enough that reviewers recognize realistic
+  Watch searches instead of synthetic-only happy paths.
+- `hybrid`, `keyword-first`, and `semantic-only` can be run through the Mastra
+  eval workflow with comparable report output.
+- The report makes launch-readiness failures visible at both summary and
+  per-query levels.
+- The team can explain whether a mode is ready, not ready, or inconclusive from
+  the report.
+
+---
+
+## Scope Boundaries
+
+- Algolia-backed eval comparison is out of scope.
+- Public Watch search behavior changes are out of scope unless required to keep
+  existing behavior stable.
+- Search analytics logging is out of scope for this ticket.
+- Multilingual search-language UX changes are out of scope for this ticket.
+- Scene embedding ranking decisions are out of scope except where existing query
+  prompts exercise scene-like searches.
+
+---
+
+## Dependencies / Assumptions
+
+- Admin can expose or extend an internal eval search contract for requested
+  pipeline modes without changing public search contracts.
+- Mastra can pass a requested search mode through its offline eval runner and
+  orchestrator schemas.
+- The existing pairwise judge and report artifact model remains the correct
+  comparison mechanism for launch-readiness decisions.
+- The Algolia-derived query data used for the prompt set is treated as aggregate
+  analytics, not user-identifying trace data.
+
+---
+
+## Sources / Research
+
+- `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+- `docs/brainstorms/2026-05-06-semantic-search-eval-harness-requirements.md`
+- `docs/brainstorms/2026-05-30-search-eval-orchestrator-requirements.md`
+- `docs/brainstorms/2026-06-01-production-search-eval-seed-baseline-requirements.md`
+- `docs/brainstorms/2026-06-19-watch-multilingual-semantic-search-requirements.md`
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/app/api/internal/search-eval/search/route.ts`
+- `apps/mastra/src/services/offline-search-eval/`
+- `apps/mastra/src/mastra/workflows/offline-search-eval.ts`
+- `apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts`
+- `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`

--- a/docs/plans/2026-06-21-001-feat-watch-search-readiness-eval-suite-plan.md
+++ b/docs/plans/2026-06-21-001-feat-watch-search-readiness-eval-suite-plan.md
@@ -1,0 +1,356 @@
+---
+title: "feat: Watch search readiness eval suite"
+type: "feat"
+date: 2026-06-21
+origin: docs/brainstorms/2026-06-21-watch-search-readiness-eval-suite-requirements.md
+---
+
+# feat: Watch Search Readiness Eval Suite
+
+## Summary
+
+Implement `feat-193` as a Watch search readiness suite that uses the committed
+100-query prompt set and compares Admin search behavior across `hybrid`,
+`keyword-first`, and internal-only `semantic-only` modes. The plan keeps public
+Watch search unchanged while making Mastra reports and native Evaluation sync
+preserve the requested pipeline mode.
+
+---
+
+## Problem Frame
+
+The team needs a launch-readiness answer for Watch search that is stronger than
+manual spot checks. Admin already owns live search execution and Mastra already
+owns offline eval prompt sets, baselines, comparisons, and report artifacts, so
+the right implementation extends those boundaries instead of adding another
+search path.
+
+The new diagnostic risk is `semantic-only`: adding it to the global Admin mode
+decoder would expose it through public REST and GraphQL because those surfaces
+already forward `mode` to the search service. The plan therefore treats
+`semantic-only` as a privileged eval mode available only through the internal
+eval route.
+
+---
+
+## Requirements
+
+**Dataset**
+
+- R1. Preserve a committed prompt set with exactly 100 realistic Watch search
+  queries.
+- R2. Cover product titles, felt needs, Bible topics, misspellings, synonyms,
+  confusing queries, multilingual queries, and scene-like queries.
+- R3. Keep real Algolia-derived aggregate examples as prompt provenance,
+  including `jesus` as the highest-traffic baseline case.
+
+**Eval Modes**
+
+- R4. Allow Mastra eval workflows to run `hybrid`, `keyword-first`, and
+  `semantic-only`.
+- R5. Run `semantic-only` through Admin internal eval search without keyword,
+  title, or full-text candidate retrieval.
+- R6. Preserve the requested pipeline mode separately from the runtime
+  degradation signal.
+- R7. Protect keyword-first brand/product intent for `bible project` and
+  `Jesus`.
+
+**Reporting And Boundaries**
+
+- R8. Keep reports detailed enough to diagnose bad matches from ranked
+  per-query results.
+- R9. Surface judged comparison outcomes, obvious failures, no-result cases, and
+  summary metrics.
+- R10. Make launch-readiness review possible without rereading every raw result.
+- R11. Keep Admin as the search execution authority and Mastra as the offline
+  eval owner.
+- R12. Keep `semantic-only` internal to eval execution.
+- R13. Do not add an Algolia-backed eval mode, parity runner, fallback path, or
+  follow-up ticket from this work.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  P["Seed prompt set v5"] --> M["Mastra offline eval workflow"]
+  M --> I["Admin internal eval search route"]
+  I --> S["HybridSearchService"]
+  S --> H["hybrid retrievers"]
+  S --> K["keyword-first retrievers"]
+  S --> O["semantic-only retrievers"]
+  M --> R["JSON report artifacts"]
+  R --> N["Native Evaluation sync"]
+```
+
+The same prompt set feeds each eval run. Mastra passes the requested pipeline
+mode to Admin over the authenticated internal eval route, Admin executes the
+mode, and Mastra records the requested mode in report and native Evaluation
+metadata.
+
+```mermaid
+flowchart TB
+  Q["mode: semantic-only"] --> E{"embedding available?"}
+  E -->|yes| V["semantic video/experience retrievers"]
+  E -->|no| Z["no lexical fallback"]
+  V --> F["fusion, paging, result mapping"]
+  Z --> F
+  F --> D["response searchMode remains degradation signal"]
+```
+
+`semantic-only` isolates semantic/vector retrieval. If embeddings are
+unavailable, it must not dispatch lexical fallback retrievers; the requested
+mode remains visible through eval metadata so reviewers can distinguish a
+diagnostic semantic-only failure from a normal keyword-only degradation.
+
+---
+
+## Key Technical Decisions
+
+- **Internal-only semantic-only gate:** Add a privileged service option for
+  internal eval modes instead of recognizing `semantic-only` through the global
+  public decoder. Public REST and GraphQL should continue treating
+  `semantic-only` as an unknown mode that falls back to `hybrid`.
+- **Smallest retrieval branch:** Add the semantic-only behavior at the
+  centralized retrieval branch in Admin search, reusing the existing semantic
+  retrievers and preserving `hybrid` and `keyword-first` behavior.
+- **No lexical fallback in semantic-only:** Embedding failure in semantic-only
+  should produce no keyword/title/full-text candidates. It should return the
+  existing `SearchResponse` shape with `results: []`, `hasMore: false`, the
+  query preserved, and `searchMode: "keyword-only"` as the runtime degradation
+  signal. Reports must preserve the requested pipeline mode separately.
+- **Mode-aware baseline identity:** Readiness runs should use mode-suffixed
+  baseline names (`seed-baseline-hybrid`, `seed-baseline-keyword-first`,
+  `seed-baseline-semantic-only`) and Native Evaluation source keys should
+  include the requested mode so `hybrid`, `keyword-first`, and `semantic-only`
+  evidence for the same prompt set stays distinguishable. The existing
+  `seed-baseline` name remains backward compatible for current single-mode
+  usage unless an operator chooses a mode-specific name.
+- **Algolia as provenance only:** Algolia-derived aggregate queries remain in
+  prompt notes and tags, but no Algolia execution mode is added.
+
+---
+
+## Implementation Units
+
+### U1. Readiness Prompt Set
+
+- **Goal:** Keep the v5 readiness prompt set as the suite input for all eval
+  modes.
+- **Requirements:** R1, R2, R3, R7
+- **Dependencies:** None
+- **Files:**
+  - `apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts`
+  - `apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts`
+  - `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+- **Approach:** Preserve the 100-prompt v5 dataset, including aggregate
+  Algolia provenance and the brand/product prompts for `bible project` and
+  `Jesus`.
+- **Patterns to follow:** Existing seed prompt shape in
+  `apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts`.
+- **Test scenarios:**
+  - Assert the prompt set has exactly 100 prompts and unique IDs.
+  - Assert required readiness tags are present.
+  - Assert `jesus` is tagged as an Algolia-derived product-title baseline.
+  - Assert `bible project` is tagged as a brand/product prompt for
+    keyword-first regression review.
+- **Verification:** Focused seed prompt test passes and roadmap notes describe
+  the v5 dataset.
+
+### U2. Internal-Only Semantic-Only Admin Mode
+
+- **Goal:** Allow `semantic-only` only through the internal eval path while
+  preserving public search behavior.
+- **Requirements:** R4, R5, R6, R11, R12
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+  - `apps/admin/src/services/hybrid-search.keyword-first.test.ts`
+  - `apps/admin/src/app/api/internal/search-eval/search/route.ts`
+  - `apps/admin/src/app/api/internal/search-eval/search/route.test.ts`
+  - `apps/admin/src/app/api/search/route.test.ts`
+  - `apps/admin/src/graphql/queries/hybrid-search.test.ts`
+- **Approach:** Add a privileged service option that lets the internal eval route
+  opt into eval-only modes. Extend Admin search branching so semantic-only
+  dispatches semantic video and experience retrievers only, respects
+  `contentTypes`, skips every lexical retriever, and leaves the response
+  degradation signal unchanged.
+- **Patterns to follow:** Keyword-first branch tests in
+  `apps/admin/src/services/hybrid-search.keyword-first.test.ts`; mode decoder
+  tests in `apps/admin/src/services/hybrid-search.service.test.ts`.
+- **Test scenarios:**
+  - Covers AE2. `semantic-only` dispatches semantic retrievers and skips video
+    keyword, experience keyword, weighted keyword, trigram, and exact-title
+    retrievers.
+  - `semantic-only` with `contentTypes: ["video"]` skips experience retrievers.
+  - Embedding failure in semantic-only dispatches no lexical retrievers and
+    returns the existing `SearchResponse` contract with `results: []`,
+    `hasMore: false`, the query preserved, and `searchMode: "keyword-only"`.
+  - Public REST with `mode=semantic-only` does not activate semantic-only.
+  - Public GraphQL with `mode: "semantic-only"` does not activate semantic-only.
+  - Internal eval route forwards `mode: "semantic-only"` with the privileged
+    service option.
+- **Verification:** Admin focused search service, route, REST, and GraphQL tests
+  pass.
+
+### U3. Mastra Workflow Mode Plumbing
+
+- **Goal:** Let Mastra leaf and orchestrator workflows accept and pass through
+  `semantic-only`.
+- **Requirements:** R4, R6, R8, R11
+- **Dependencies:** U2
+- **Files:**
+  - `apps/mastra/src/mastra/workflows/offline-search-eval.ts`
+  - `apps/mastra/src/mastra/workflows/offline-search-eval.test.ts`
+  - `apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts`
+  - `apps/mastra/src/mastra/workflows/search-eval-orchestrator.test.ts`
+  - `apps/mastra/src/services/offline-search-eval/runner.ts`
+  - `apps/mastra/src/services/offline-search-eval/runner.test.ts`
+  - `apps/mastra/src/services/admin-search-eval-client.test.ts`
+- **Approach:** Extend workflow schemas and tests to include `semantic-only`.
+  The runner already sends `input.searchMode` as Admin payload `mode` and stores
+  it in report metadata, so keep that pass-through path intact and add focused
+  assertions.
+- **Patterns to follow:** Existing `keyword-first` payload assertions in
+  `apps/mastra/src/services/admin-search-eval-client.test.ts`.
+- **Test scenarios:**
+  - Offline workflow schema accepts `searchMode: "semantic-only"`.
+  - Orchestrator schema accepts `searchMode: "semantic-only"`.
+  - Runner sends Admin payload `mode: "semantic-only"`.
+  - Report metadata records requested mode `semantic-only` while result
+    `searchMode` remains the Admin degradation signal.
+  - `algolia` and `algolia-backed` are not accepted as Mastra workflow modes.
+- **Verification:** Focused Mastra workflow, runner, and Admin eval client tests
+  pass.
+
+### U4. Native Evaluation And Mode-Aware Reporting
+
+- **Goal:** Preserve requested mode in native Evaluation inputs and avoid
+  clobbering evidence across modes.
+- **Requirements:** R6, R8, R9, R10
+- **Dependencies:** U3
+- **Files:**
+  - `apps/mastra/src/services/offline-search-eval/native-evaluation.ts`
+  - `apps/mastra/src/services/offline-search-eval/native-evaluation.test.ts`
+  - `apps/mastra/src/services/offline-search-eval/report.ts`
+  - `apps/mastra/src/services/offline-search-eval/report.test.ts`
+  - `apps/mastra/src/services/offline-search-eval/artifacts.ts`
+  - `apps/mastra/src/services/offline-search-eval/artifacts.test.ts`
+- **Approach:** Extend native search eval schemas and helper functions so
+  `semantic-only` survives sync. Include requested mode in native source keys so
+  multiple modes for the same prompt set do not overwrite each other, and make
+  docs/run recipes use mode-specific baseline names for mode-by-mode evidence.
+- **Patterns to follow:** Native Evaluation bridge patterns in
+  `docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md`.
+- **Test scenarios:**
+  - Native input schema accepts `mode: "semantic-only"`.
+  - Native projection maps report metadata mode `semantic-only` to
+    `searchOptions.mode: "semantic-only"`.
+  - Native source keys differ for the same prompt case across `hybrid` and
+    `semantic-only`.
+  - The run recipe names mode-suffixed baselines so two modes do not share the
+    same baseline/report identity by accident.
+  - Report summaries distinguish requested mode from baseline mode and runtime
+    degradation.
+- **Verification:** Native Evaluation and report artifact tests pass.
+
+### U5. Launch-Readiness Documentation And Validation
+
+- **Goal:** Make the ticket handoff explain how to run and interpret the suite.
+- **Requirements:** R8, R9, R10, R12, R13
+- **Dependencies:** U1, U2, U3, U4
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+  - `docs/brainstorms/2026-06-21-watch-search-readiness-eval-suite-requirements.md`
+  - `CONCEPTS.md`
+- **Approach:** Update roadmap notes to state that the executable suite covers
+  `hybrid`, `keyword-first`, and internal-only `semantic-only`; keep Algolia
+  execution out of scope. Keep the origin requirements doc aligned when product
+  acceptance cases change, and keep `CONCEPTS.md` as the glossary source for
+  Semantic-Only Search. Define the recommended run recipe as mode-specific
+  baseline/report runs (`seed-baseline-hybrid`,
+  `seed-baseline-keyword-first`, `seed-baseline-semantic-only`) rather than an
+  implicit three-mode matrix.
+- **Patterns to follow:** Roadmap progress note style already present in
+  `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`.
+- **Test scenarios:**
+  - Documentation names `semantic-only` as diagnostic and internal-only.
+  - Documentation names `bible project` and `Jesus` as keyword-first
+    brand/product readiness checks.
+  - Documentation names the mode-suffixed baseline convention for running the
+    three readiness modes.
+  - Documentation does not promise Algolia-backed comparison.
+  - `CONCEPTS.md` defines Semantic-Only Search as an eval diagnostic rather
+    than a public Watch behavior.
+- **Verification:** Docs are formatted and code verification results are
+  reflected in the final ticket summary.
+
+---
+
+## Scope Boundaries
+
+- Public Watch search behavior changes are out of scope except to ensure
+  `semantic-only` remains unavailable publicly.
+- Algolia-backed comparison, fallback, or parity execution is out of scope.
+- Search query analytics logging is out of scope.
+- Multilingual search-language UX is out of scope.
+- Scene embedding ranking policy changes are out of scope.
+
+---
+
+## Risks And Dependencies
+
+- **Mode leakage risk:** Public REST and GraphQL forward `mode`, so semantic-only
+  must be gated by an internal service option.
+- **Misleading degradation risk:** Response `searchMode` can say
+  `keyword-only` when embeddings fail; requested pipeline mode must remain
+  visible in eval metadata.
+- **Native sync clobber risk:** Native item source keys need requested mode to
+  keep mode-specific evidence distinct.
+- **Baseline interpretation risk:** Comparing a semantic-only run against a
+  hybrid baseline is intentional diagnostic work, so reports should label the
+  mode mismatch as expected when the operator requested it.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given the readiness suite prompt set, when a reviewer inspects it, then
+  it contains 100 realistic prompts across the required query categories and
+  includes the top Algolia-derived query.
+- AE2. Given the suite runs in `semantic-only` mode, when Admin executes the
+  search, then keyword, title, and full-text retrieval do not contribute
+  candidates.
+- AE3. Given the suite runs in `keyword-first` mode, when it searches
+  `bible project`, then Bible Project videos appear near the top of the ranked
+  results.
+- AE4. Given the suite runs in `keyword-first` mode, when it searches `Jesus`,
+  then the JESUS film/video appears near the top of the ranked results.
+- AE5. Given a report was produced for `keyword-first`, when the report metadata
+  is inspected, then it records `keyword-first` as the requested pipeline mode
+  even if the response also reports runtime search degradation.
+- AE6. Given the suite finishes a comparison run, when the team opens the
+  report, then they can see summary metrics, obvious failures, no-result cases,
+  and per-query ranked results.
+- AE7. Given this ticket is complete, when public Watch search runs, then it has
+  not been changed to expose semantic-only search and the ticket has not added
+  an Algolia-backed eval mode.
+
+---
+
+## Sources And Research
+
+- `docs/brainstorms/2026-06-21-watch-search-readiness-eval-suite-requirements.md`
+- `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+- `/tmp/compound-engineering/ce-brainstorm/watch-search-readiness-20260621/grounding.md`
+- `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`
+- `docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md`
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
+- `docs/solutions/runtime-errors/silent-semantic-search-degradation-missing-openrouter-key-20260415.md`
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/app/api/internal/search-eval/search/route.ts`
+- `apps/mastra/src/mastra/workflows/offline-search-eval.ts`
+- `apps/mastra/src/mastra/workflows/search-eval-orchestrator.ts`
+- `apps/mastra/src/services/offline-search-eval/native-evaluation.ts`

--- a/docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md
+++ b/docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md
@@ -3,7 +3,7 @@ id: "feat-193"
 title: "Watch search readiness eval suite"
 owner: "nisal"
 priority: "P1"
-status: "not-started"
+status: "in-progress"
 start_date: "2026-06-16"
 duration: 4
 depends_on:
@@ -24,7 +24,7 @@ tags:
 
 The team needs a concrete launch-readiness answer for Watch search, not just
 ad hoc spot checks. The current search work has multiple possible execution
-modes: keyword-first, hybrid, semantic, and Algolia fallback. Without a shared
+modes: keyword-first, hybrid, and semantic-only diagnostics. Without a shared
 eval set and a readable report, humans and AI agents cannot confidently decide
 whether the current implementation is ready to launch.
 
@@ -65,8 +65,8 @@ Roadmap window: this week, June 16-19, 2026.
    - confusing or ambiguous searches;
    - multilingual queries;
    - scene-like queries.
-4. Run the same dataset against keyword, hybrid, semantic, and Algolia-backed
-   result modes.
+4. Run the same dataset against keyword-first, hybrid, and internal-only
+   semantic-only result modes.
 5. Produce a report that includes ranked results, relevance scores, obvious
    failures, no-result cases, and summary metrics.
 6. Make the report structured enough that both team members and AI agents can
@@ -78,7 +78,10 @@ Roadmap window: this week, June 16-19, 2026.
 - Queries include product titles, felt needs, Bible topics, misspellings,
   synonyms, confusing queries, multilingual queries, and scene-like queries.
 - Real Algolia-derived queries are included where available.
-- Eval compares keyword, hybrid, semantic, and Algolia-backed results.
+- Eval compares keyword-first, hybrid, and internal-only semantic-only results.
+- Keyword-first brand/product cases include `bible project`, which should bring
+  back Bible Project videos, and `Jesus`, which should bring back the JESUS
+  film/video.
 - Output includes scored/ranked results, obvious failures, and summary metrics.
 - Team members and AI agents can use the generated report to decide whether the
   current search implementation is launch-ready.
@@ -89,3 +92,52 @@ Roadmap window: this week, June 16-19, 2026.
 - Confirm the report includes enough per-query detail to diagnose failures.
 - Confirm the report includes a summary that can support a launch/no-launch
   recommendation without rereading every raw result.
+
+## Progress Notes
+
+- 2026-06-21: Expanded
+  `apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts` to
+  `search-eval-seed-prompts/v5` with exactly 100 reusable readiness prompts.
+- The prompt set now includes product titles, felt needs, Bible topics,
+  misspellings, synonyms, confusing searches, multilingual searches, and
+  scene-like searches.
+- Added explicit keyword-first brand/product readiness checks for
+  `bible project` and `jesus`.
+- Seeded the set from Algolia Productivity MCP analytics for
+  `FJYYBFHBHS / video-variants-prd`, covering 2026-05-22 through 2026-06-21.
+  The top non-empty query, `jesus` with count=88 and nbHits=395, is preserved
+  as the canonical high-traffic baseline prompt.
+- Added no-result regressions from Algolia analytics, including
+  `walking wih jesus`, `walking wth jesus`, `jrius daughter`,
+  `finding hope when life feels heavy`, and `world cup 2026 outreach`.
+- Added focused tests that enforce the 100-query size, unique IDs, required
+  readiness categories, Algolia-derived baseline coverage, no-result typo
+  coverage, and multilingual/locale-mismatch cases.
+- Added internal-only `semantic-only` execution through Admin's eval route.
+  Public REST and GraphQL still treat `semantic-only` as an unknown mode and
+  fall back to `hybrid`.
+- Extended Mastra offline eval and orchestrator schemas to accept `hybrid`,
+  `keyword-first`, and `semantic-only`, while rejecting `algolia-backed`.
+- Native Evaluation projection now preserves `semantic-only` and includes the
+  requested search mode in dataset, experiment, and report outcome source keys
+  so mode-by-mode evidence does not overwrite itself.
+- Algolia is prompt provenance only in this ticket; no Algolia-backed execution,
+  fallback path, or follow-up ticket is in scope.
+- Code-level implementation is verified below. A launch/no-launch decision
+  still requires running the Mastra eval workflow against a configured Admin
+  search-eval endpoint and reviewing the produced report.
+
+## Implementation Verification Notes
+
+- Passed:
+  `pnpm --filter @forge/admin test -- hybrid-search.keyword-first hybrid-search.service route.test.ts`
+- Passed:
+  `pnpm --filter @forge/admin test -- hybrid-search.bible-project`
+- Passed:
+  `pnpm --filter @forge/mastra test -- seed-prompt-set runner offline-search-eval search-eval-orchestrator native-evaluation admin-search-eval-client search-eval-native-suite artifacts report`
+- Typecheck caveat: `pnpm --filter @forge/admin typecheck` currently fails on
+  pre-existing Prisma schema drift in
+  `apps/admin/src/services/transcript-embedding.service.ts` for `sourceKind`.
+- Typecheck caveat: `pnpm --filter @forge/mastra typecheck` currently fails
+  because `apps/mastra/src/mastra/memory.ts` cannot resolve `@mastra/memory` in
+  this isolated worktree dependency setup.

--- a/docs/solutions/architecture-patterns/internal-diagnostic-search-modes-need-mode-aware-eval-identity.md
+++ b/docs/solutions/architecture-patterns/internal-diagnostic-search-modes-need-mode-aware-eval-identity.md
@@ -1,0 +1,158 @@
+---
+title: "Internal diagnostic search modes need mode-aware eval identity"
+date: "2026-06-21"
+category: "architecture-patterns"
+module: "apps/admin, apps/mastra"
+problem_type: "architecture_pattern"
+component: "service_object"
+severity: "medium"
+applies_when:
+  - "A search mode is useful for offline evaluation but should not become a public product mode"
+  - "The same prompt set is evaluated across multiple retrieval modes"
+  - "Native Evaluation records are synced from search eval reports"
+related_components:
+  - "apps/admin"
+  - "apps/mastra"
+tags:
+  - "search-eval"
+  - "semantic-search"
+  - "native-evaluation"
+  - "internal-contracts"
+  - "mode-identity"
+related:
+  - "docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md"
+  - "docs/solutions/architecture-patterns/mastra-native-evaluation-search-eval-bridge-pattern.md"
+  - "docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md"
+---
+
+# Internal Diagnostic Search Modes Need Mode-Aware Eval Identity
+
+## Context
+
+Watch search readiness needed a `semantic-only` mode so the team could measure
+vector retrieval without keyword, title, or full-text retrieval helping the
+result set. That mode is useful for offline evaluation, but it is not a public
+Watch search decision.
+
+Admin already accepts free-form `mode` strings at public REST and GraphQL
+boundaries so future public modes can roll out without schema churn. If
+`semantic-only` is added to the global decoder without another guard, public
+callers can activate it immediately by passing that raw string. Mastra also
+syncs reports into native Evaluation records, so a second failure mode appears:
+multi-mode runs over the same prompt set can overwrite or mingle Dataset items
+unless the requested mode is part of native identity.
+
+## Guidance
+
+Treat diagnostic search modes as privileged internal execution, not as global
+public mode recognition.
+
+In Admin, keep public boundaries stringly typed and tolerant, but make the
+service decoder require an internal option before it recognizes the diagnostic
+mode:
+
+```ts
+export function normalizeMode(
+  raw: string | null | undefined,
+  logger: { warn: (message: string) => void },
+  options: { allowInternalEvalModes?: boolean } = {},
+): SearchPipelineMode {
+  if (raw == null || raw === "" || raw === "hybrid") return "hybrid"
+  if (raw === "keyword-first") return "keyword-first"
+  if (raw === "semantic-only" && options.allowInternalEvalModes === true) {
+    return "semantic-only"
+  }
+  logger.warn(`[search] event=search_unknown_mode ...`)
+  return "hybrid"
+}
+```
+
+Only the authenticated internal eval route should pass the option:
+
+```ts
+await service.search({
+  query,
+  locale,
+  mode,
+  allowInternalEvalModes: true,
+})
+```
+
+The diagnostic branch should skip every lexical retriever. If query embedding
+fails, do not silently fall back to keyword retrieval; return the existing
+search response shape with an empty result set and the normal degradation
+signal. The requested pipeline mode stays in eval metadata, while
+`searchMode` remains the runtime embedding-health signal.
+
+In Mastra, allow diagnostic modes only in offline eval workflow schemas and
+Admin-eval payloads. Reject non-scope modes such as `algolia-backed` when the
+ticket explicitly keeps Algolia as prompt provenance only.
+
+When syncing report results into native Evaluation, include the requested mode
+in every identity that can collide:
+
+- Dataset name and native key.
+- Experiment name and native key.
+- Dataset item source key.
+
+Mode-specific baseline names are still good operator hygiene, but code should
+not rely on operators remembering them. If `hybrid` and `semantic-only` reports
+share a baseline name by accident, they should still sync into separate native
+Datasets instead of creating mixed-mode items inside one experiment.
+
+## Why This Matters
+
+Diagnostic modes often have deliberately bad user-facing behavior. A
+semantic-only eval mode can return no results when embeddings are unavailable,
+which is correct for diagnosis and unacceptable as a public fallback.
+
+Mode-aware native identity protects the review surface. Without it, one mode
+can update another mode's Dataset item, or worse, a new experiment can run
+against Dataset items from a different requested mode and fail because no
+output exists for those source keys.
+
+## When To Apply
+
+- Adding an eval-only or operator-only retrieval mode.
+- Comparing one prompt set across `hybrid`, `keyword-first`, and diagnostic
+  modes.
+- Projecting search eval reports into native Evaluation records.
+- Keeping public REST or GraphQL mode arguments forward-compatible while
+  avoiding accidental public activation.
+
+## Examples
+
+Good coverage has three layers:
+
+```ts
+expect(normalizeMode("semantic-only", logger)).toBe("hybrid")
+expect(
+  normalizeMode("semantic-only", logger, { allowInternalEvalModes: true }),
+).toBe("semantic-only")
+```
+
+```ts
+await service.search({
+  query: "jesus",
+  locale: "en",
+  mode: "semantic-only",
+  allowInternalEvalModes: true,
+})
+
+expect(searchVideoSemantic).toHaveBeenCalled()
+expect(searchVideoKeyword).not.toHaveBeenCalled()
+expect(searchByKeywordWeighted).not.toHaveBeenCalled()
+expect(searchExperienceKeyword).not.toHaveBeenCalled()
+```
+
+```ts
+expect(first.dataset.nativeKey).toContain("mode:hybrid")
+expect(second.dataset.nativeKey).toContain("mode:semantic-only")
+expect(second.dataset.datasetId).not.toBe(first.dataset.datasetId)
+```
+
+## Related
+
+- [Mastra offline search eval orchestration boundary pattern](./mastra-offline-search-eval-orchestration-boundary-pattern.md)
+- [Mastra native Evaluation search eval bridge pattern](./mastra-native-evaluation-search-eval-bridge-pattern.md)
+- [Admin hybrid search keyword-first R4 extension pattern](../platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md)


### PR DESCRIPTION
## Summary

Watch search can now be evaluated against a shared 100-query readiness set instead of ad hoc spot checks. The set combines Algolia-derived top and no-result queries with generated product-title, felt-need, Bible-topic, misspelling, multilingual mismatch, confusing, synonym, and scene-like cases, including explicit keyword-first checks for `bible project` and `jesus`.

The eval runner can compare public `hybrid` and `keyword-first` modes plus an internal-only `semantic-only` diagnostic mode, while public search boundaries still treat unknown modes as hybrid. Native Evaluation artifacts now include the requested search mode in dataset, experiment, and outcome keys, so mode-by-mode captures stay comparable instead of overwriting one another.

| Area | Decision |
| --- | --- |
| Prompt provenance | Algolia analytics is used for prompt selection only. |
| Search modes | `hybrid`, `keyword-first`, and internal-only `semantic-only` are in this ticket. |
| Algolia-backed execution | Out of scope for this ticket and not added as a follow-up. |
| Public safety | `semantic-only` is only accepted by the internal Admin eval route. |

## Validation

- `pnpm --filter @forge/admin test -- hybrid-search.keyword-first hybrid-search.service route.test.ts`
- `pnpm --filter @forge/admin test -- hybrid-search.bible-project`
- `pnpm --filter @forge/mastra test -- seed-prompt-set runner offline-search-eval search-eval-orchestrator native-evaluation admin-search-eval-client search-eval-native-suite artifacts report`

Typecheck caveats are documented in the roadmap ticket: Admin currently hits pre-existing Prisma schema drift around `sourceKind`, and Mastra typecheck cannot resolve `@mastra/memory` in this isolated worktree dependency setup.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
