### PR TITLE
fix(admin): resume transcript backfill safely

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -119,6 +119,10 @@ The response-side state that says whether semantic retrieval actually contribute
 
 A vector representation of localized content used for semantic retrieval across videos, scenes, transcripts, and experiences. Content Embeddings are only comparable when the query vector and stored document vectors come from the same provider contract and transform behavior.
 
+### AI Gateway
+
+The project-owned embedding provider surface that produces vectors for Content Embeddings. AI Gateway health proves provider availability, not that Admin can launch or store a specific embedding backfill through Mastra.
+
 ### Embedding Provenance
 
 The metadata that says which provider contract produced a stored Content Embedding and how that vector was transformed before storage. Provenance is part of search correctness: it prevents legacy vectors, newly generated vectors, and future provider variants from being treated as the same embedding space.

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -159,6 +159,11 @@ and a correction report highlights applied and flagged findings for review.
 
 A controlled batch process that generates or regenerates vectors for existing content without changing the underlying source content.
 
+For large corpora, an Embedding Backfill's completion state should be judged
+from stored embedding provenance and healthy vector rows, not from the lifetime
+of the trigger request that started it. Resume flows should preserve already
+healthy embeddings and continue from missing, legacy, or incomplete rows.
+
 ## Known-caller auth
 
 ### Search Passport

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1150,11 +1150,11 @@ writing, and is idempotent by default. Explicit modes are `idempotent`,
   anywhere, it produces no targets (a data-quality signal, not a
   silent default). Per-target error isolation; `artifact_missing`
   → skipped, every other error → failed but the run continues.
-	  Safe to re-run at the storage identity level. The workflow first groups
-	  enumerated targets by `(video, edition)` for stable reporting and source
-	  gap aggregation, then shards each `(video, edition, language)` target into
-	  target-bounded batches so no single Workflow step owns the full
-	  all-language corpus.
+  Safe to re-run at the storage identity level. The workflow first groups
+  enumerated targets by `(video, edition)` for stable reporting and source
+  gap aggregation, then shards each `(video, edition, language)` target into
+  target-bounded batches so no single Workflow step owns the full
+  all-language corpus.
 - **Bounded parallelism (Stage 2 — feat-116, updated for feat-192 hotfix):**
   the workflow calls `stepProcessTranscriptEmbeddingGroups` sequentially per
   target-bounded batch. Parallelism stays inside each batch via

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1150,15 +1150,36 @@ writing, and is idempotent by default. Explicit modes are `idempotent`,
   anywhere, it produces no targets (a data-quality signal, not a
   silent default). Per-target error isolation; `artifact_missing`
   → skipped, every other error → failed but the run continues.
-  Safe to re-run. The workflow loads the Manager transcript source once
-  per `(video, edition)` group and launches Mastra once per target.
-- **Bounded parallelism (Stage 2 — feat-116):** the workflow groups
-  enumerated `(video, edition, language)` targets by
-  `(video, edition)` and parallelises over GROUPS via
-  `pLimit(env.TRANSCRIPT_EMBEDDING_CONCURRENCY ?? 5) +
-Promise.allSettled` — never bare `Promise.all`. Per-language work
-  inside a group runs sequentially with the source artifact in scope. Same
-  shape / same rule as R1.
+	  Safe to re-run at the storage identity level. The workflow first groups
+	  enumerated targets by `(video, edition)` for stable reporting and source
+	  gap aggregation, then shards each `(video, edition, language)` target into
+	  target-bounded batches so no single Workflow step owns the full
+	  all-language corpus.
+- **Bounded parallelism (Stage 2 — feat-116, updated for feat-192 hotfix):**
+  the workflow calls `stepProcessTranscriptEmbeddingGroups` sequentially per
+  target-bounded batch. Parallelism stays inside each batch via
+  `TRANSCRIPT_EMBEDDING_CONCURRENCY`; do not use parallel dynamic workflow
+  step fanout. The default step target limit is 50, each durable step stops
+  launching new work after a 220s budget and returns remaining groups for the
+  next step, and each Mastra launch has a 120s Admin-side timeout. The start
+  log includes `groupBatchCount`, `stepTargetLimit`, `stepMaxDurationMs`, and
+  `launchTimeoutMs` for production verification. Runtime knobs are resolved in
+  a step before batching so workflow replay keeps the same partitioning even if
+  Railway env changes mid-run.
+- **Manager transcript fallback tradeoff:** target sharding means Manager
+  fallback artifacts may be read once per durable step per `cmsVideoId`, not
+  once for the whole run. The step-local source loader caches artifact reads
+  while that batch is active, but later batches may reread the same Manager
+  artifact. That is intentional for all-language backfills: bounded step
+  duration is more important than whole-run S3 memoization until a first-class
+  backfill ledger exists.
+- **Timed-out Mastra launch confirmation:** if Admin receives a retryable
+  Mastra launch network error that still has a `mastraRunId`, the batch step
+  returns a pending confirmation. The workflow checks pending confirmations
+  opportunistically between launch batches, then drains any remaining pending
+  runs through short `stepConfirmTranscriptEmbeddingIngests` calls separated by
+  workflow-level `sleep()`. Unresolved confirmations are marked failed only
+  after the 20 minute confirmation window. Do not sleep inside the worker step.
 - Tune via the `TRANSCRIPT_EMBEDDING_CONCURRENCY` env var. Admin
   backfill is now network-bound on Mastra plus DB-bound inside the
   ingest callback; default `5` leaves headroom on admin's

--- a/apps/admin/src/graphql/mutations/transcript-embedding.test.ts
+++ b/apps/admin/src/graphql/mutations/transcript-embedding.test.ts
@@ -74,6 +74,24 @@ describe("dispatchTranscriptEmbeddingBackfill", () => {
     ])
   })
 
+  it("preserves the production resume shape for the latest failure point", async () => {
+    dispatch.mockReturnValue(BASE_REPORT)
+
+    await dispatchTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      coreIds: ["1_jf-0-0"],
+      mode: "model-upgrade",
+    })
+
+    dispatch.expectDispatched(runTranscriptEmbeddingBackfill, [
+      {
+        mappingS3Key: "admin-migrations/core-id-mapping.json",
+        coreIds: ["1_jf-0-0"],
+        mode: "model-upgrade",
+      },
+    ])
+  })
+
   it("propagates workflow rejections as thrown errors", async () => {
     const boom = new Error("mapping not found")
     dispatch.mockRejection(boom)

--- a/apps/admin/src/services/mastra-experience-embedding-client.ts
+++ b/apps/admin/src/services/mastra-experience-embedding-client.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client"
 import { env } from "@/config/env"
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
 import { prisma as defaultPrisma } from "@/db/client"
 import { buildExperienceEmbeddingSource } from "@/services/embeddings.service"
 
@@ -167,9 +168,9 @@ export async function launchMastraExperienceEmbedding(
         },
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(
-          options.timeoutMs ??
-            env.MASTRA_EXPERIENCE_EMBEDDING_TIMEOUT_MS ??
-            120_000,
+          resolveMastraLaunchTimeoutMs(
+            options.timeoutMs ?? env.MASTRA_EXPERIENCE_EMBEDDING_TIMEOUT_MS,
+          ),
         ),
       },
     )

--- a/apps/admin/src/services/mastra-launch-timeout.test.ts
+++ b/apps/admin/src/services/mastra-launch-timeout.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
+
+describe("resolveMastraLaunchTimeoutMs", () => {
+  it("accepts positive integer numbers and numeric env strings", () => {
+    expect(resolveMastraLaunchTimeoutMs(300_000)).toBe(300_000)
+    expect(resolveMastraLaunchTimeoutMs("1200000")).toBe(1_200_000)
+  })
+
+  it("falls back for missing or invalid runtime values", () => {
+    expect(resolveMastraLaunchTimeoutMs(undefined)).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("")).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("5m")).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("1.5")).toBe(120_000)
+    expect(resolveMastraLaunchTimeoutMs("-1")).toBe(120_000)
+  })
+})

--- a/apps/admin/src/services/mastra-launch-timeout.ts
+++ b/apps/admin/src/services/mastra-launch-timeout.ts
@@ -1,0 +1,17 @@
+const DEFAULT_MASTRA_LAUNCH_TIMEOUT_MS = 120_000
+
+export function resolveMastraLaunchTimeoutMs(
+  value: number | string | undefined,
+  fallbackMs: number = DEFAULT_MASTRA_LAUNCH_TIMEOUT_MS,
+): number {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isInteger(parsed) && parsed > 0) return parsed
+  }
+
+  return fallbackMs
+}

--- a/apps/admin/src/services/mastra-scene-embedding-client.ts
+++ b/apps/admin/src/services/mastra-scene-embedding-client.ts
@@ -1,4 +1,5 @@
 import { env } from "@/config/env"
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
 import {
   sceneAnalysisArtifactKey,
   type SceneAnalysisResult,
@@ -211,7 +212,9 @@ export async function launchMastraSceneEmbedding(
         },
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(
-          options.timeoutMs ?? env.MASTRA_SCENE_EMBEDDING_TIMEOUT_MS ?? 120_000,
+          resolveMastraLaunchTimeoutMs(
+            options.timeoutMs ?? env.MASTRA_SCENE_EMBEDDING_TIMEOUT_MS,
+          ),
         ),
       },
     )

--- a/apps/admin/src/services/mastra-transcript-embedding-client.test.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.test.ts
@@ -187,6 +187,39 @@ describe("launchMastraTranscriptEmbedding", () => {
     })
   })
 
+  it("preserves caller run id when the Mastra launch fetch throws", async () => {
+    const threw = vi.fn(async () => {
+      throw Object.assign(new Error("operation timed out"), {
+        name: "TimeoutError",
+      })
+    })
+
+    await expect(
+      launchMastraTranscriptEmbedding(
+        {
+          target: { videoId: "v-1", videoEditionId: "e-1" },
+          language: "en",
+          cmsVideoId: 42,
+          transcript: {
+            text: "hello transcript",
+            segments: [{ start: 0, end: 1, text: "hello transcript" }],
+          },
+        },
+        {
+          baseUrl: "https://mastra.internal",
+          bearer: "secret",
+          runId: "run-fetch-threw",
+          fetchImpl: threw as typeof fetch,
+        },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+      mastraRunId: "run-fetch-threw",
+    })
+  })
+
   it("returns Mastra failures and upstream auth failures safely", async () => {
     const productFailure = {
       ok: false,

--- a/apps/admin/src/services/mastra-transcript-embedding-client.test.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.test.ts
@@ -60,6 +60,7 @@ describe("launchMastraTranscriptEmbedding", () => {
         {
           baseUrl: "https://mastra.internal",
           bearer: "secret",
+          runId: "run-launch-1",
           fetchImpl,
         },
       ),
@@ -77,20 +78,23 @@ describe("launchMastraTranscriptEmbedding", () => {
       }),
     )
     expect(body).toMatchObject({
-      target: {
-        admin: {
-          videoId: "v-1",
-          videoEditionId: "e-1",
-          coreId: "core-1",
+      runId: "run-launch-1",
+      input: {
+        target: {
+          admin: {
+            videoId: "v-1",
+            videoEditionId: "e-1",
+            coreId: "core-1",
+          },
         },
+        language: "en",
+        transcript: {
+          text: "hello transcript",
+          artifactKey: "42/transcript.json",
+          provider: "mux",
+        },
+        mode: "repair",
       },
-      language: "en",
-      transcript: {
-        text: "hello transcript",
-        artifactKey: "42/transcript.json",
-        provider: "mux",
-      },
-      mode: "repair",
     })
     expect(JSON.stringify(body)).not.toContain("embedding")
   })
@@ -131,21 +135,55 @@ describe("launchMastraTranscriptEmbedding", () => {
       },
     )
 
-    const body = JSON.parse(
-      String(fetchImpl.mock.calls[0]?.[1]?.body),
-    ) as Record<string, unknown>
+    const body = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
+      input?: Record<string, unknown>
+    }
     expect(body).toMatchObject({
-      transcript: {
-        artifactKey: "admin-video-subtitle/sub-1.vtt",
-        kind: "subtitle",
-        languageId: "lang-en",
-        languageSlug: "english",
-        subtitleId: "sub-1",
-        format: "vtt",
-        url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
-        provider: "admin-subtitle",
-        generatedAt: "2026-06-01T00:00:00.000Z",
+      input: {
+        transcript: {
+          artifactKey: "admin-video-subtitle/sub-1.vtt",
+          kind: "subtitle",
+          languageId: "lang-en",
+          languageSlug: "english",
+          subtitleId: "sub-1",
+          format: "vtt",
+          url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+          provider: "admin-subtitle",
+          generatedAt: "2026-06-01T00:00:00.000Z",
+        },
       },
+    })
+  })
+
+  it("preserves caller run id on Mastra gateway timeouts", async () => {
+    const timedOut = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({ error: "Gateway Timeout" }, { status: 504 }),
+    )
+
+    await expect(
+      launchMastraTranscriptEmbedding(
+        {
+          target: { videoId: "v-1", videoEditionId: "e-1" },
+          language: "en",
+          cmsVideoId: 42,
+          transcript: {
+            text: "hello transcript",
+            segments: [{ start: 0, end: 1, text: "hello transcript" }],
+          },
+        },
+        {
+          baseUrl: "https://mastra.internal",
+          bearer: "secret",
+          runId: "run-timeout",
+          fetchImpl: timedOut,
+        },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+      mastraRunId: "run-timeout",
     })
   })
 
@@ -235,6 +273,7 @@ describe("launchMastraTranscriptEmbedding", () => {
         {
           baseUrl: "https://mastra.internal",
           bearer: "secret",
+          runId: "run-malformed-status",
           fetchImpl: malformedStatus,
         },
       ),
@@ -242,6 +281,7 @@ describe("launchMastraTranscriptEmbedding", () => {
       ok: false,
       reason: "parse_error",
       retryable: true,
+      mastraRunId: "run-malformed-status",
     })
 
     const malformedReason = vi.fn(
@@ -269,6 +309,7 @@ describe("launchMastraTranscriptEmbedding", () => {
         {
           baseUrl: "https://mastra.internal",
           bearer: "secret",
+          runId: "run-malformed-reason",
           fetchImpl: malformedReason,
         },
       ),
@@ -276,6 +317,7 @@ describe("launchMastraTranscriptEmbedding", () => {
       ok: false,
       reason: "parse_error",
       retryable: true,
+      mastraRunId: "run-malformed-reason",
     })
   })
 })

--- a/apps/admin/src/services/mastra-transcript-embedding-client.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.ts
@@ -1,4 +1,5 @@
 import { env } from "@/config/env"
+import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
 
 export type MastraTranscriptEmbeddingMode =
   | "idempotent"
@@ -260,9 +261,9 @@ export async function launchMastraTranscriptEmbedding(
         },
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(
-          options.timeoutMs ??
-            env.MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS ??
-            120_000,
+          resolveMastraLaunchTimeoutMs(
+            options.timeoutMs ?? env.MASTRA_TRANSCRIPT_EMBEDDING_TIMEOUT_MS,
+          ),
         ),
       },
     )
@@ -307,4 +308,5 @@ export async function launchMastraTranscriptEmbedding(
 
 export const _internals = {
   parseWorkflowResult,
+  resolveMastraLaunchTimeoutMs,
 }

--- a/apps/admin/src/services/mastra-transcript-embedding-client.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.ts
@@ -276,6 +276,7 @@ export async function launchMastraTranscriptEmbedding(
     console.error(
       JSON.stringify({
         event: "mastra_transcript_embedding_launch_threw",
+        mastraRunId: runId,
         name: error instanceof Error ? error.name : "unknown",
         message:
           error instanceof Error
@@ -283,7 +284,12 @@ export async function launchMastraTranscriptEmbedding(
             : String(error).slice(0, 240),
       }),
     )
-    return { ok: false, reason: "network_error", retryable: true }
+    return {
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+      mastraRunId: runId,
+    }
   }
 
   if (response.status === 401) {

--- a/apps/admin/src/services/mastra-transcript-embedding-client.ts
+++ b/apps/admin/src/services/mastra-transcript-embedding-client.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto"
+
 import { env } from "@/config/env"
 import { resolveMastraLaunchTimeoutMs } from "@/services/mastra-launch-timeout"
 
@@ -78,6 +80,7 @@ export type LaunchMastraTranscriptEmbeddingOptions = {
   baseUrl?: string
   bearer?: string
   timeoutMs?: number
+  runId?: string
   fetchImpl?: typeof fetch
 }
 
@@ -227,7 +230,8 @@ export async function launchMastraTranscriptEmbedding(
     return { ok: false, reason: "config_missing", retryable: false }
   }
 
-  const body = {
+  const runId = options.runId ?? randomUUID()
+  const workflowInput = {
     target: {
       admin: input.target,
     },
@@ -248,6 +252,7 @@ export async function launchMastraTranscriptEmbedding(
     },
     mode: input.mode ?? "idempotent",
   }
+  const body = { runId, input: workflowInput }
 
   let response: Response
   try {
@@ -300,10 +305,17 @@ export async function launchMastraTranscriptEmbedding(
       ok: false,
       reason: "network_error",
       retryable: response.status >= 500 || response.status === 429,
+      mastraRunId:
+        response.status >= 500 || response.status === 429 ? runId : undefined,
     }
   }
 
-  return { ok: false, reason: "parse_error", retryable: true }
+  return {
+    ok: false,
+    reason: "parse_error",
+    retryable: true,
+    mastraRunId: runId,
+  }
 }
 
 export const _internals = {

--- a/apps/admin/src/services/transcript-embedding-ingest.service.test.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.service.test.ts
@@ -539,6 +539,52 @@ describe("ingestTranscriptEmbeddings", () => {
     expect(writeTranscriptEmbeddingPayloadMock).not.toHaveBeenCalled()
   })
 
+  it("retries serializable transcript writes before surfacing write_failed", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const prisma = buildPrisma()
+    const serializationFailure = Object.assign(
+      new Error("Transaction failed due to a write conflict or a deadlock"),
+      {
+        name: "PrismaClientKnownRequestError",
+        code: "P2034",
+      },
+    )
+    writeTranscriptEmbeddingPayloadMock
+      .mockRejectedValueOnce(serializationFailure)
+      .mockResolvedValueOnce(undefined)
+
+    const result = await ingestTranscriptEmbeddings(prisma as never, payload())
+
+    expect(result.status).toBe("created")
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2)
+    expect(writeTranscriptEmbeddingPayloadMock).toHaveBeenCalledTimes(2)
+    expect(
+      warnSpy.mock.calls.some(([message]) =>
+        String(message).includes(
+          "transcript_embedding_ingest_transaction_retry",
+        ),
+      ),
+    ).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it("detects retryable Prisma transaction codes before nested causes", () => {
+    const retryableWithCause = Object.assign(
+      new Error("Transaction failed due to a write conflict or a deadlock"),
+      {
+        name: "PrismaClientKnownRequestError",
+        code: "P2034",
+        cause: new Error("nested non-retryable wrapper"),
+      },
+    )
+
+    expect(
+      _internals.isRetryableTranscriptIngestTransactionError(
+        retryableWithCause,
+      ),
+    ).toBe(true)
+  })
+
   it("force mode rewrites even when existing provenance and chunks are healthy", async () => {
     const prisma = buildPrisma()
     const base = payload()

--- a/apps/admin/src/services/transcript-embedding-ingest.service.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.service.ts
@@ -225,6 +225,53 @@ export class TranscriptEmbeddingIngestError extends Error {
 }
 
 const TRANSCRIPT_INGEST_TRANSACTION_TIMEOUT_MS = 30_000
+const TRANSCRIPT_INGEST_TRANSACTION_MAX_ATTEMPTS = 3
+const TRANSCRIPT_INGEST_TRANSACTION_RETRY_DELAY_MS = 250
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isRetryableTranscriptIngestTransactionError(error: unknown): boolean {
+  const record =
+    error && typeof error === "object"
+      ? (error as { name?: unknown; code?: unknown; message?: unknown })
+      : null
+  const name = typeof record?.name === "string" ? record.name : ""
+  const code = typeof record?.code === "string" ? record.code : ""
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof record?.message === "string"
+        ? record.message
+        : ""
+
+  const isCurrentErrorRetryable =
+    name === "PrismaClientKnownRequestError" &&
+    (code === "P2034" ||
+      (code === "P2010" &&
+        /40001|40P01|serialize|serialization|deadlock/i.test(message)))
+  if (isCurrentErrorRetryable) return true
+
+  const nestedCause =
+    record && "cause" in record
+      ? (record as { cause?: unknown }).cause
+      : error instanceof TranscriptEmbeddingIngestError
+        ? error.cause
+        : undefined
+
+  return (
+    nestedCause !== undefined &&
+    isRetryableTranscriptIngestTransactionError(nestedCause)
+  )
+}
+
+function transactionRetryDelayMs(attempt: number): number {
+  return (
+    TRANSCRIPT_INGEST_TRANSACTION_RETRY_DELAY_MS * 2 ** Math.max(0, attempt - 1)
+  )
+}
 
 function sha256Json(value: unknown): string {
   return `sha256:${createHash("sha256")
@@ -640,90 +687,132 @@ export async function ingestTranscriptEmbeddings(
   const target = await resolveTarget(prisma, payload)
   const mode = payload.generation.mode as TranscriptEmbeddingGenerationMode
 
-  return prisma.$transaction(
-    async (tx) => {
-      await lockTranscriptTarget(tx, target, payload.language)
-      const existing = await readExistingTranscript(
-        tx,
-        target,
-        payload.language,
+  for (
+    let attempt = 1;
+    attempt <= TRANSCRIPT_INGEST_TRANSACTION_MAX_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      return await prisma.$transaction(
+        async (tx) => {
+          await lockTranscriptTarget(tx, target, payload.language)
+          const existing = await readExistingTranscript(
+            tx,
+            target,
+            payload.language,
+          )
+
+          if (existing) {
+            const matches = existingMatches(existing, payload, hash)
+            const healthyChunks = matches
+              ? await countHealthyChunks(tx, existing.id)
+              : 0
+
+            if (
+              mode === "idempotent" &&
+              matches &&
+              healthyChunks === payload.chunks.length
+            ) {
+              return {
+                status: "unchanged",
+                target: { ...target, language: payload.language },
+                chunks: payload.chunks.length,
+                model: payload.model.name,
+                dimensions: payload.model.dimensions,
+                mastraRunId: payload.generation.mastraRunId,
+              }
+            }
+
+            if (mode === "idempotent") {
+              return resultForRejected(
+                payload,
+                target,
+                "existing_transcript_differs",
+              )
+            }
+
+            if (mode === "repair" && !matches) {
+              return resultForRejected(
+                payload,
+                target,
+                "repair_requires_matching_provenance",
+              )
+            }
+            if (mode === "repair" && healthyChunks === payload.chunks.length) {
+              return {
+                status: "unchanged",
+                target: { ...target, language: payload.language },
+                chunks: payload.chunks.length,
+                model: payload.model.name,
+                dimensions: payload.model.dimensions,
+                mastraRunId: payload.generation.mastraRunId,
+              }
+            }
+          }
+
+          let status: TranscriptEmbeddingIngestStatus = "created"
+          if (existing) {
+            if (mode === "idempotent") {
+              return resultForRejected(
+                payload,
+                target,
+                "existing_transcript_differs",
+              )
+            }
+            status = statusForEmbeddingRewrite(mode)
+          }
+
+          await writePayload(tx, payload, target, chunks, hash)
+
+          return {
+            status,
+            target: { ...target, language: payload.language },
+            chunks: payload.chunks.length,
+            model: payload.model.name,
+            dimensions: payload.model.dimensions,
+            mastraRunId: payload.generation.mastraRunId,
+          }
+        },
+        {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+          timeout: TRANSCRIPT_INGEST_TRANSACTION_TIMEOUT_MS,
+        },
       )
-
-      if (existing) {
-        const matches = existingMatches(existing, payload, hash)
-        const healthyChunks = matches
-          ? await countHealthyChunks(tx, existing.id)
-          : 0
-
-        if (
-          mode === "idempotent" &&
-          matches &&
-          healthyChunks === payload.chunks.length
-        ) {
-          return {
-            status: "unchanged",
-            target: { ...target, language: payload.language },
-            chunks: payload.chunks.length,
-            model: payload.model.name,
-            dimensions: payload.model.dimensions,
-            mastraRunId: payload.generation.mastraRunId,
-          }
-        }
-
-        if (mode === "idempotent") {
-          return resultForRejected(
-            payload,
-            target,
-            "existing_transcript_differs",
-          )
-        }
-
-        if (mode === "repair" && !matches) {
-          return resultForRejected(
-            payload,
-            target,
-            "repair_requires_matching_provenance",
-          )
-        }
-        if (mode === "repair" && healthyChunks === payload.chunks.length) {
-          return {
-            status: "unchanged",
-            target: { ...target, language: payload.language },
-            chunks: payload.chunks.length,
-            model: payload.model.name,
-            dimensions: payload.model.dimensions,
-            mastraRunId: payload.generation.mastraRunId,
-          }
-        }
+    } catch (error) {
+      if (
+        attempt >= TRANSCRIPT_INGEST_TRANSACTION_MAX_ATTEMPTS ||
+        !isRetryableTranscriptIngestTransactionError(error)
+      ) {
+        throw error
       }
 
-      let status: TranscriptEmbeddingIngestStatus = "created"
-      if (existing) {
-        if (mode === "idempotent") {
-          return resultForRejected(
-            payload,
-            target,
-            "existing_transcript_differs",
-          )
-        }
-        status = statusForEmbeddingRewrite(mode)
-      }
+      const delayMs = transactionRetryDelayMs(attempt)
+      console.warn(
+        JSON.stringify({
+          event: "transcript_embedding_ingest_transaction_retry",
+          target: {
+            videoId: target.videoId,
+            videoEditionId: target.videoEditionId,
+            coreId: target.coreId,
+          },
+          language: payload.language,
+          mastraRunId: payload.generation.mastraRunId,
+          attempt,
+          maxAttempts: TRANSCRIPT_INGEST_TRANSACTION_MAX_ATTEMPTS,
+          delayMs,
+          code:
+            error && typeof error === "object" && "code" in error
+              ? String((error as { code?: unknown }).code ?? "")
+              : "unknown",
+        }),
+      )
+      await sleep(delayMs)
+    }
+  }
 
-      await writePayload(tx, payload, target, chunks, hash)
-
-      return {
-        status,
-        target: { ...target, language: payload.language },
-        chunks: payload.chunks.length,
-        model: payload.model.name,
-        dimensions: payload.model.dimensions,
-        mastraRunId: payload.generation.mastraRunId,
-      }
-    },
-    {
-      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-      timeout: TRANSCRIPT_INGEST_TRANSACTION_TIMEOUT_MS,
-    },
+  throw new TranscriptEmbeddingIngestError(
+    "write_failed",
+    "transcript embedding ingest retry loop exhausted unexpectedly",
   )
 }
 
@@ -732,4 +821,5 @@ export const _internals = {
   sourceContentHash,
   validateChunks,
   existingMatches,
+  isRetryableTranscriptIngestTransactionError,
 }

--- a/apps/admin/src/services/transcript-embedding.service.ts
+++ b/apps/admin/src/services/transcript-embedding.service.ts
@@ -56,15 +56,18 @@ export const EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS = 1536
  * the payload here; intentional model replacement must use the ingest
  * service's explicit generation modes.
  */
-const ACCEPTED_MODEL_STAMPS = new Set<string>([
-  "openai/text-embedding-3-small",
-  "text-embedding-3-small",
-  "embeddings",
-])
+export const ACCEPTED_TRANSCRIPT_EMBEDDING_MODEL_STAMPS: ReadonlySet<string> =
+  new Set<string>([
+    "openai/text-embedding-3-small",
+    "text-embedding-3-small",
+    "embeddings",
+  ])
 
 // Precomputed list form for the drift-warning log payload. Avoids
 // re-serializing the Set on every mismatch.
-const ACCEPTED_MODEL_STAMPS_LIST = Array.from(ACCEPTED_MODEL_STAMPS)
+const ACCEPTED_MODEL_STAMPS_LIST = Array.from(
+  ACCEPTED_TRANSCRIPT_EMBEDDING_MODEL_STAMPS,
+)
 
 /**
  * Prisma's default interactive-transaction timeout is 5s. Stage 3
@@ -255,7 +258,7 @@ function assertNonEmptyText(chunks: EmbeddingsResult["chunks"]): void {
 }
 
 function logModelStampDriftIfAny(artifactModel: string): void {
-  if (ACCEPTED_MODEL_STAMPS.has(artifactModel)) return
+  if (ACCEPTED_TRANSCRIPT_EMBEDDING_MODEL_STAMPS.has(artifactModel)) return
   console.warn(
     JSON.stringify({
       event: "transcript_model_mismatch",

--- a/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
+++ b/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client"
 import { prisma } from "@/db/client"
 import {
   ManagerArtifactError,
@@ -9,6 +10,10 @@ import {
   type MastraTranscriptEmbeddingLaunchResult,
   type MastraTranscriptEmbeddingMode,
 } from "@/services/mastra-transcript-embedding-client"
+import {
+  ACCEPTED_TRANSCRIPT_EMBEDDING_MODEL_STAMPS,
+  EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+} from "@/services/transcript-embedding.service"
 import {
   resolveSubtitleTranscriptSource,
   type ResolvedTranscriptEmbeddingSource,
@@ -67,6 +72,27 @@ type TranscriptIngestConfirmationRow = {
   embedding_provider: string | null
   source_content_hash: string | null
   healthy_chunks: number | bigint
+}
+
+type ExistingTranscriptBackfillHealthRow = {
+  video_edition_id: string
+  language: string
+  total_chunks: number | bigint
+  model: string
+  dimensions: number
+  embedding_provider: string | null
+  generation_mode: string | null
+  source_kind: string | null
+  chunks_with_embedding: number | bigint
+  chunks_with_embedding_input_text: number | bigint
+}
+
+function resumeTargetKey(videoEditionId: string, language: string): string {
+  return `${videoEditionId}::${language}`
+}
+
+function targetResumeKey(target: BackfillTarget): string {
+  return resumeTargetKey(target.videoEditionId, target.language)
 }
 
 function managerTranscriptSourceFromArtifact(
@@ -278,6 +304,80 @@ async function readTranscriptIngestConfirmation(
   }
 }
 
+function isHealthyEnrichedTranscriptForResume(
+  row: ExistingTranscriptBackfillHealthRow,
+): boolean {
+  const totalChunks = Number(row.total_chunks)
+  const chunksWithEmbedding = Number(row.chunks_with_embedding)
+  const chunksWithEmbeddingInputText = Number(
+    row.chunks_with_embedding_input_text,
+  )
+
+  return (
+    Number.isFinite(totalChunks) &&
+    totalChunks > 0 &&
+    row.generation_mode === "model-upgrade" &&
+    row.source_kind != null &&
+    row.source_kind.length > 0 &&
+    ACCEPTED_TRANSCRIPT_EMBEDDING_MODEL_STAMPS.has(row.model) &&
+    row.dimensions === EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS &&
+    row.embedding_provider === "jesus-film-ai-gateway" &&
+    chunksWithEmbedding === totalChunks &&
+    chunksWithEmbeddingInputText === totalChunks
+  )
+}
+
+async function readHealthyEnrichedTranscriptResumeKeys(
+  targets: readonly BackfillTarget[],
+): Promise<ReadonlySet<string>> {
+  if (targets.length === 0) return new Set()
+
+  const uniqueTargets = Array.from(
+    new Map(
+      targets.map((target) => [targetResumeKey(target), target]),
+    ).values(),
+  )
+  const rows = await prisma.$queryRaw<ExistingTranscriptBackfillHealthRow[]>`
+    WITH target(video_edition_id, language) AS (
+      VALUES ${Prisma.join(
+        uniqueTargets.map(
+          (target) =>
+            Prisma.sql`(${target.videoEditionId}, ${target.language})`,
+        ),
+      )}
+    )
+    SELECT
+      vt.video_edition_id,
+      vt.language,
+      vt.total_chunks,
+      vt.model,
+      vt.dimensions,
+      vt.embedding_provider,
+      vt.generation_mode,
+      vt.source_kind,
+      COUNT(vtc.id) FILTER (
+        WHERE vtc.embedding IS NOT NULL
+      ) AS chunks_with_embedding,
+      COUNT(vtc.id) FILTER (
+        WHERE vtc.embedding_input_text IS NOT NULL
+          AND length(vtc.embedding_input_text) > 0
+      ) AS chunks_with_embedding_input_text
+    FROM video_transcript vt
+    JOIN target t
+      ON t.video_edition_id = vt.video_edition_id
+      AND t.language = vt.language
+    LEFT JOIN video_transcript_chunk vtc
+      ON vtc.transcript_id = vt.id
+    GROUP BY vt.id
+  `
+
+  return new Set(
+    rows
+      .filter(isHealthyEnrichedTranscriptForResume)
+      .map((row) => resumeTargetKey(row.video_edition_id, row.language)),
+  )
+}
+
 async function launchTranscriptEmbedding(
   target: BackfillTarget,
   transcriptSource: ResolvedTranscriptEmbeddingSource,
@@ -388,12 +488,30 @@ async function processTranscriptEmbeddingGroup(
   mode: MastraTranscriptEmbeddingMode,
   loadManagerSource: ManagerSourceLoader,
   launchTimeoutMs: number,
+  healthyResumeTargets: ReadonlySet<string>,
 ): Promise<TranscriptIngestConfirmationBatchResult> {
   const groupStartedAt = Date.now()
 
   const outcomes: BackfillOutcome[] = []
   const pendingConfirmations: PendingTranscriptIngestConfirmation[] = []
   for (const target of group.targets) {
+    const targetStartedAt = Date.now()
+    if (
+      mode === "model-upgrade" &&
+      healthyResumeTargets.has(targetResumeKey(target))
+    ) {
+      const outcome: BackfillOutcome = {
+        status: "skipped",
+        target,
+        language: target.language,
+        reason: "already_enriched_healthy",
+        durationMs: Date.now() - targetStartedAt,
+      }
+      logOutcome(outcome)
+      outcomes.push(outcome)
+      continue
+    }
+
     const subtitleResolution = await resolveSubtitleTranscriptSource(
       prisma,
       target,
@@ -479,6 +597,12 @@ export async function stepProcessTranscriptEmbeddingGroups(
       : 220_000
   const batchStartedAt = Date.now()
   const loadManagerSource = createManagerSourceLoader()
+  const healthyResumeTargets =
+    mode === "model-upgrade"
+      ? await readHealthyEnrichedTranscriptResumeKeys(
+          groups.flatMap((group) => group.targets),
+        )
+      : new Set<string>()
 
   const outcomes: BackfillOutcome[] = []
   const pendingConfirmations: PendingTranscriptIngestConfirmation[] = []
@@ -498,6 +622,7 @@ export async function stepProcessTranscriptEmbeddingGroups(
           mode,
           loadManagerSource,
           launchTimeoutMs,
+          healthyResumeTargets,
         ),
       ),
     )

--- a/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
+++ b/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
@@ -1,4 +1,3 @@
-import pLimit from "p-limit"
 import { prisma } from "@/db/client"
 import {
   ManagerArtifactError,
@@ -22,13 +21,13 @@ import type {
   TranscriptEmbeddingSourceGap,
 } from "../transcriptEmbeddingBackfill"
 
-const TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS = 20 * 60 * 1_000
-const TIMED_OUT_LAUNCH_CONFIRM_POLL_MS = 5_000
-
 type ManagerSourceLoadState =
-  | { status: "not-attempted" }
   | { status: "resolved"; artifact: TranscriptSourceArtifact }
   | { status: "failed"; reason: string; missing: boolean }
+
+type ManagerSourceLoader = (
+  cmsVideoId: number,
+) => Promise<ManagerSourceLoadState>
 
 type TranscriptIngestConfirmation = {
   chunks: number
@@ -40,6 +39,26 @@ type TranscriptIngestConfirmation = {
   sourceContentHash: string
 }
 
+export type PendingTranscriptIngestConfirmation = {
+  status: "pending-ingest-confirmation"
+  target: BackfillTarget
+  language: string
+  sourceKind: ResolvedTranscriptEmbeddingSource["sourceKind"]
+  mastraRunId: string
+  startedAtEpochMs: number
+}
+
+export type TranscriptEmbeddingGroupBatchResult = {
+  outcomes: BackfillOutcome[]
+  pendingConfirmations: PendingTranscriptIngestConfirmation[]
+  unprocessedGroups: BackfillGroup[]
+}
+
+export type TranscriptIngestConfirmationBatchResult = {
+  outcomes: BackfillOutcome[]
+  pendingConfirmations: PendingTranscriptIngestConfirmation[]
+}
+
 type TranscriptIngestConfirmationRow = {
   total_chunks: number | bigint
   total_tokens: number | bigint
@@ -48,11 +67,6 @@ type TranscriptIngestConfirmationRow = {
   embedding_provider: string | null
   source_content_hash: string | null
   healthy_chunks: number | bigint
-}
-
-function sleep(ms: number): Promise<void> {
-  if (ms <= 0) return Promise.resolve()
-  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function managerTranscriptSourceFromArtifact(
@@ -78,6 +92,40 @@ function managerTranscriptSourceFromArtifact(
       languageId: target.languageId,
       languageSlug: target.languageSlug,
     },
+  }
+}
+
+function createManagerSourceLoader(): ManagerSourceLoader {
+  const cache = new Map<number, Promise<ManagerSourceLoadState>>()
+
+  return (cmsVideoId) => {
+    const existing = cache.get(cmsVideoId)
+    if (existing) return existing
+
+    const loading = readTranscriptSourceArtifact(String(cmsVideoId))
+      .then(
+        (artifact): ManagerSourceLoadState => ({
+          status: "resolved",
+          artifact,
+        }),
+      )
+      .catch((error): ManagerSourceLoadState => {
+        const missing =
+          error instanceof ManagerArtifactError &&
+          error.code === "artifact_missing"
+        return {
+          status: "failed",
+          missing,
+          reason: missing
+            ? "artifact_missing"
+            : error instanceof Error
+              ? error.message
+              : String(error),
+        }
+      })
+
+    cache.set(cmsVideoId, loading)
+    return loading
   }
 }
 
@@ -230,60 +278,41 @@ async function readTranscriptIngestConfirmation(
   }
 }
 
-async function waitForTimedOutLaunchIngest(
-  target: BackfillTarget,
-  language: string,
-  mastraRunId: string,
-): Promise<TranscriptIngestConfirmation | null> {
-  const deadline = Date.now() + TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS
-
-  while (Date.now() <= deadline) {
-    const confirmation = await readTranscriptIngestConfirmation(
-      target,
-      language,
-      mastraRunId,
-    )
-    if (confirmation) return confirmation
-    await sleep(TIMED_OUT_LAUNCH_CONFIRM_POLL_MS)
-  }
-
-  return null
-}
-
 async function launchTranscriptEmbedding(
   target: BackfillTarget,
   transcriptSource: ResolvedTranscriptEmbeddingSource,
   mode: MastraTranscriptEmbeddingMode,
-): Promise<BackfillOutcome> {
+  launchTimeoutMs: number,
+): Promise<BackfillOutcome | PendingTranscriptIngestConfirmation> {
   const startedAt = Date.now()
 
   try {
-    const result = await launchMastraTranscriptEmbedding({
-      target: {
-        videoId: target.videoId,
-        videoEditionId: target.videoEditionId,
-        coreId: target.coreId,
+    const result = await launchMastraTranscriptEmbedding(
+      {
+        target: {
+          videoId: target.videoId,
+          videoEditionId: target.videoEditionId,
+          coreId: target.coreId,
+        },
+        language: target.language,
+        cmsVideoId: target.cmsVideoId,
+        transcript: transcriptSource.transcript,
+        mode,
       },
-      language: target.language,
-      cmsVideoId: target.cmsVideoId,
-      transcript: transcriptSource.transcript,
-      mode,
-    })
+      { timeoutMs: launchTimeoutMs },
+    )
     if (!result.ok) {
       if (result.reason === "network_error" && result.mastraRunId) {
-        const confirmation = await waitForTimedOutLaunchIngest(
+        const pending: PendingTranscriptIngestConfirmation = {
+          status: "pending-ingest-confirmation",
           target,
-          target.language,
-          result.mastraRunId,
-        )
-        if (confirmation) {
-          return toSucceeded(
-            target,
-            transcriptSource.sourceKind,
-            confirmation,
-            Date.now() - startedAt,
-          )
+          language: target.language,
+          sourceKind: transcriptSource.sourceKind,
+          mastraRunId: result.mastraRunId,
+          startedAtEpochMs: startedAt,
         }
+        logPendingConfirmation(pending)
+        return pending
       }
 
       return {
@@ -325,6 +354,30 @@ async function launchTranscriptEmbedding(
   }
 }
 
+function logPendingConfirmation(
+  pending: PendingTranscriptIngestConfirmation,
+): void {
+  try {
+    console.log(
+      JSON.stringify({
+        workflow: "transcript-embedding-backfill",
+        event: "transcript_index_pending_ingest_confirmation",
+        coreId: pending.target.coreId,
+        videoEditionId: pending.target.videoEditionId,
+        language: pending.language,
+        sourceKind: pending.sourceKind,
+        mastraRunId: pending.mastraRunId,
+      }),
+    )
+  } catch (logErr) {
+    console.error(
+      `[transcript-embedding-backfill] logPendingConfirmation failed: ${
+        logErr instanceof Error ? logErr.message : String(logErr)
+      }`,
+    )
+  }
+}
+
 /**
  * Plain per-group worker. This deliberately is NOT a `"use step"` function:
  * production useworkflow gives every call to the same step function the same
@@ -333,11 +386,13 @@ async function launchTranscriptEmbedding(
 async function processTranscriptEmbeddingGroup(
   group: BackfillGroup,
   mode: MastraTranscriptEmbeddingMode,
-): Promise<BackfillOutcome[]> {
+  loadManagerSource: ManagerSourceLoader,
+  launchTimeoutMs: number,
+): Promise<TranscriptIngestConfirmationBatchResult> {
   const groupStartedAt = Date.now()
-  let managerSourceState: ManagerSourceLoadState = { status: "not-attempted" }
 
   const outcomes: BackfillOutcome[] = []
+  const pendingConfirmations: PendingTranscriptIngestConfirmation[] = []
   for (const target of group.targets) {
     const subtitleResolution = await resolveSubtitleTranscriptSource(
       prisma,
@@ -349,36 +404,9 @@ async function processTranscriptEmbeddingGroup(
         : null
 
     if (!source) {
-      if (managerSourceState.status === "not-attempted") {
-        try {
-          managerSourceState = {
-            status: "resolved",
-            artifact: await readTranscriptSourceArtifact(
-              String(group.cmsVideoId),
-            ),
-          }
-        } catch (error) {
-          const missing =
-            error instanceof ManagerArtifactError &&
-            error.code === "artifact_missing"
-          managerSourceState = {
-            status: "failed",
-            missing,
-            reason: missing
-              ? "artifact_missing"
-              : error instanceof Error
-                ? error.message
-                : String(error),
-          }
-        }
-      }
+      const managerSourceState = await loadManagerSource(group.cmsVideoId)
 
-      if (managerSourceState.status === "resolved") {
-        source = managerTranscriptSourceFromArtifact(
-          target,
-          managerSourceState.artifact,
-        )
-      } else if (managerSourceState.status === "failed") {
+      if (managerSourceState.status === "failed") {
         const durationMs = Date.now() - groupStartedAt
         const sourceGap = sourceGapForMissingManager(
           target,
@@ -405,59 +433,153 @@ async function processTranscriptEmbeddingGroup(
         logOutcome(outcome)
         outcomes.push(outcome)
         continue
-      } else {
-        throw new Error("internal transcript source resolver state was unset")
       }
+
+      source = managerTranscriptSourceFromArtifact(
+        target,
+        managerSourceState.artifact,
+      )
     }
 
-    const outcome = await launchTranscriptEmbedding(target, source, mode)
-    logOutcome(outcome)
-    outcomes.push(outcome)
+    const outcome = await launchTranscriptEmbedding(
+      target,
+      source,
+      mode,
+      launchTimeoutMs,
+    )
+    if (outcome.status === "pending-ingest-confirmation") {
+      pendingConfirmations.push(outcome)
+    } else {
+      logOutcome(outcome)
+      outcomes.push(outcome)
+    }
   }
-  return outcomes
+  return { outcomes, pendingConfirmations }
 }
 
 /**
- * One durable step for all group work. Keep bounded parallelism inside this
- * step so the production workflow event log sees a single step event rather
- * than thousands of repeated dynamic group step events.
+ * One durable step for a bounded batch of group work. Keep parallelism inside
+ * this step so the production workflow event log sees sequential batch steps
+ * rather than repeated dynamic group step fanout.
  */
 export async function stepProcessTranscriptEmbeddingGroups(
   groups: readonly BackfillGroup[],
   mode: MastraTranscriptEmbeddingMode,
   concurrency: number,
+  stepMaxDurationMs: number,
+  launchTimeoutMs: number,
+): Promise<TranscriptEmbeddingGroupBatchResult> {
+  "use step"
+
+  const safeConcurrency =
+    Number.isInteger(concurrency) && concurrency > 0 ? concurrency : 1
+  const safeStepMaxDurationMs =
+    Number.isInteger(stepMaxDurationMs) && stepMaxDurationMs > 0
+      ? stepMaxDurationMs
+      : 220_000
+  const batchStartedAt = Date.now()
+  const loadManagerSource = createManagerSourceLoader()
+
+  const outcomes: BackfillOutcome[] = []
+  const pendingConfirmations: PendingTranscriptIngestConfirmation[] = []
+  const unprocessedGroups: BackfillGroup[] = []
+
+  for (let i = 0; i < groups.length; i += safeConcurrency) {
+    if (i > 0 && Date.now() - batchStartedAt >= safeStepMaxDurationMs) {
+      unprocessedGroups.push(...groups.slice(i))
+      break
+    }
+
+    const wave = groups.slice(i, i + safeConcurrency)
+    const settled = await Promise.allSettled(
+      wave.map((group) =>
+        processTranscriptEmbeddingGroup(
+          group,
+          mode,
+          loadManagerSource,
+          launchTimeoutMs,
+        ),
+      ),
+    )
+
+    for (const [waveIndex, result] of settled.entries()) {
+      const group = wave[waveIndex]!
+      if (result.status === "fulfilled") {
+        outcomes.push(...result.value.outcomes)
+        pendingConfirmations.push(...result.value.pendingConfirmations)
+        continue
+      }
+
+      const reason =
+        result.reason instanceof Error
+          ? result.reason.message
+          : String(result.reason)
+      const durationMs = Date.now() - batchStartedAt
+
+      for (const target of group.targets) {
+        const synthetic: BackfillOutcome = {
+          status: "failed",
+          target,
+          language: target.language,
+          reason,
+          durationMs,
+        }
+        logOutcome(synthetic)
+        outcomes.push(synthetic)
+      }
+    }
+  }
+
+  return { outcomes, pendingConfirmations, unprocessedGroups }
+}
+
+export async function stepConfirmTranscriptEmbeddingIngests(
+  pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+): Promise<TranscriptIngestConfirmationBatchResult> {
+  "use step"
+
+  const outcomes: BackfillOutcome[] = []
+  const pending: PendingTranscriptIngestConfirmation[] = []
+
+  for (const confirmation of pendingConfirmations) {
+    const result = await readTranscriptIngestConfirmation(
+      confirmation.target,
+      confirmation.language,
+      confirmation.mastraRunId,
+    )
+
+    if (!result) {
+      pending.push(confirmation)
+      continue
+    }
+
+    const outcome = toSucceeded(
+      confirmation.target,
+      confirmation.sourceKind,
+      result,
+      Date.now() - confirmation.startedAtEpochMs,
+    )
+    logOutcome(outcome)
+    outcomes.push(outcome)
+  }
+
+  return { outcomes, pendingConfirmations: pending }
+}
+
+export async function stepFailPendingTranscriptEmbeddingIngests(
+  pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
 ): Promise<BackfillOutcome[]> {
   "use step"
 
-  const limit = pLimit(concurrency)
-  const batchStartedAt = Date.now()
-
-  const settled = await Promise.allSettled(
-    groups.map((group) =>
-      limit(() => processTranscriptEmbeddingGroup(group, mode)),
-    ),
-  )
-
-  return settled.flatMap((result, i) => {
-    const group = groups[i]!
-    if (result.status === "fulfilled") return result.value
-
-    const reason =
-      result.reason instanceof Error
-        ? result.reason.message
-        : String(result.reason)
-    const durationMs = Date.now() - batchStartedAt
-
-    return group.targets.map((target) => {
-      const synthetic: BackfillOutcome = {
-        status: "failed",
-        target,
-        language: target.language,
-        reason,
-        durationMs,
-      }
-      logOutcome(synthetic)
-      return synthetic
-    })
+  return pendingConfirmations.map((confirmation) => {
+    const outcome: BackfillOutcome = {
+      status: "failed",
+      target: confirmation.target,
+      language: confirmation.language,
+      reason: "network_error",
+      durationMs: Date.now() - confirmation.startedAtEpochMs,
+    }
+    logOutcome(outcome)
+    return outcome
   })
 }

--- a/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
+++ b/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
@@ -22,10 +22,38 @@ import type {
   TranscriptEmbeddingSourceGap,
 } from "../transcriptEmbeddingBackfill"
 
+const TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS = 20 * 60 * 1_000
+const TIMED_OUT_LAUNCH_CONFIRM_POLL_MS = 5_000
+
 type ManagerSourceLoadState =
   | { status: "not-attempted" }
   | { status: "resolved"; artifact: TranscriptSourceArtifact }
   | { status: "failed"; reason: string; missing: boolean }
+
+type TranscriptIngestConfirmation = {
+  chunks: number
+  totalTokens: number
+  model: string
+  provider: string
+  dimensions: number
+  mastraRunId: string
+  sourceContentHash: string
+}
+
+type TranscriptIngestConfirmationRow = {
+  total_chunks: number | bigint
+  total_tokens: number | bigint
+  model: string
+  dimensions: number
+  embedding_provider: string | null
+  source_content_hash: string | null
+  healthy_chunks: number | bigint
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 function managerTranscriptSourceFromArtifact(
   target: BackfillTarget,
@@ -81,7 +109,9 @@ function sourceGapForMissingManager(
 function toSucceeded(
   target: BackfillTarget,
   sourceKind: ResolvedTranscriptEmbeddingSource["sourceKind"],
-  result: Extract<MastraTranscriptEmbeddingLaunchResult, { ok: true }>,
+  result:
+    | Extract<MastraTranscriptEmbeddingLaunchResult, { ok: true }>
+    | TranscriptIngestConfirmation,
   durationMs: number,
 ): BackfillOutcome {
   return {
@@ -90,7 +120,8 @@ function toSucceeded(
     language: target.language,
     sourceKind,
     chunksIndexed: result.chunks,
-    embeddingsWritten: result.status === "unchanged" ? 0 : result.chunks,
+    embeddingsWritten:
+      "status" in result && result.status === "unchanged" ? 0 : result.chunks,
     chunksPruned: 0,
     durationMs,
   }
@@ -156,6 +187,69 @@ function logOutcome(outcome: BackfillOutcome): void {
   }
 }
 
+async function readTranscriptIngestConfirmation(
+  target: BackfillTarget,
+  language: string,
+  mastraRunId: string,
+): Promise<TranscriptIngestConfirmation | null> {
+  const rows = await prisma.$queryRaw<TranscriptIngestConfirmationRow[]>`
+    SELECT
+      vt.total_chunks,
+      vt.total_tokens,
+      vt.model,
+      vt.dimensions,
+      vt.embedding_provider,
+      vt.source_content_hash,
+      COUNT(vtc.id) FILTER (WHERE vtc.embedding IS NOT NULL) AS healthy_chunks
+    FROM video_transcript vt
+    LEFT JOIN video_transcript_chunk vtc
+      ON vtc.transcript_id = vt.id
+    WHERE vt.video_edition_id = ${target.videoEditionId}
+      AND vt.language = ${language}
+      AND vt.mastra_run_id = ${mastraRunId}
+    GROUP BY vt.id
+    LIMIT 1
+  `
+  const row = rows[0]
+  if (!row) return null
+
+  const chunks = Number(row.total_chunks)
+  const healthyChunks = Number(row.healthy_chunks)
+  if (!Number.isFinite(chunks) || chunks <= 0 || healthyChunks !== chunks) {
+    return null
+  }
+
+  return {
+    chunks,
+    totalTokens: Number(row.total_tokens),
+    model: row.model,
+    provider: row.embedding_provider ?? "unknown",
+    dimensions: Number(row.dimensions),
+    mastraRunId,
+    sourceContentHash: row.source_content_hash ?? "",
+  }
+}
+
+async function waitForTimedOutLaunchIngest(
+  target: BackfillTarget,
+  language: string,
+  mastraRunId: string,
+): Promise<TranscriptIngestConfirmation | null> {
+  const deadline = Date.now() + TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS
+
+  while (Date.now() <= deadline) {
+    const confirmation = await readTranscriptIngestConfirmation(
+      target,
+      language,
+      mastraRunId,
+    )
+    if (confirmation) return confirmation
+    await sleep(TIMED_OUT_LAUNCH_CONFIRM_POLL_MS)
+  }
+
+  return null
+}
+
 async function launchTranscriptEmbedding(
   target: BackfillTarget,
   transcriptSource: ResolvedTranscriptEmbeddingSource,
@@ -176,6 +270,22 @@ async function launchTranscriptEmbedding(
       mode,
     })
     if (!result.ok) {
+      if (result.reason === "network_error" && result.mastraRunId) {
+        const confirmation = await waitForTimedOutLaunchIngest(
+          target,
+          target.language,
+          result.mastraRunId,
+        )
+        if (confirmation) {
+          return toSucceeded(
+            target,
+            transcriptSource.sourceKind,
+            confirmation,
+            Date.now() - startedAt,
+          )
+        }
+      }
+
       return {
         status: "failed",
         target,

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
@@ -78,8 +78,11 @@ const { ManagerArtifactError, readTranscriptSourceArtifact } =
   await import("@/services/manager-artifacts.service")
 const { launchMastraTranscriptEmbedding } =
   await import("@/services/mastra-transcript-embedding-client")
-const { runTranscriptEmbeddingBackfill, _internals } =
-  await import("./transcriptEmbeddingBackfill")
+const {
+  DEFAULT_TRANSCRIPT_EMBEDDING_CONFIRMATION_BATCH_LIMIT,
+  runTranscriptEmbeddingBackfill,
+  _internals,
+} = await import("./transcriptEmbeddingBackfill")
 
 type PrismaStub = { $queryRaw: ReturnType<typeof vi.fn> }
 
@@ -127,6 +130,69 @@ function target(
     hasSubtitle: false,
     hasDub: false,
     isPrimaryLanguage: true,
+  }
+}
+
+function pendingConfirmation(
+  language: string,
+  overrides: Partial<{
+    videoId: string
+    editionId: string
+    coreId: string
+    cmsVideoId: number
+    sourceKind: "manager-transcript" | "subtitle"
+    mastraRunId: string
+    startedAtEpochMs: number
+  }> = {},
+) {
+  return {
+    status: "pending-ingest-confirmation" as const,
+    target: target(
+      overrides.videoId ?? `v-${language}`,
+      overrides.editionId ?? `e-${language}`,
+      overrides.coreId ?? "core-a",
+      overrides.cmsVideoId ?? 1,
+      language,
+    ),
+    language,
+    sourceKind: overrides.sourceKind ?? ("manager-transcript" as const),
+    mastraRunId: overrides.mastraRunId ?? `run-${language}`,
+    startedAtEpochMs: overrides.startedAtEpochMs ?? Date.now(),
+  }
+}
+
+function transcriptHealthRow(
+  overrides: Partial<{
+    videoEditionId: string
+    language: string
+    totalChunks: number
+    model: string
+    dimensions: number
+    embeddingProvider: string | null
+    generationMode: string | null
+    sourceKind: string | null
+    chunksWithEmbedding: number
+    chunksWithEmbeddingInputText: number
+  }> = {},
+) {
+  return {
+    video_edition_id: overrides.videoEditionId ?? "e-a",
+    language: overrides.language ?? "en",
+    total_chunks: overrides.totalChunks ?? 2,
+    model: overrides.model ?? "embeddings",
+    dimensions: overrides.dimensions ?? 1536,
+    embedding_provider: Object.hasOwn(overrides, "embeddingProvider")
+      ? (overrides.embeddingProvider ?? null)
+      : "jesus-film-ai-gateway",
+    generation_mode: Object.hasOwn(overrides, "generationMode")
+      ? (overrides.generationMode ?? null)
+      : "model-upgrade",
+    source_kind: Object.hasOwn(overrides, "sourceKind")
+      ? (overrides.sourceKind ?? null)
+      : "subtitle",
+    chunks_with_embedding: overrides.chunksWithEmbedding ?? 2,
+    chunks_with_embedding_input_text:
+      overrides.chunksWithEmbeddingInputText ?? 2,
   }
 }
 
@@ -323,6 +389,195 @@ Subtitle transcript text.
       expect(call[0].mode).toBe("force")
       expect(call[0].language).toBe("en")
     }
+  })
+
+  it("skips already healthy enriched transcript rows during model-upgrade resumes", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw
+      .mockResolvedValueOnce([row("v-a", "e-a", "core-a", "en")])
+      .mockResolvedValueOnce([transcriptHealthRow()])
+
+    const report = await runTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      mode: "model-upgrade",
+    })
+
+    expect(report.succeeded).toBe(0)
+    expect(report.skipped).toBe(1)
+    expect(report.failed).toBe(0)
+    expect(report.outcomes[0]).toMatchObject({
+      status: "skipped",
+      language: "en",
+      reason: "already_enriched_healthy",
+    })
+    expect(readTranscriptSourceArtifact).not.toHaveBeenCalled()
+    expect(launchMastraTranscriptEmbedding).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      label: "legacy transcript rows",
+      healthRows: [
+        transcriptHealthRow({
+          generationMode: null,
+          sourceKind: null,
+          chunksWithEmbeddingInputText: 0,
+        }),
+      ],
+    },
+    {
+      label: "incomplete chunk rows",
+      healthRows: [
+        transcriptHealthRow({
+          chunksWithEmbedding: 1,
+          chunksWithEmbeddingInputText: 1,
+        }),
+      ],
+    },
+    {
+      label: "rows missing embedding input text",
+      healthRows: [
+        transcriptHealthRow({
+          chunksWithEmbeddingInputText: 1,
+        }),
+      ],
+    },
+    {
+      label: "missing transcript rows",
+      healthRows: [],
+    },
+    {
+      label: "force-generated rows",
+      healthRows: [
+        transcriptHealthRow({
+          generationMode: "force",
+        }),
+      ],
+    },
+    {
+      label: "idempotent generation rows",
+      healthRows: [
+        transcriptHealthRow({
+          generationMode: "idempotent",
+        }),
+      ],
+    },
+    {
+      label: "rows with null source kind",
+      healthRows: [
+        transcriptHealthRow({
+          sourceKind: null,
+        }),
+      ],
+    },
+    {
+      label: "rows with empty source kind",
+      healthRows: [
+        transcriptHealthRow({
+          sourceKind: "",
+        }),
+      ],
+    },
+    {
+      label: "zero-chunk rows",
+      healthRows: [
+        transcriptHealthRow({
+          totalChunks: 0,
+          chunksWithEmbedding: 0,
+          chunksWithEmbeddingInputText: 0,
+        }),
+      ],
+    },
+    {
+      label: "rows with stale model stamps",
+      healthRows: [
+        transcriptHealthRow({
+          model: "openai/text-embedding-future-model",
+        }),
+      ],
+    },
+    {
+      label: "rows with stale providers",
+      healthRows: [
+        transcriptHealthRow({
+          embeddingProvider: "openai",
+        }),
+      ],
+    },
+    {
+      label: "rows with null providers",
+      healthRows: [
+        transcriptHealthRow({
+          embeddingProvider: null,
+        }),
+      ],
+    },
+    {
+      label: "rows with stale dimensions",
+      healthRows: [
+        transcriptHealthRow({
+          dimensions: 3072,
+        }),
+      ],
+    },
+  ])(
+    "keeps $label eligible in model-upgrade resumes",
+    async ({ healthRows }) => {
+      ;(prisma as unknown as PrismaStub).$queryRaw
+        .mockResolvedValueOnce([row("v-a", "e-a", "core-a", "en")])
+        .mockResolvedValueOnce(healthRows)
+
+      const report = await runTranscriptEmbeddingBackfill({
+        mappingS3Key: "admin-migrations/core-id-mapping.json",
+        mode: "model-upgrade",
+      })
+
+      expect(report.succeeded).toBe(1)
+      expect(report.skipped).toBe(0)
+      expect(report.failed).toBe(0)
+      expect(readTranscriptSourceArtifact).toHaveBeenCalledWith("1")
+      expect(launchMastraTranscriptEmbedding).toHaveBeenCalledTimes(1)
+      expect(
+        vi.mocked(launchMastraTranscriptEmbedding).mock.calls[0]?.[0].mode,
+      ).toBe("model-upgrade")
+    },
+  )
+
+  it("batches model-upgrade resume health checks per durable process step", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw
+      .mockResolvedValueOnce([
+        row("v-a", "e-a", "core-a", "en"),
+        row("v-b", "e-b", "core-b", "es"),
+        row("v-c", "e-c", "core-c", "fr"),
+      ])
+      .mockResolvedValueOnce([
+        transcriptHealthRow({
+          videoEditionId: "e-a",
+          language: "en",
+        }),
+        transcriptHealthRow({
+          videoEditionId: "e-b",
+          language: "es",
+        }),
+      ])
+
+    const report = await runTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+      mode: "model-upgrade",
+    })
+
+    expect(report.skipped).toBe(2)
+    expect(report.succeeded).toBe(1)
+    expect((prisma as unknown as PrismaStub).$queryRaw).toHaveBeenCalledTimes(2)
+    expect(launchMastraTranscriptEmbedding).toHaveBeenCalledTimes(1)
+    expect(
+      vi.mocked(launchMastraTranscriptEmbedding).mock.calls[0]?.[0],
+    ).toMatchObject({
+      target: {
+        videoEditionId: "e-c",
+      },
+      language: "fr",
+      mode: "model-upgrade",
+    })
   })
 
   it("skips every language in a group when transcript source is missing and emits missingArtifacts once", async () => {
@@ -522,6 +777,132 @@ Subtitle transcript text.
     expect(sleep).toHaveBeenCalledTimes(240)
   })
 
+  it("checks timed-out Mastra ingest confirmations in bounded rotating slices", async () => {
+    const pending = [
+      pendingConfirmation("en"),
+      pendingConfirmation("es"),
+      pendingConfirmation("fr"),
+    ]
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValue([])
+
+    const result = await _internals.confirmPendingTranscriptIngestsOnce(
+      pending,
+      2,
+    )
+
+    expect((prisma as unknown as PrismaStub).$queryRaw).toHaveBeenCalledTimes(2)
+    expect(result.checkedCount).toBe(2)
+    expect(result.outcomes).toEqual([])
+    expect(result.pendingConfirmations.map((item) => item.language)).toEqual([
+      "fr",
+      "en",
+      "es",
+    ])
+  })
+
+  it("removes confirmed Mastra ingests from the bounded pending slice", async () => {
+    const pending = [
+      pendingConfirmation("en"),
+      pendingConfirmation("es"),
+      pendingConfirmation("fr"),
+    ]
+    ;(prisma as unknown as PrismaStub).$queryRaw
+      .mockResolvedValueOnce([
+        {
+          total_chunks: 2,
+          total_tokens: 24,
+          model: "embeddings",
+          dimensions: 1536,
+          embedding_provider: "jesus-film-ai-gateway",
+          source_content_hash: "sha256:confirmed",
+          healthy_chunks: 2,
+        },
+      ])
+      .mockResolvedValueOnce([])
+
+    const result = await _internals.confirmPendingTranscriptIngestsOnce(
+      pending,
+      2,
+    )
+
+    expect(result.checkedCount).toBe(2)
+    expect(result.outcomes).toHaveLength(1)
+    expect(result.outcomes[0]).toMatchObject({
+      status: "succeeded",
+      language: "en",
+      chunksIndexed: 2,
+    })
+    expect(result.pendingConfirmations.map((item) => item.language)).toEqual([
+      "fr",
+      "es",
+    ])
+  })
+
+  it("fails final pending confirmations through bounded batches", async () => {
+    const pending = Array.from({ length: 3 }, (_, i) =>
+      pendingConfirmation(`l${i}`, {
+        videoId: `v-${i}`,
+        editionId: `e-${i}`,
+        mastraRunId: `run-${i}`,
+      }),
+    )
+
+    const outcomes =
+      await _internals.failPendingTranscriptEmbeddingIngestsInBatches(
+        pending,
+        2,
+      )
+
+    expect(outcomes).toHaveLength(3)
+    expect(outcomes.map((outcome) => outcome.status)).toEqual([
+      "failed",
+      "failed",
+      "failed",
+    ])
+    expect(outcomes.map((outcome) => outcome.language)).toEqual([
+      "l0",
+      "l1",
+      "l2",
+    ])
+    expect(
+      _internals
+        .batchPendingConfirmations(pending, 2)
+        .map((batch) => batch.length),
+    ).toEqual([2, 1])
+  })
+
+  it("budgets final confirmation slices by full poll cycles", () => {
+    expect(_internals.confirmationSliceBudget(3, 2, 240)).toBe(482)
+    expect(_internals.confirmationSliceBudget(25, 25, 240)).toBe(241)
+    expect(_internals.confirmationSliceBudget(26, 25, 240)).toBe(482)
+  })
+
+  it("checks multiple final confirmation slices before the first sleep", async () => {
+    const pending = [
+      pendingConfirmation("en"),
+      pendingConfirmation("es"),
+      pendingConfirmation("fr"),
+    ]
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValue([
+      {
+        total_chunks: 2,
+        total_tokens: 24,
+        model: "embeddings",
+        dimensions: 1536,
+        embedding_provider: "jesus-film-ai-gateway",
+        source_content_hash: "sha256:confirmed",
+        healthy_chunks: 2,
+      },
+    ])
+
+    const outcomes =
+      await _internals.waitForPendingTranscriptIngestConfirmations(pending, 2)
+
+    expect(outcomes).toHaveLength(3)
+    expect((prisma as unknown as PrismaStub).$queryRaw).toHaveBeenCalledTimes(3)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
   it("reports target-bounded batch sizing through the workflow dispatch path", async () => {
     ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce(
       Array.from({ length: 51 }, (_, i) =>
@@ -546,6 +927,8 @@ Subtitle transcript text.
         groupCount: 51,
         groupBatchCount: 2,
         stepTargetLimit: 50,
+        confirmationBatchLimit:
+          DEFAULT_TRANSCRIPT_EMBEDDING_CONFIRMATION_BATCH_LIMIT,
         concurrency: 2,
       })
     } finally {

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
@@ -436,6 +436,41 @@ Subtitle transcript text.
     })
   })
 
+  it("confirms timed-out Mastra launches through the later Admin ingest row", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw
+      .mockResolvedValueOnce([row("v-a", "e-a", "core-a", "en")])
+      .mockResolvedValueOnce([
+        {
+          total_chunks: 2,
+          total_tokens: 24,
+          model: "embeddings",
+          dimensions: 1536,
+          embedding_provider: "jesus-film-ai-gateway",
+          source_content_hash: "sha256:confirmed",
+          healthy_chunks: 2,
+        },
+      ])
+    vi.mocked(launchMastraTranscriptEmbedding).mockResolvedValueOnce({
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+      mastraRunId: "run-timeout-continued",
+    })
+
+    const report = await runTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.succeeded).toBe(1)
+    expect(report.failed).toBe(0)
+    expect(report.outcomes[0]).toMatchObject({
+      status: "succeeded",
+      language: "en",
+      chunksIndexed: 2,
+      embeddingsWritten: 2,
+    })
+  })
+
   it("uses one external groups step so production workflow steps are not dynamically repeated", async () => {
     const source = await readFile(
       new URL("./transcriptEmbeddingBackfill.ts", import.meta.url),

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
@@ -7,6 +7,16 @@ vi.mock("@/config/env", () => ({
   },
 }))
 
+vi.mock("workflow", () => ({
+  getWorkflowMetadata: vi.fn(() => ({
+    workflowName: "test-workflow",
+    workflowRunId: "test-run",
+    workflowStartedAt: new Date("2026-06-20T00:00:00.000Z"),
+    url: "http://test.local/workflow",
+  })),
+  sleep: vi.fn(async () => undefined),
+}))
+
 vi.mock("@/db/client", () => {
   const mock = {
     $queryRaw: vi.fn(async () => []),
@@ -63,6 +73,7 @@ vi.mock("@/services/mastra-transcript-embedding-client", () => ({
 
 const { prisma } = await import("@/db/client")
 const { env } = await import("@/config/env")
+const { getWorkflowMetadata, sleep } = await import("workflow")
 const { ManagerArtifactError, readTranscriptSourceArtifact } =
   await import("@/services/manager-artifacts.service")
 const { launchMastraTranscriptEmbedding } =
@@ -136,6 +147,15 @@ describe("runTranscriptEmbeddingBackfill", () => {
       }
     ).videoSubtitle.findMany.mockResolvedValue([])
     vi.unstubAllGlobals()
+    vi.mocked(getWorkflowMetadata).mockClear()
+    vi.mocked(getWorkflowMetadata).mockReturnValue({
+      workflowName: "test-workflow",
+      workflowRunId: "test-run",
+      workflowStartedAt: new Date("2026-06-20T00:00:00.000Z"),
+      url: "http://test.local/workflow",
+    })
+    vi.mocked(sleep).mockClear()
+    vi.mocked(sleep).mockResolvedValue(undefined)
     vi.mocked(readTranscriptSourceArtifact).mockReset()
     vi.mocked(readTranscriptSourceArtifact).mockResolvedValue(STUB_TRANSCRIPT)
     vi.mocked(launchMastraTranscriptEmbedding).mockReset()
@@ -166,25 +186,28 @@ describe("runTranscriptEmbeddingBackfill", () => {
     expect(report.succeeded).toBe(2)
     expect(report.failed).toBe(0)
     expect(readTranscriptSourceArtifact).toHaveBeenCalledTimes(2)
-    expect(launchMastraTranscriptEmbedding).toHaveBeenCalledWith({
-      target: {
-        videoId: "v-a",
-        videoEditionId: "e-a",
-        coreId: "core-a",
+    expect(launchMastraTranscriptEmbedding).toHaveBeenCalledWith(
+      {
+        target: {
+          videoId: "v-a",
+          videoEditionId: "e-a",
+          coreId: "core-a",
+        },
+        language: "en",
+        cmsVideoId: 1,
+        transcript: {
+          text: STUB_TRANSCRIPT.text,
+          segments: STUB_TRANSCRIPT.segments,
+          artifactKey: "1/transcript.json",
+          kind: "manager-transcript",
+          languageId: "lang-en",
+          languageSlug: "en",
+          provider: STUB_TRANSCRIPT.resolvedProvider,
+        },
+        mode: "idempotent",
       },
-      language: "en",
-      cmsVideoId: 1,
-      transcript: {
-        text: STUB_TRANSCRIPT.text,
-        segments: STUB_TRANSCRIPT.segments,
-        artifactKey: "1/transcript.json",
-        kind: "manager-transcript",
-        languageId: "lang-en",
-        languageSlug: "en",
-        provider: STUB_TRANSCRIPT.resolvedProvider,
-      },
-      mode: "idempotent",
-    })
+      { timeoutMs: 120_000 },
+    )
   })
 
   it("uses exact Admin subtitle timed text before Manager transcript fallback", async () => {
@@ -233,32 +256,35 @@ Subtitle transcript text.
       sourceKind: "subtitle",
     })
     expect(readTranscriptSourceArtifact).not.toHaveBeenCalled()
-    expect(launchMastraTranscriptEmbedding).toHaveBeenCalledWith({
-      target: {
-        videoId: "v-a",
-        videoEditionId: "e-a",
-        coreId: "core-a",
+    expect(launchMastraTranscriptEmbedding).toHaveBeenCalledWith(
+      {
+        target: {
+          videoId: "v-a",
+          videoEditionId: "e-a",
+          coreId: "core-a",
+        },
+        language: "en",
+        cmsVideoId: 1,
+        transcript: {
+          text: "Subtitle transcript text.",
+          segments: [{ start: 0, end: 2, text: "Subtitle transcript text." }],
+          artifactKey: "admin-video-subtitle/sub-1.vtt",
+          kind: "subtitle",
+          languageId: "lang-en",
+          languageSlug: "english",
+          subtitleId: "sub-1",
+          format: "vtt",
+          url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
+          provider: "admin-subtitle",
+          generatedAt: "2026-06-01T00:00:00.000Z",
+        },
+        mode: "idempotent",
       },
-      language: "en",
-      cmsVideoId: 1,
-      transcript: {
-        text: "Subtitle transcript text.",
-        segments: [{ start: 0, end: 2, text: "Subtitle transcript text." }],
-        artifactKey: "admin-video-subtitle/sub-1.vtt",
-        kind: "subtitle",
-        languageId: "lang-en",
-        languageSlug: "english",
-        subtitleId: "sub-1",
-        format: "vtt",
-        url: "https://api-media-core.jesusfilm.org/subtitles/en.vtt",
-        provider: "admin-subtitle",
-        generatedAt: "2026-06-01T00:00:00.000Z",
-      },
-      mode: "idempotent",
-    })
+      { timeoutMs: 120_000 },
+    )
   })
 
-  it("loads transcript source once per (video, edition) group across languages", async () => {
+  it("shares Manager transcript source loads inside a target-bounded step batch", async () => {
     ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce([
       row("v-a", "e-a", "core-a", "en"),
       row("v-a", "e-a", "core-a", "es"),
@@ -304,7 +330,7 @@ Subtitle transcript text.
       row("v-a", "e-a", "core-a", "en"),
       row("v-a", "e-a", "core-a", "es"),
     ])
-    vi.mocked(readTranscriptSourceArtifact).mockRejectedValueOnce(
+    vi.mocked(readTranscriptSourceArtifact).mockRejectedValue(
       new ManagerArtifactError(
         "artifact_missing",
         "transcript artifact not found for assetId=1",
@@ -471,13 +497,73 @@ Subtitle transcript text.
     })
   })
 
-  it("uses one external groups step so production workflow steps are not dynamically repeated", async () => {
+  it("fails timed-out Mastra launches when no later Admin ingest row appears", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw
+      .mockResolvedValueOnce([row("v-a", "e-a", "core-a", "en")])
+      .mockResolvedValue([])
+    vi.mocked(launchMastraTranscriptEmbedding).mockResolvedValueOnce({
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+      mastraRunId: "run-timeout-never-ingested",
+    })
+
+    const report = await runTranscriptEmbeddingBackfill({
+      mappingS3Key: "admin-migrations/core-id-mapping.json",
+    })
+
+    expect(report.succeeded).toBe(0)
+    expect(report.failed).toBe(1)
+    expect(report.outcomes[0]).toMatchObject({
+      status: "failed",
+      language: "en",
+      reason: "network_error",
+    })
+    expect(sleep).toHaveBeenCalledTimes(240)
+  })
+
+  it("reports target-bounded batch sizing through the workflow dispatch path", async () => {
+    ;(prisma as unknown as PrismaStub).$queryRaw.mockResolvedValueOnce(
+      Array.from({ length: 51 }, (_, i) =>
+        row(`v-${i}`, `e-${i}`, "core-a", `l${i}`),
+      ),
+    )
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+
+    try {
+      const report = await runTranscriptEmbeddingBackfill({
+        mappingS3Key: "admin-migrations/core-id-mapping.json",
+      })
+
+      const startMessage = logSpy.mock.calls
+        .map(([message]) => String(message))
+        .find((message) => message.includes('"event":"start"'))
+
+      expect(report.totalTargets).toBe(51)
+      expect(report.succeeded).toBe(51)
+      expect(JSON.parse(startMessage ?? "{}")).toMatchObject({
+        totalTargets: 51,
+        groupCount: 51,
+        groupBatchCount: 2,
+        stepTargetLimit: 50,
+        concurrency: 2,
+      })
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+
+  it("uses sequential target-bounded group batch steps so production workflow steps are not parallel-repeated", async () => {
     const source = await readFile(
       new URL("./transcriptEmbeddingBackfill.ts", import.meta.url),
       "utf8",
     )
 
-    expect(source).toMatch(/stepProcessTranscriptEmbeddingGroups\(\s*groups,/)
+    expect(source).toMatch(/batchGroupsByTargetLimit\(\s*groups,/)
+    expect(source).toMatch(/for \(const groupBatch of groupBatches\)/)
+    expect(source).toMatch(
+      /stepProcessTranscriptEmbeddingGroups\(\s*remainingBatch,/,
+    )
     expect(source).not.toMatch(/\bstepProcessTranscriptEmbeddingGroup\(/)
     expect(source).not.toMatch(/Promise\.allSettled\(\s*groups\.map/)
     expect(source).not.toMatch(/\basync function processGroup\b/)
@@ -582,5 +668,36 @@ describe("groupTargetsByVideoEdition", () => {
       "es",
     ])
     expect(groups[1]?.targets.map((target) => target.language)).toEqual(["en"])
+  })
+
+  it("batches groups by target count and shards oversized multilingual groups into single-target entries", () => {
+    const groups = _internals.groupTargetsByVideoEdition([
+      target("v-a", "e-a", "core-a", 1, "en"),
+      target("v-a", "e-a", "core-a", 1, "es"),
+      target("v-a", "e-a", "core-a", 1, "fr"),
+      target("v-a", "e-a", "core-a", 1, "af"),
+      target("v-a", "e-a", "core-a", 1, "am"),
+      target("v-a", "e-a", "core-a", 1, "ar"),
+      target("v-b", "e-b", "core-b", 2, "en"),
+    ])
+
+    const batches = _internals.batchGroupsByTargetLimit(groups, 5)
+
+    expect(batches).toHaveLength(2)
+    expect(batches[0]?.map((group) => group.targets.length)).toEqual([
+      1, 1, 1, 1, 1,
+    ])
+    expect(
+      batches[0]?.flatMap((group) =>
+        group.targets.map((target) => target.language),
+      ),
+    ).toEqual(["en", "es", "fr", "af", "am"])
+    expect(batches[1]?.map((group) => group.targets.length)).toEqual([1, 1])
+    expect(
+      batches[1]?.flatMap((group) =>
+        group.targets.map((target) => target.language),
+      ),
+    ).toEqual(["ar", "en"])
+    expect(batches[1]?.[1]?.videoEditionId).toBe("e-b")
   })
 })

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
@@ -79,6 +79,7 @@ export const DEFAULT_TRANSCRIPT_EMBEDDING_CONCURRENCY = 5
 export const DEFAULT_TRANSCRIPT_EMBEDDING_STEP_TARGET_LIMIT = 50
 export const DEFAULT_TRANSCRIPT_EMBEDDING_STEP_MAX_DURATION_MS = 220_000
 export const DEFAULT_TRANSCRIPT_EMBEDDING_LAUNCH_TIMEOUT_MS = 120_000
+export const DEFAULT_TRANSCRIPT_EMBEDDING_CONFIRMATION_BATCH_LIMIT = 25
 export const TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS = 20 * 60 * 1_000
 export const TIMED_OUT_LAUNCH_CONFIRM_POLL_MS = 5_000
 
@@ -87,6 +88,7 @@ type TranscriptEmbeddingRuntimeConfig = {
   stepTargetLimit: number
   stepMaxDurationMs: number
   launchTimeoutMs: number
+  confirmationBatchLimit: number
 }
 
 function transcriptEmbeddingConcurrency(): number {
@@ -106,6 +108,8 @@ function transcriptEmbeddingRuntimeConfig(): TranscriptEmbeddingRuntimeConfig {
     stepTargetLimit: DEFAULT_TRANSCRIPT_EMBEDDING_STEP_TARGET_LIMIT,
     stepMaxDurationMs: DEFAULT_TRANSCRIPT_EMBEDDING_STEP_MAX_DURATION_MS,
     launchTimeoutMs: DEFAULT_TRANSCRIPT_EMBEDDING_LAUNCH_TIMEOUT_MS,
+    confirmationBatchLimit:
+      DEFAULT_TRANSCRIPT_EMBEDDING_CONFIRMATION_BATCH_LIMIT,
   }
 }
 
@@ -304,6 +308,7 @@ export async function runTranscriptEmbeddingBackfill(
       stepTargetLimit: runtimeConfig.stepTargetLimit,
       stepMaxDurationMs: runtimeConfig.stepMaxDurationMs,
       launchTimeoutMs: runtimeConfig.launchTimeoutMs,
+      confirmationBatchLimit: runtimeConfig.confirmationBatchLimit,
       concurrency: runtimeConfig.concurrency,
       languageFilter:
         input.languages && input.languages.length > 0 ? input.languages : null,
@@ -325,8 +330,10 @@ export async function runTranscriptEmbeddingBackfill(
       outcomes.push(...batchResult.outcomes)
       pendingConfirmations.push(...batchResult.pendingConfirmations)
 
-      const confirmation =
-        await confirmPendingTranscriptIngestsOnce(pendingConfirmations)
+      const confirmation = await confirmPendingTranscriptIngestsOnce(
+        pendingConfirmations,
+        runtimeConfig.confirmationBatchLimit,
+      )
       outcomes.push(...confirmation.outcomes)
       pendingConfirmations = confirmation.pendingConfirmations
       remainingBatch = batchResult.unprocessedGroups
@@ -335,6 +342,7 @@ export async function runTranscriptEmbeddingBackfill(
   outcomes.push(
     ...(await waitForPendingTranscriptIngestConfirmations(
       pendingConfirmations,
+      runtimeConfig.confirmationBatchLimit,
     )),
   )
 
@@ -359,35 +367,132 @@ async function stepResolveTranscriptEmbeddingRuntimeConfig(): Promise<Transcript
 
 async function confirmPendingTranscriptIngestsOnce(
   pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+  batchLimit: number,
 ) {
   if (pendingConfirmations.length === 0) {
-    return { outcomes: [], pendingConfirmations: [] }
+    return { outcomes: [], pendingConfirmations: [], checkedCount: 0 }
   }
-  return stepConfirmTranscriptEmbeddingIngests(pendingConfirmations)
+  const { batch, rest } = splitPendingConfirmations(
+    pendingConfirmations,
+    batchLimit,
+  )
+  const result = await stepConfirmTranscriptEmbeddingIngests(batch)
+  return {
+    outcomes: result.outcomes,
+    pendingConfirmations: [...rest, ...result.pendingConfirmations],
+    checkedCount: batch.length,
+  }
 }
 
 async function waitForPendingTranscriptIngestConfirmations(
   pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+  batchLimit: number,
 ): Promise<BackfillOutcome[]> {
   let pending = Array.from(pendingConfirmations)
   const outcomes: BackfillOutcome[] = []
   const maxPolls = Math.ceil(
     TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS / TIMED_OUT_LAUNCH_CONFIRM_POLL_MS,
   )
+  const maxConfirmationSlices = confirmationSliceBudget(
+    pending.length,
+    batchLimit,
+    maxPolls,
+  )
+  let uncheckedThisPollCycle = pending.length
 
-  for (let poll = 0; pending.length > 0 && poll <= maxPolls; poll += 1) {
-    const confirmation = await stepConfirmTranscriptEmbeddingIngests(pending)
+  for (
+    let poll = 0, confirmationSlices = 0;
+    pending.length > 0 && confirmationSlices < maxConfirmationSlices;
+  ) {
+    const confirmation = await confirmPendingTranscriptIngestsOnce(
+      pending,
+      batchLimit,
+    )
+    confirmationSlices += 1
     outcomes.push(...confirmation.outcomes)
     pending = confirmation.pendingConfirmations
+    uncheckedThisPollCycle -= confirmation.checkedCount
 
-    if (pending.length === 0 || poll === maxPolls) break
+    if (pending.length === 0) break
+    if (uncheckedThisPollCycle > 0) continue
+
+    poll += 1
+    if (poll > maxPolls) break
     await sleepForPendingConfirmation(TIMED_OUT_LAUNCH_CONFIRM_POLL_MS)
+    uncheckedThisPollCycle = pending.length
   }
 
   if (pending.length === 0) return outcomes
 
-  outcomes.push(...(await stepFailPendingTranscriptEmbeddingIngests(pending)))
+  outcomes.push(
+    ...(await failPendingTranscriptEmbeddingIngestsInBatches(
+      pending,
+      batchLimit,
+    )),
+  )
   return outcomes
+}
+
+async function failPendingTranscriptEmbeddingIngestsInBatches(
+  pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+  batchLimit: number,
+): Promise<BackfillOutcome[]> {
+  const outcomes: BackfillOutcome[] = []
+  for (const batch of batchPendingConfirmations(
+    pendingConfirmations,
+    batchLimit,
+  )) {
+    outcomes.push(...(await stepFailPendingTranscriptEmbeddingIngests(batch)))
+  }
+  return outcomes
+}
+
+function batchPendingConfirmations(
+  pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+  batchLimit: number,
+): PendingTranscriptIngestConfirmation[][] {
+  const batches: PendingTranscriptIngestConfirmation[][] = []
+  let pending = Array.from(pendingConfirmations)
+  while (pending.length > 0) {
+    const { batch, rest } = splitPendingConfirmations(pending, batchLimit)
+    batches.push(batch)
+    pending = rest
+  }
+  return batches
+}
+
+function confirmationSliceBudget(
+  pendingCount: number,
+  batchLimit: number,
+  maxPolls: number,
+): number {
+  const safePendingCount =
+    Number.isInteger(pendingCount) && pendingCount > 0 ? pendingCount : 0
+  if (safePendingCount === 0) return 0
+  const safeBatchLimit = safePendingConfirmationBatchLimit(batchLimit)
+  const slicesPerPollCycle = Math.ceil(safePendingCount / safeBatchLimit)
+  return slicesPerPollCycle * (maxPolls + 1)
+}
+
+function splitPendingConfirmations(
+  pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+  batchLimit: number,
+): {
+  batch: PendingTranscriptIngestConfirmation[]
+  rest: PendingTranscriptIngestConfirmation[]
+} {
+  const safeLimit = safePendingConfirmationBatchLimit(batchLimit)
+
+  return {
+    batch: pendingConfirmations.slice(0, safeLimit),
+    rest: pendingConfirmations.slice(safeLimit),
+  }
+}
+
+function safePendingConfirmationBatchLimit(batchLimit: number): number {
+  return Number.isInteger(batchLimit) && batchLimit > 0
+    ? batchLimit
+    : DEFAULT_TRANSCRIPT_EMBEDDING_CONFIRMATION_BATCH_LIMIT
 }
 
 async function sleepForPendingConfirmation(ms: number): Promise<void> {
@@ -706,4 +811,10 @@ export const _internals = {
   stepReport,
   groupTargetsByVideoEdition,
   batchGroupsByTargetLimit,
+  batchPendingConfirmations,
+  confirmationSliceBudget,
+  splitPendingConfirmations,
+  confirmPendingTranscriptIngestsOnce,
+  waitForPendingTranscriptIngestConfirmations,
+  failPendingTranscriptEmbeddingIngestsInBatches,
 }

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
@@ -1,5 +1,6 @@
 // Transcript embedding backfill — durable useworkflow job that launches
-// Mastra from manager's transcript.json source artifacts.
+// Mastra from subtitle timed text first, then manager transcript.json
+// fallback artifacts.
 //
 // Flow (Stage 2 — feat-116):
 //   1. stepLoadMapping              — load coreId → cms video id snapshot
@@ -11,21 +12,21 @@
 //                                     dub languages
 //   3. groupTargetsByVideoEdition   — flat targets → groups keyed by
 //                                     (videoId, videoEditionId). The
-//                                     transcript source artifact is shared
-//                                     across every language in a group,
-//                                     so fetching it once per group
-//                                     collapses S3 reads from N×L to N.
-//   4. stepProcessTranscriptEmbeddingGroups — one durable step that:
-//        4a. Load transcript source artifact ONCE for the group.
+//                                     transcript source gaps still aggregate
+//                                     at the video-edition boundary.
+//   4. stepProcessTranscriptEmbeddingGroups — target-bounded durable batches:
+//        4a. Load transcript source artifact through a step-local cache.
 //        4b. For each language in the group, call Mastra with Admin
 //            target identifiers so Mastra embeds and Admin ingest stores.
-//   5. stepReport                   — aggregate per-target outcomes.
+//   5. stepConfirmTranscriptEmbeddingIngests — short polling steps for Mastra
+//                                     runs that outlive the launch request.
+//   6. stepReport                   — aggregate per-target outcomes.
 //
 // feat-132 boundary: Admin never imports manager-generated transcript
 // vectors. Admin reads transcript source only; Mastra owns chunking and
 // provider calls; Admin ingest owns vector storage.
 //
-// Per-target errors are caught inside the per-language step so one bad
+// Per-target errors are caught inside the per-language helper so one bad
 // artifact doesn't halt the backfill. A group-level artifact-load
 // failure cascades to per-language outcomes for every language in the
 // group with the right classification (artifact_missing → skipped;
@@ -34,16 +35,16 @@
 // (transcriptId, chunkIndex) for chunks), so the workflow is safe to
 // re-run.
 //
-// pLimit boundary moved up one level relative to Stage 1: the cap now
-// constrains concurrent (video, edition) GROUPS, not concurrent flat
-// targets. Inside a group, per-language work runs sequentially so the
-// loaded artifact stays scoped to one stack frame.
+// Concurrency boundary moved up one level relative to Stage 1, then
+// feat-192's production hotfix added target-bounded step batches so the full
+// corpus is not held inside one Graphile task.
 //
 // Language model: data-derived at enumeration time, not a hardcoded
 // list. Earlier prototype iterations hardcoded a `DEFAULT_LOCALES =
 // ['en', 'es', 'fr']` constant + an `en` fallback; both dropped once
 // the enumeration became data-derived.
 
+import { getWorkflowMetadata, sleep } from "workflow"
 import { prisma } from "@/db/client"
 import { env } from "@/config/env"
 import {
@@ -55,7 +56,12 @@ import type {
   ResolvedTranscriptEmbeddingSource,
   TranscriptSourceGap,
 } from "@/services/transcript-source-resolver.service"
-import { stepProcessTranscriptEmbeddingGroups } from "./_steps/process-transcript-embedding-group"
+import {
+  stepConfirmTranscriptEmbeddingIngests,
+  stepFailPendingTranscriptEmbeddingIngests,
+  stepProcessTranscriptEmbeddingGroups,
+  type PendingTranscriptIngestConfirmation,
+} from "./_steps/process-transcript-embedding-group"
 
 /**
  * Default per-group concurrency for the Mastra transcript-embedding
@@ -70,6 +76,18 @@ import { stepProcessTranscriptEmbeddingGroups } from "./_steps/process-transcrip
  * provider work to Mastra.
  */
 export const DEFAULT_TRANSCRIPT_EMBEDDING_CONCURRENCY = 5
+export const DEFAULT_TRANSCRIPT_EMBEDDING_STEP_TARGET_LIMIT = 50
+export const DEFAULT_TRANSCRIPT_EMBEDDING_STEP_MAX_DURATION_MS = 220_000
+export const DEFAULT_TRANSCRIPT_EMBEDDING_LAUNCH_TIMEOUT_MS = 120_000
+export const TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS = 20 * 60 * 1_000
+export const TIMED_OUT_LAUNCH_CONFIRM_POLL_MS = 5_000
+
+type TranscriptEmbeddingRuntimeConfig = {
+  concurrency: number
+  stepTargetLimit: number
+  stepMaxDurationMs: number
+  launchTimeoutMs: number
+}
 
 function transcriptEmbeddingConcurrency(): number {
   const value =
@@ -80,6 +98,15 @@ function transcriptEmbeddingConcurrency(): number {
   return Number.isInteger(concurrency) && concurrency > 0
     ? concurrency
     : DEFAULT_TRANSCRIPT_EMBEDDING_CONCURRENCY
+}
+
+function transcriptEmbeddingRuntimeConfig(): TranscriptEmbeddingRuntimeConfig {
+  return {
+    concurrency: transcriptEmbeddingConcurrency(),
+    stepTargetLimit: DEFAULT_TRANSCRIPT_EMBEDDING_STEP_TARGET_LIMIT,
+    stepMaxDurationMs: DEFAULT_TRANSCRIPT_EMBEDDING_STEP_MAX_DURATION_MS,
+    launchTimeoutMs: DEFAULT_TRANSCRIPT_EMBEDDING_LAUNCH_TIMEOUT_MS,
+  }
 }
 
 export type TranscriptEmbeddingBackfillInput = {
@@ -242,19 +269,30 @@ export async function runTranscriptEmbeddingBackfill(
     ? allTargets.filter((t) => languageFilter.has(t.language))
     : allTargets
 
-  // Group flat targets by (video, edition) so the artifact load
-  // collapses from per-target to per-group.
+  // Group flat targets by (video, edition) first so reporting and source-gap
+  // aggregation keep the same order. The runtime batcher below shards large
+  // groups by target so no single Workflow step owns a whole multilingual
+  // edition.
   const groups = groupTargetsByVideoEdition(targets)
 
-  // Bounded parallelism is intentionally inside one durable step below.
-  // Production useworkflow rejects dynamic repeated calls to the same step
-  // function from a groups.map(...) loop with event-log corruption.
-  const concurrency = transcriptEmbeddingConcurrency()
+  // Persist runtime knobs before batching so replay keeps the same partitioning
+  // even if Railway env changes during a long run.
+  const runtimeConfig = await stepResolveTranscriptEmbeddingRuntimeConfig()
+
+  // Production useworkflow rejects parallel repeated calls to the same step
+  // function from a groups.map(...) loop with event-log corruption. Keep the
+  // repeated step calls sequential at workflow scope, and keep the parallelism
+  // inside each target-bounded batch step.
+  const groupBatches = batchGroupsByTargetLimit(
+    groups,
+    runtimeConfig.stepTargetLimit,
+  )
 
   // Structured start log so the workflow's effective concurrency is
   // observable from any trigger path. `groupCount` surfaces Stage 2's
   // reshape so an operator inspecting logs can see the artifact-fetch
-  // fan-in.
+  // fan-in. `groupBatchCount` and `stepTargetLimit` surface the Workflow
+  // time-slicing boundary used to keep Graphile tasks below the step ceiling.
   console.log(
     JSON.stringify({
       workflow: "transcript-embedding-backfill",
@@ -262,16 +300,42 @@ export async function runTranscriptEmbeddingBackfill(
       mappingGeneratedAt: mapping.generatedAt,
       totalTargets: targets.length,
       groupCount: groups.length,
-      concurrency,
+      groupBatchCount: groupBatches.length,
+      stepTargetLimit: runtimeConfig.stepTargetLimit,
+      stepMaxDurationMs: runtimeConfig.stepMaxDurationMs,
+      launchTimeoutMs: runtimeConfig.launchTimeoutMs,
+      concurrency: runtimeConfig.concurrency,
       languageFilter:
         input.languages && input.languages.length > 0 ? input.languages : null,
     }),
   )
 
-  const outcomes = await stepProcessTranscriptEmbeddingGroups(
-    groups,
-    input.mode ?? "idempotent",
-    concurrency,
+  const outcomes: BackfillOutcome[] = []
+  let pendingConfirmations: PendingTranscriptIngestConfirmation[] = []
+  for (const groupBatch of groupBatches) {
+    let remainingBatch = groupBatch
+    while (remainingBatch.length > 0) {
+      const batchResult = await stepProcessTranscriptEmbeddingGroups(
+        remainingBatch,
+        input.mode ?? "idempotent",
+        runtimeConfig.concurrency,
+        runtimeConfig.stepMaxDurationMs,
+        runtimeConfig.launchTimeoutMs,
+      )
+      outcomes.push(...batchResult.outcomes)
+      pendingConfirmations.push(...batchResult.pendingConfirmations)
+
+      const confirmation =
+        await confirmPendingTranscriptIngestsOnce(pendingConfirmations)
+      outcomes.push(...confirmation.outcomes)
+      pendingConfirmations = confirmation.pendingConfirmations
+      remainingBatch = batchResult.unprocessedGroups
+    }
+  }
+  outcomes.push(
+    ...(await waitForPendingTranscriptIngestConfirmations(
+      pendingConfirmations,
+    )),
   )
 
   return stepReport({
@@ -286,6 +350,58 @@ export async function runTranscriptEmbeddingBackfill(
 async function stepLoadMapping(s3Key: string): Promise<CoreIdMapping> {
   "use step"
   return loadCoreIdMapping(s3Key)
+}
+
+async function stepResolveTranscriptEmbeddingRuntimeConfig(): Promise<TranscriptEmbeddingRuntimeConfig> {
+  "use step"
+  return transcriptEmbeddingRuntimeConfig()
+}
+
+async function confirmPendingTranscriptIngestsOnce(
+  pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+) {
+  if (pendingConfirmations.length === 0) {
+    return { outcomes: [], pendingConfirmations: [] }
+  }
+  return stepConfirmTranscriptEmbeddingIngests(pendingConfirmations)
+}
+
+async function waitForPendingTranscriptIngestConfirmations(
+  pendingConfirmations: readonly PendingTranscriptIngestConfirmation[],
+): Promise<BackfillOutcome[]> {
+  let pending = Array.from(pendingConfirmations)
+  const outcomes: BackfillOutcome[] = []
+  const maxPolls = Math.ceil(
+    TIMED_OUT_LAUNCH_CONFIRM_TIMEOUT_MS / TIMED_OUT_LAUNCH_CONFIRM_POLL_MS,
+  )
+
+  for (let poll = 0; pending.length > 0 && poll <= maxPolls; poll += 1) {
+    const confirmation = await stepConfirmTranscriptEmbeddingIngests(pending)
+    outcomes.push(...confirmation.outcomes)
+    pending = confirmation.pendingConfirmations
+
+    if (pending.length === 0 || poll === maxPolls) break
+    await sleepForPendingConfirmation(TIMED_OUT_LAUNCH_CONFIRM_POLL_MS)
+  }
+
+  if (pending.length === 0) return outcomes
+
+  outcomes.push(...(await stepFailPendingTranscriptEmbeddingIngests(pending)))
+  return outcomes
+}
+
+async function sleepForPendingConfirmation(ms: number): Promise<void> {
+  try {
+    getWorkflowMetadata()
+    await sleep(ms)
+  } catch {
+    await stepSleepForDirectExecution(ms)
+  }
+}
+
+async function stepSleepForDirectExecution(ms: number): Promise<void> {
+  "use step"
+  await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 async function stepEnumerateTargets(
@@ -460,6 +576,41 @@ function groupTargetsByVideoEdition(
   return Array.from(groupMap.values(), (e) => e.group)
 }
 
+function batchGroupsByTargetLimit(
+  groups: readonly BackfillGroup[],
+  targetLimit: number,
+): BackfillGroup[][] {
+  const safeLimit =
+    Number.isInteger(targetLimit) && targetLimit > 0
+      ? targetLimit
+      : DEFAULT_TRANSCRIPT_EMBEDDING_STEP_TARGET_LIMIT
+  const batches: BackfillGroup[][] = []
+  let current: BackfillGroup[] = []
+  let currentTargetCount = 0
+
+  const flush = () => {
+    if (current.length === 0) return
+    batches.push(current)
+    current = []
+    currentTargetCount = 0
+  }
+
+  for (const group of groups) {
+    for (const target of group.targets) {
+      if (currentTargetCount >= safeLimit) flush()
+
+      current.push({
+        ...group,
+        targets: [target],
+      })
+      currentTargetCount += 1
+    }
+  }
+
+  flush()
+  return batches
+}
+
 /**
  * Project the outcome list to the deduped, sorted set of missing
  * transcript source artifacts. See R1's `deriveMissingArtifacts` for the full
@@ -554,4 +705,5 @@ function stepReport(args: {
 export const _internals = {
   stepReport,
   groupTargetsByVideoEdition,
+  batchGroupsByTargetLimit,
 }

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
@@ -864,6 +864,52 @@ describe("transcript embedding workflow", () => {
     })
   })
 
+  it("accepts a caller run id envelope at the transcript embedding route", async () => {
+    const launch = vi.fn(async () => ({
+      ok: true as const,
+      status: "created" as const,
+      chunks: 1,
+      totalTokens: 4,
+      model: "embeddings",
+      provider: "jesus-film-ai-gateway",
+      dimensions: 1536,
+      mastraRunId: "run-from-admin",
+      sourceContentHash: "sha256:test",
+      target: {
+        videoId: "video-1",
+        videoEditionId: "edition-1",
+        coreId: "core-1",
+        language: "en",
+      },
+      chunking: {
+        type: "segment-aware" as const,
+        maxChunkTokens: 500,
+        overlapTokens: 100,
+        version: _internals.CHUNKING_VERSION,
+      },
+    }))
+    const workflowInput = input()
+
+    const response = await handleTranscriptEmbeddingRouteRequest({
+      authHeader: "Bearer secret",
+      serviceKeys: ["secret"],
+      readJson: async () => ({
+        runId: "run-from-admin",
+        input: workflowInput,
+      }),
+      launch,
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.body.result).toMatchObject({
+      ok: true,
+      mastraRunId: "run-from-admin",
+    })
+    expect(launch).toHaveBeenCalledWith(workflowInput, {
+      runId: "run-from-admin",
+    })
+  })
+
   it("marks committed Mastra runs as failed when the workflow result is a typed failure", async () => {
     const run = await transcriptEmbeddingWorkflow.createRun({
       runId: "run-committed-provider-config",

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
@@ -354,6 +354,192 @@ describe("transcript embedding workflow", () => {
     )
   })
 
+  it("splits non-retryable invalid provider responses and preserves chunk order", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const embeddingRequester = vi.fn(async (items: string[]) => {
+      if (items.length > 1) {
+        throw new EmbeddingProviderError(
+          "invalid_response",
+          "provider returned an error envelope without data",
+          false,
+        )
+      }
+      return seededEmbeddingResult(items)
+    })
+    const adminIngestClient = vi.fn(async (payload) => ({
+      ok: true as const,
+      result: {
+        status: "created" as const,
+        target: {
+          videoId: "video-1",
+          videoEditionId: "edition-1",
+          coreId: "core-1",
+          language: payload.language,
+        },
+        chunks: payload.chunks.length,
+        model: payload.model.name,
+        dimensions: payload.model.dimensions,
+        mastraRunId: payload.generation.mastraRunId,
+      },
+    }))
+
+    const result = await runTranscriptEmbeddingWorkflow(
+      input({
+        transcript: {
+          text: "one two three four five six seven eight nine ten eleven twelve",
+          artifactKey: "asset-1/transcript.json",
+        },
+        chunking: {
+          maxChunkTokens: 4,
+          overlapTokens: 0,
+          maxBatchChunks: 4,
+          maxBatchTokens: 100_000,
+        },
+      }),
+      {
+        runId: "run-split-invalid-response",
+        embeddingRequester,
+        adminIngestClient,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "created",
+      chunks: 4,
+      mastraRunId: "run-split-invalid-response",
+    })
+    expect(
+      embeddingRequester.mock.calls.map(([items]) => items.length),
+    ).toEqual([4, 2, 1, 1, 2, 1, 1])
+    const splitWarnings = warnSpy.mock.calls.map(([message]) =>
+      JSON.parse(String(message)),
+    )
+    expect(splitWarnings).toEqual([
+      expect.objectContaining({
+        event: "transcript_embedding_batch_split_retry",
+        mastraRunId: "run-split-invalid-response",
+        errorCode: "invalid_response",
+        retryable: false,
+        splitDepth: 0,
+        splitPath: "root",
+        chunkCount: 4,
+      }),
+      expect.objectContaining({
+        splitDepth: 1,
+        splitPath: "root.1",
+        chunkCount: 2,
+      }),
+      expect.objectContaining({
+        splitDepth: 1,
+        splitPath: "root.2",
+        chunkCount: 2,
+      }),
+    ])
+    const serializedWarnings = JSON.stringify(splitWarnings)
+    expect(serializedWarnings).not.toContain("one two three")
+    expect(serializedWarnings).not.toContain("Transcript:")
+    expect(serializedWarnings).not.toContain("embeddingInputText")
+    expect(serializedWarnings).not.toContain("provider returned")
+    warnSpy.mockRestore()
+    expect(adminIngestClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chunks: [
+          expect.objectContaining({
+            text: "one two three",
+            embedding: vector(1),
+          }),
+          expect.objectContaining({
+            text: "four five six",
+            embedding: vector(2),
+          }),
+          expect.objectContaining({
+            text: "seven eight nine",
+            embedding: vector(3),
+          }),
+          expect.objectContaining({
+            text: "ten eleven twelve",
+            embedding: vector(4),
+          }),
+        ],
+      }),
+    )
+  })
+
+  it("retries unsplittable gateway provider responses with scrubbed telemetry", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const embeddingRequester = vi.fn(async (items: string[]) => {
+      if (embeddingRequester.mock.calls.length < 3) {
+        throw new EmbeddingProviderError(
+          "invalid_response",
+          "gateway returned an empty response body",
+          false,
+        )
+      }
+      return seededEmbeddingResult(items)
+    })
+    const adminIngestClient = vi.fn(async (payload) => ({
+      ok: true as const,
+      result: {
+        status: "created" as const,
+        target: {
+          videoId: "video-1",
+          videoEditionId: "edition-1",
+          coreId: "core-1",
+          language: payload.language,
+        },
+        chunks: payload.chunks.length,
+        model: payload.model.name,
+        dimensions: payload.model.dimensions,
+        mastraRunId: payload.generation.mastraRunId,
+      },
+    }))
+
+    const result = await runTranscriptEmbeddingWorkflow(input(), {
+      runId: "run-singleton-retry",
+      embeddingRequester,
+      adminIngestClient,
+      providerRetryDelayMs: 0,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "created",
+      chunks: 1,
+      mastraRunId: "run-singleton-retry",
+    })
+    expect(embeddingRequester).toHaveBeenCalledTimes(3)
+    const retryWarnings = warnSpy.mock.calls.map(([message]) =>
+      JSON.parse(String(message)),
+    )
+    expect(retryWarnings).toEqual([
+      expect.objectContaining({
+        event: "transcript_embedding_batch_provider_retry",
+        mastraRunId: "run-singleton-retry",
+        errorCode: "invalid_response",
+        retryable: false,
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 0,
+        chunkCount: 1,
+      }),
+      expect.objectContaining({
+        event: "transcript_embedding_batch_provider_retry",
+        attempt: 2,
+        maxAttempts: 3,
+        delayMs: 0,
+        chunkCount: 1,
+      }),
+    ])
+    const serializedWarnings = JSON.stringify(retryWarnings)
+    expect(serializedWarnings).not.toContain("Jesus teaches hope")
+    expect(serializedWarnings).not.toContain("Transcript:")
+    expect(serializedWarnings).not.toContain("embeddingInputText")
+    expect(serializedWarnings).not.toContain("gateway returned")
+    warnSpy.mockRestore()
+    expect(adminIngestClient).toHaveBeenCalledOnce()
+  })
+
   it("rejects malformed split child results before Admin ingest", async () => {
     const embeddingRequester = vi.fn(async (items: string[]) => {
       if (items.length > 2) {

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.test.ts
@@ -59,6 +59,27 @@ function embeddingResult(inputs: string[]): EmbeddingProviderResult {
   }
 }
 
+function seededEmbeddingResult(inputs: string[]): EmbeddingProviderResult {
+  const seedForInput = (value: string) => {
+    if (value.includes("Transcript: one two three")) return 1
+    if (value.includes("Transcript: four five six")) return 2
+    if (value.includes("Transcript: seven eight nine")) return 3
+    if (value.includes("Transcript: ten eleven twelve")) return 4
+    return 9
+  }
+
+  return {
+    embeddings: inputs.map((value) => vector(seedForInput(value))),
+    dimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+    tokenCount: inputs.length * 3,
+    model: "embeddings",
+    provider: "jesus-film-ai-gateway",
+    requestModel: "embeddings",
+    nativeDimensions: 4096,
+    transformVersion: "matryoshka-truncate-1536-v1",
+  }
+}
+
 describe("transcript embedding workflow", () => {
   it("plans segment-aware chunks and submits aligned vectors to Admin ingest", async () => {
     const embeddingRequester = vi.fn(async (items: string[]) =>
@@ -210,6 +231,224 @@ describe("transcript embedding workflow", () => {
         ],
       }),
     )
+  })
+
+  it("recursively splits non-retryable provider batch rejections and preserves chunk order", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const embeddingRequester = vi.fn(async (items: string[]) => {
+      if (items.length > 1) {
+        throw new EmbeddingProviderError(
+          "upstream_failed",
+          "provider rejected oversized batch",
+          false,
+        )
+      }
+      return seededEmbeddingResult(items)
+    })
+    const adminIngestClient = vi.fn(async (payload) => ({
+      ok: true as const,
+      result: {
+        status: "created" as const,
+        target: {
+          videoId: "video-1",
+          videoEditionId: "edition-1",
+          coreId: "core-1",
+          language: payload.language,
+        },
+        chunks: payload.chunks.length,
+        model: payload.model.name,
+        dimensions: payload.model.dimensions,
+        mastraRunId: payload.generation.mastraRunId,
+      },
+    }))
+
+    const result = await runTranscriptEmbeddingWorkflow(
+      input({
+        transcript: {
+          text: "one two three four five six seven eight nine ten eleven twelve",
+          artifactKey: "asset-1/transcript.json",
+        },
+        chunking: {
+          maxChunkTokens: 4,
+          overlapTokens: 0,
+          maxBatchChunks: 4,
+          maxBatchTokens: 100_000,
+        },
+      }),
+      {
+        runId: "run-split-batch",
+        embeddingRequester,
+        adminIngestClient,
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "created",
+      chunks: 4,
+      mastraRunId: "run-split-batch",
+    })
+    expect(
+      embeddingRequester.mock.calls.map(([items]) => items.length),
+    ).toEqual([4, 2, 1, 1, 2, 1, 1])
+    const splitWarnings = warnSpy.mock.calls.map(([message]) =>
+      JSON.parse(String(message)),
+    )
+    expect(splitWarnings).toEqual([
+      expect.objectContaining({
+        event: "transcript_embedding_batch_split_retry",
+        mastraRunId: "run-split-batch",
+        language: "en",
+        model: "embeddings",
+        provider: "jesus-film-ai-gateway",
+        requestModel: "embeddings",
+        errorCode: "upstream_failed",
+        retryable: false,
+        splitDepth: 0,
+        splitPath: "root",
+        chunkCount: 4,
+      }),
+      expect.objectContaining({
+        splitDepth: 1,
+        splitPath: "root.1",
+        chunkCount: 2,
+      }),
+      expect.objectContaining({
+        splitDepth: 1,
+        splitPath: "root.2",
+        chunkCount: 2,
+      }),
+    ])
+    const serializedWarnings = JSON.stringify(splitWarnings)
+    expect(serializedWarnings).not.toContain("one two three")
+    expect(serializedWarnings).not.toContain("Transcript:")
+    expect(serializedWarnings).not.toContain("embeddingInputText")
+    expect(serializedWarnings).not.toContain('"embeddings":')
+    expect(serializedWarnings).not.toContain('"embedding":')
+    expect(serializedWarnings).not.toContain("apiKey")
+    expect(serializedWarnings).not.toContain(
+      "provider rejected oversized batch",
+    )
+    warnSpy.mockRestore()
+    expect(adminIngestClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chunks: [
+          expect.objectContaining({
+            text: "one two three",
+            embedding: vector(1),
+          }),
+          expect.objectContaining({
+            text: "four five six",
+            embedding: vector(2),
+          }),
+          expect.objectContaining({
+            text: "seven eight nine",
+            embedding: vector(3),
+          }),
+          expect.objectContaining({
+            text: "ten eleven twelve",
+            embedding: vector(4),
+          }),
+        ],
+      }),
+    )
+  })
+
+  it("rejects malformed split child results before Admin ingest", async () => {
+    const embeddingRequester = vi.fn(async (items: string[]) => {
+      if (items.length > 2) {
+        throw new EmbeddingProviderError(
+          "upstream_failed",
+          "provider rejected oversized batch",
+          false,
+        )
+      }
+      if (items.length === 2) return seededEmbeddingResult(items.slice(0, 1))
+      return seededEmbeddingResult(items)
+    })
+    const adminIngestClient = vi.fn()
+
+    await expect(
+      runTranscriptEmbeddingWorkflow(
+        input({
+          transcript: {
+            text: "one two three four five six seven eight nine ten eleven twelve",
+            artifactKey: "asset-1/transcript.json",
+          },
+          chunking: {
+            maxChunkTokens: 4,
+            overlapTokens: 0,
+            maxBatchChunks: 4,
+            maxBatchTokens: 100_000,
+          },
+        }),
+        {
+          runId: "run-split-count-mismatch",
+          embeddingRequester,
+          adminIngestClient,
+        },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider_failed",
+      retryable: true,
+      mastraRunId: "run-split-count-mismatch",
+      adminStatus: undefined,
+      adminReason: undefined,
+    })
+    expect(
+      embeddingRequester.mock.calls.map(([items]) => items.length),
+    ).toEqual([4, 2])
+    expect(adminIngestClient).not.toHaveBeenCalled()
+  })
+
+  it("rejects inconsistent split child provenance before Admin ingest", async () => {
+    const embeddingRequester = vi.fn(async (items: string[]) => {
+      if (items.length > 2) {
+        throw new EmbeddingProviderError(
+          "upstream_failed",
+          "provider rejected oversized batch",
+          false,
+        )
+      }
+      const result = seededEmbeddingResult(items)
+      if (items[0]?.includes("Transcript: one two three")) {
+        return { ...result, transformVersion: undefined }
+      }
+      return result
+    })
+    const adminIngestClient = vi.fn()
+
+    await expect(
+      runTranscriptEmbeddingWorkflow(
+        input({
+          transcript: {
+            text: "one two three four five six seven eight nine ten eleven twelve",
+            artifactKey: "asset-1/transcript.json",
+          },
+          chunking: {
+            maxChunkTokens: 4,
+            overlapTokens: 0,
+            maxBatchChunks: 4,
+            maxBatchTokens: 100_000,
+          },
+        }),
+        {
+          runId: "run-split-provenance-mismatch",
+          embeddingRequester,
+          adminIngestClient,
+        },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "provider_dimension_mismatch",
+      retryable: false,
+      mastraRunId: "run-split-provenance-mismatch",
+    })
+    expect(
+      embeddingRequester.mock.calls.map(([items]) => items.length),
+    ).toEqual([4, 2, 2])
+    expect(adminIngestClient).not.toHaveBeenCalled()
   })
 
   it("returns safe failures for empty sources, provider failures, and Admin rejects", async () => {

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.ts
@@ -13,6 +13,7 @@ import {
 import {
   EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
   EmbeddingProviderError,
+  requestModelForEndpoint,
   requestEmbeddingVectors,
   validateEmbeddingProviderResult,
   type EmbeddingProviderResult,
@@ -775,6 +776,161 @@ function createBatches(
   return batches
 }
 
+function shouldSplitProviderBatch(error: unknown, batchSize: number): boolean {
+  return (
+    batchSize > 1 &&
+    error instanceof EmbeddingProviderError &&
+    error.code === "upstream_failed" &&
+    !error.retryable
+  )
+}
+
+function combineEmbeddingProviderResults(
+  left: EmbeddingProviderResult,
+  right: EmbeddingProviderResult,
+  options: {
+    context: string
+    itemLabel: string
+    expectedDimensions: number
+    expectedCount: number
+  },
+): EmbeddingProviderResult {
+  const mismatch =
+    left.dimensions !== right.dimensions ||
+    left.model !== right.model ||
+    left.provider !== right.provider ||
+    left.requestModel !== right.requestModel ||
+    left.nativeDimensions !== right.nativeDimensions ||
+    left.transformVersion !== right.transformVersion
+
+  if (mismatch) {
+    throw new EmbeddingProviderError(
+      "dimension_mismatch",
+      `${options.context} split embedding responses were inconsistent`,
+    )
+  }
+
+  return validateEmbeddingProviderResult(
+    {
+      embeddings: [...left.embeddings, ...right.embeddings],
+      dimensions: left.dimensions,
+      nativeDimensions: left.nativeDimensions ?? right.nativeDimensions,
+      transformVersion: left.transformVersion ?? right.transformVersion,
+      tokenCount: left.tokenCount + right.tokenCount,
+      model: left.model,
+      provider: left.provider,
+      requestModel: left.requestModel,
+    },
+    options.expectedCount,
+    {
+      expectedDimensions: options.expectedDimensions,
+      context: options.context,
+      itemLabel: options.itemLabel,
+    },
+  )
+}
+
+async function requestEmbeddingBatchWithFallback(
+  batch: PlannedChunk[],
+  options: TranscriptEmbeddingWorkflowOptions & {
+    planned: PlannedRun
+    providerConfig: ReturnType<typeof getTranscriptEmbeddingProviderConfig>
+    context: string
+    splitDepth?: number
+    splitPath?: string
+  },
+): Promise<EmbeddingProviderResult> {
+  const batchInput = batch.map(
+    (chunk) => chunk.embeddingInputText ?? chunk.text,
+  )
+
+  try {
+    const rawResult = options.embeddingRequester
+      ? await options.embeddingRequester(batchInput, {
+          expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+          context: options.context,
+          itemLabel: "chunks",
+        })
+      : await requestEmbeddingVectors(batchInput, {
+          apiKey: options.apiKey ?? options.providerConfig.apiKey,
+          baseUrl: options.embeddingsBaseUrl ?? options.providerConfig.baseUrl,
+          model: options.planned.model.name,
+          provider: options.planned.model.provider,
+          expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+          expectedNativeDimensions:
+            options.providerConfig.expectedNativeDimensions,
+          truncateToDimensions: options.providerConfig.truncateToDimensions,
+          transformVersion: options.providerConfig.transformVersion,
+          userAgent: options.providerConfig.userAgent,
+          context: options.context,
+          itemLabel: "chunks",
+          timeoutMs: options.timeoutMs ?? options.providerConfig.timeoutMs,
+          fetchImpl: options.fetchImpl,
+        })
+
+    return validateEmbeddingProviderResult(rawResult, batch.length, {
+      expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+      context: options.context,
+      itemLabel: "chunks",
+    })
+  } catch (error) {
+    if (!shouldSplitProviderBatch(error, batch.length)) throw error
+
+    const splitDepth = options.splitDepth ?? 0
+    const splitPath = options.splitPath ?? "root"
+    console.warn(
+      JSON.stringify({
+        event: "transcript_embedding_batch_split_retry",
+        context: options.context,
+        mastraRunId: options.planned.generation.mastraRunId,
+        target: options.planned.target,
+        language: options.planned.language,
+        model: options.planned.model.name,
+        provider: options.planned.model.provider,
+        requestModel: requestModelForEndpoint(
+          options.planned.model.name,
+          options.embeddingsBaseUrl ?? options.providerConfig.baseUrl,
+        ),
+        errorCode:
+          error instanceof EmbeddingProviderError ? error.code : "unknown",
+        retryable:
+          error instanceof EmbeddingProviderError ? error.retryable : null,
+        splitDepth,
+        splitPath,
+        chunkCount: batch.length,
+        tokenCount: batch.reduce((sum, chunk) => sum + chunk.tokenCount, 0),
+      }),
+    )
+
+    const splitIndex = Math.ceil(batch.length / 2)
+    const left = await requestEmbeddingBatchWithFallback(
+      batch.slice(0, splitIndex),
+      {
+        ...options,
+        context: `${options.context} split 1/2`,
+        splitDepth: splitDepth + 1,
+        splitPath: `${splitPath}.1`,
+      },
+    )
+    const right = await requestEmbeddingBatchWithFallback(
+      batch.slice(splitIndex),
+      {
+        ...options,
+        context: `${options.context} split 2/2`,
+        splitDepth: splitDepth + 1,
+        splitPath: `${splitPath}.2`,
+      },
+    )
+
+    return combineEmbeddingProviderResults(left, right, {
+      context: options.context,
+      itemLabel: "chunks",
+      expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+      expectedCount: batch.length,
+    })
+  }
+}
+
 function sha256Json(value: unknown): string {
   return `sha256:${createHash("sha256")
     .update(JSON.stringify(value))
@@ -1118,40 +1274,18 @@ export async function embedPlannedTranscript(
   for (let index = 0; index < batches.length; index += 1) {
     const batch = batches[index]!
     const providerConfig = getTranscriptEmbeddingProviderConfig()
-    const batchInput = batch.map(
-      (chunk) => chunk.embeddingInputText ?? chunk.text,
-    )
     const requestContext = `Transcript embedding batch ${index + 1}/${batches.length}`
-    const rawResult = options.embeddingRequester
-      ? await options.embeddingRequester(batchInput, {
-          expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
-          context: requestContext,
-          itemLabel: "chunks",
-        })
-      : await requestEmbeddingVectors(batchInput, {
-          apiKey: options.apiKey ?? providerConfig.apiKey,
-          baseUrl: options.embeddingsBaseUrl ?? providerConfig.baseUrl,
-          model: planned.model.name,
-          provider: planned.model.provider,
-          expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
-          expectedNativeDimensions: providerConfig.expectedNativeDimensions,
-          truncateToDimensions: providerConfig.truncateToDimensions,
-          transformVersion: providerConfig.transformVersion,
-          userAgent: providerConfig.userAgent,
-          context: requestContext,
-          itemLabel: "chunks",
-          timeoutMs: options.timeoutMs ?? providerConfig.timeoutMs,
-          fetchImpl: options.fetchImpl,
-        })
-    const result = validateEmbeddingProviderResult(
-      rawResult,
-      batchInput.length,
-      {
-        expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
-        context: requestContext,
-        itemLabel: "chunks",
-      },
-    )
+    const rawResult = await requestEmbeddingBatchWithFallback(batch, {
+      ...options,
+      planned,
+      providerConfig,
+      context: requestContext,
+    })
+    const result = validateEmbeddingProviderResult(rawResult, batch.length, {
+      expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+      context: requestContext,
+      itemLabel: "chunks",
+    })
 
     tokenCount += result.tokenCount
     transformVersion ??= result.transformVersion

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.ts
@@ -26,6 +26,8 @@ const DEFAULT_OVERLAP_TOKENS = 100
 const DEFAULT_MAX_BATCH_CHUNKS = 8
 const DEFAULT_MAX_BATCH_TOKENS = 20_000
 const CHUNKING_VERSION = "enriched-transcript-v2"
+const DEFAULT_PROVIDER_BATCH_MAX_ATTEMPTS = 3
+const DEFAULT_PROVIDER_BATCH_RETRY_DELAY_MS = 1_000
 
 type CanonicalFeltNeed =
   | "Acceptance"
@@ -377,6 +379,8 @@ export type TranscriptEmbeddingWorkflowOptions = {
       itemLabel: string
     },
   ) => Promise<EmbeddingProviderResult>
+  providerRetryMaxAttempts?: number
+  providerRetryDelayMs?: number
   adminIngestClient?: (
     payload: AdminTranscriptEmbeddingIngestPayload,
   ) => Promise<AdminTranscriptIngestClientResult>
@@ -776,13 +780,44 @@ function createBatches(
   return batches
 }
 
+function isRecoverableGatewayProviderError(
+  error: unknown,
+): error is EmbeddingProviderError {
+  return (
+    error instanceof EmbeddingProviderError &&
+    (error.code === "upstream_failed" || error.code === "invalid_response")
+  )
+}
+
 function shouldSplitProviderBatch(error: unknown, batchSize: number): boolean {
   return (
     batchSize > 1 &&
-    error instanceof EmbeddingProviderError &&
-    error.code === "upstream_failed" &&
+    isRecoverableGatewayProviderError(error) &&
     !error.retryable
   )
+}
+
+function shouldRetryProviderBatch(
+  error: unknown,
+  options: { batchSize: number; attempt: number; maxAttempts: number },
+): boolean {
+  if (options.attempt >= options.maxAttempts) return false
+  if (!isRecoverableGatewayProviderError(error)) return false
+
+  return error.retryable || options.batchSize === 1
+}
+
+function retryDelayMs(options: {
+  baseDelayMs: number
+  attempt: number
+}): number {
+  if (options.baseDelayMs <= 0) return 0
+  return options.baseDelayMs * 2 ** Math.max(0, options.attempt - 1)
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function combineEmbeddingProviderResults(
@@ -843,90 +878,137 @@ async function requestEmbeddingBatchWithFallback(
   const batchInput = batch.map(
     (chunk) => chunk.embeddingInputText ?? chunk.text,
   )
+  const maxAttempts =
+    options.providerRetryMaxAttempts ?? DEFAULT_PROVIDER_BATCH_MAX_ATTEMPTS
+  const retryBaseDelayMs =
+    options.providerRetryDelayMs ?? DEFAULT_PROVIDER_BATCH_RETRY_DELAY_MS
 
-  try {
-    const rawResult = options.embeddingRequester
-      ? await options.embeddingRequester(batchInput, {
-          expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
-          context: options.context,
-          itemLabel: "chunks",
+  for (let attempt = 1; ; attempt += 1) {
+    let rawResult: EmbeddingProviderResult
+    try {
+      rawResult = options.embeddingRequester
+        ? await options.embeddingRequester(batchInput, {
+            expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+            context: options.context,
+            itemLabel: "chunks",
+          })
+        : await requestEmbeddingVectors(batchInput, {
+            apiKey: options.apiKey ?? options.providerConfig.apiKey,
+            baseUrl:
+              options.embeddingsBaseUrl ?? options.providerConfig.baseUrl,
+            model: options.planned.model.name,
+            provider: options.planned.model.provider,
+            expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+            expectedNativeDimensions:
+              options.providerConfig.expectedNativeDimensions,
+            truncateToDimensions: options.providerConfig.truncateToDimensions,
+            transformVersion: options.providerConfig.transformVersion,
+            userAgent: options.providerConfig.userAgent,
+            context: options.context,
+            itemLabel: "chunks",
+            timeoutMs: options.timeoutMs ?? options.providerConfig.timeoutMs,
+            fetchImpl: options.fetchImpl,
+          })
+    } catch (error) {
+      if (
+        shouldRetryProviderBatch(error, {
+          batchSize: batch.length,
+          attempt,
+          maxAttempts,
         })
-      : await requestEmbeddingVectors(batchInput, {
-          apiKey: options.apiKey ?? options.providerConfig.apiKey,
-          baseUrl: options.embeddingsBaseUrl ?? options.providerConfig.baseUrl,
+      ) {
+        const delayMs = retryDelayMs({
+          baseDelayMs: retryBaseDelayMs,
+          attempt,
+        })
+        console.warn(
+          JSON.stringify({
+            event: "transcript_embedding_batch_provider_retry",
+            context: options.context,
+            mastraRunId: options.planned.generation.mastraRunId,
+            target: options.planned.target,
+            language: options.planned.language,
+            model: options.planned.model.name,
+            provider: options.planned.model.provider,
+            requestModel: requestModelForEndpoint(
+              options.planned.model.name,
+              options.embeddingsBaseUrl ?? options.providerConfig.baseUrl,
+            ),
+            errorCode:
+              error instanceof EmbeddingProviderError ? error.code : "unknown",
+            retryable:
+              error instanceof EmbeddingProviderError ? error.retryable : null,
+            attempt,
+            maxAttempts,
+            delayMs,
+            chunkCount: batch.length,
+            tokenCount: batch.reduce((sum, chunk) => sum + chunk.tokenCount, 0),
+          }),
+        )
+        await sleep(delayMs)
+        continue
+      }
+
+      if (!shouldSplitProviderBatch(error, batch.length)) throw error
+
+      const splitDepth = options.splitDepth ?? 0
+      const splitPath = options.splitPath ?? "root"
+      console.warn(
+        JSON.stringify({
+          event: "transcript_embedding_batch_split_retry",
+          context: options.context,
+          mastraRunId: options.planned.generation.mastraRunId,
+          target: options.planned.target,
+          language: options.planned.language,
           model: options.planned.model.name,
           provider: options.planned.model.provider,
-          expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
-          expectedNativeDimensions:
-            options.providerConfig.expectedNativeDimensions,
-          truncateToDimensions: options.providerConfig.truncateToDimensions,
-          transformVersion: options.providerConfig.transformVersion,
-          userAgent: options.providerConfig.userAgent,
-          context: options.context,
-          itemLabel: "chunks",
-          timeoutMs: options.timeoutMs ?? options.providerConfig.timeoutMs,
-          fetchImpl: options.fetchImpl,
-        })
+          requestModel: requestModelForEndpoint(
+            options.planned.model.name,
+            options.embeddingsBaseUrl ?? options.providerConfig.baseUrl,
+          ),
+          errorCode:
+            error instanceof EmbeddingProviderError ? error.code : "unknown",
+          retryable:
+            error instanceof EmbeddingProviderError ? error.retryable : null,
+          splitDepth,
+          splitPath,
+          chunkCount: batch.length,
+          tokenCount: batch.reduce((sum, chunk) => sum + chunk.tokenCount, 0),
+        }),
+      )
+
+      const splitIndex = Math.ceil(batch.length / 2)
+      const left = await requestEmbeddingBatchWithFallback(
+        batch.slice(0, splitIndex),
+        {
+          ...options,
+          context: `${options.context} split 1/2`,
+          splitDepth: splitDepth + 1,
+          splitPath: `${splitPath}.1`,
+        },
+      )
+      const right = await requestEmbeddingBatchWithFallback(
+        batch.slice(splitIndex),
+        {
+          ...options,
+          context: `${options.context} split 2/2`,
+          splitDepth: splitDepth + 1,
+          splitPath: `${splitPath}.2`,
+        },
+      )
+
+      return combineEmbeddingProviderResults(left, right, {
+        context: options.context,
+        itemLabel: "chunks",
+        expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
+        expectedCount: batch.length,
+      })
+    }
 
     return validateEmbeddingProviderResult(rawResult, batch.length, {
       expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
       context: options.context,
       itemLabel: "chunks",
-    })
-  } catch (error) {
-    if (!shouldSplitProviderBatch(error, batch.length)) throw error
-
-    const splitDepth = options.splitDepth ?? 0
-    const splitPath = options.splitPath ?? "root"
-    console.warn(
-      JSON.stringify({
-        event: "transcript_embedding_batch_split_retry",
-        context: options.context,
-        mastraRunId: options.planned.generation.mastraRunId,
-        target: options.planned.target,
-        language: options.planned.language,
-        model: options.planned.model.name,
-        provider: options.planned.model.provider,
-        requestModel: requestModelForEndpoint(
-          options.planned.model.name,
-          options.embeddingsBaseUrl ?? options.providerConfig.baseUrl,
-        ),
-        errorCode:
-          error instanceof EmbeddingProviderError ? error.code : "unknown",
-        retryable:
-          error instanceof EmbeddingProviderError ? error.retryable : null,
-        splitDepth,
-        splitPath,
-        chunkCount: batch.length,
-        tokenCount: batch.reduce((sum, chunk) => sum + chunk.tokenCount, 0),
-      }),
-    )
-
-    const splitIndex = Math.ceil(batch.length / 2)
-    const left = await requestEmbeddingBatchWithFallback(
-      batch.slice(0, splitIndex),
-      {
-        ...options,
-        context: `${options.context} split 1/2`,
-        splitDepth: splitDepth + 1,
-        splitPath: `${splitPath}.1`,
-      },
-    )
-    const right = await requestEmbeddingBatchWithFallback(
-      batch.slice(splitIndex),
-      {
-        ...options,
-        context: `${options.context} split 2/2`,
-        splitDepth: splitDepth + 1,
-        splitPath: `${splitPath}.2`,
-      },
-    )
-
-    return combineEmbeddingProviderResults(left, right, {
-      context: options.context,
-      itemLabel: "chunks",
-      expectedDimensions: EXPECTED_TRANSCRIPT_EMBEDDING_DIMENSIONS,
-      expectedCount: batch.length,
     })
   }
 }

--- a/apps/mastra/src/mastra/workflows/transcript-embedding.ts
+++ b/apps/mastra/src/mastra/workflows/transcript-embedding.ts
@@ -403,6 +403,28 @@ export type TranscriptEmbeddingRouteOutcome = {
   body: { result?: TranscriptEmbeddingWorkflowResult; error?: string }
 }
 
+function routeRequestEnvelope(body: unknown): {
+  runId: string
+  input: unknown
+} {
+  if (
+    body !== null &&
+    typeof body === "object" &&
+    !Array.isArray(body) &&
+    "runId" in body &&
+    "input" in body
+  ) {
+    const record = body as { runId?: unknown; input?: unknown }
+    const runId =
+      typeof record.runId === "string" && record.runId.trim()
+        ? record.runId.trim()
+        : randomUUID()
+    return { runId, input: record.input }
+  }
+
+  return { runId: randomUUID(), input: body }
+}
+
 function normalizeTranscriptText(
   transcript: TranscriptEmbeddingWorkflowInput["transcript"],
 ): string {
@@ -1743,12 +1765,15 @@ export async function handleTranscriptEmbeddingRouteRequest({
     }
   }
 
-  const runId = randomUUID()
   const body = await readJson().catch(() => undefined)
+  const envelope = routeRequestEnvelope(body)
   const result =
     body === undefined
-      ? failure("invalid_input", { mastraRunId: runId, retryable: false })
-      : await launch(body, { runId })
+      ? failure("invalid_input", {
+          mastraRunId: envelope.runId,
+          retryable: false,
+        })
+      : await launch(envelope.input, { runId: envelope.runId })
 
   return {
     status: routeStatusForResult(result),
@@ -1766,4 +1791,5 @@ export const _internals = {
   toAdminPayload,
   CHUNKING_VERSION,
   workflowFailureFromRunResult,
+  routeRequestEnvelope,
 }

--- a/docs/plans/2026-06-22-001-fix-transcript-backfill-confirm-resume-plan.md
+++ b/docs/plans/2026-06-22-001-fix-transcript-backfill-confirm-resume-plan.md
@@ -1,0 +1,253 @@
+---
+title: "fix: Bound transcript backfill confirm resume"
+type: "fix"
+date: "2026-06-22"
+origin: "docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md"
+---
+
+# fix: Bound transcript backfill confirm resume
+
+## Summary
+
+Fix the production transcript embedding backfill failure by bounding pending
+Mastra ingest confirmation work, then resume from the known `1_jf-0-0` failure
+point without rewriting transcript rows that are already enriched and healthy.
+
+---
+
+## Problem Frame
+
+The all-language `MODEL_UPGRADE` run `wrun_01KVJ5MSF2V6EEMG7FDQQKFF84` failed
+after `stepConfirmTranscriptEmbeddingIngests` carried a large pending
+confirmation list through Workflow storage. The confirm step had about 620 KB
+of CBOR input/output, ran past the Graphile worker task boundary, and left a
+duplicate `step_started` event that useworkflow treated as a corrupted event
+log. Late Mastra ingests still wrote rows after the parent run failed, so the
+resume must treat Admin storage health as source of truth.
+
+---
+
+## Requirements
+
+**Workflow durability**
+
+- R1. Confirmation of timed-out Mastra launches must be split into bounded
+  durable step inputs so no confirm step scans the whole pending list.
+- R2. Unresolved pending confirmations must rotate fairly across slices so an
+  old unresolved Mastra run cannot starve newer pending runs.
+- R3. Final pending-failure projection must also be bounded so the timeout path
+  cannot create a giant failure step.
+
+**Resume correctness**
+
+- R4. A model-upgrade resume must skip transcript targets whose current Admin
+  row is enriched healthy: source kind present, model-upgrade/force generation,
+  all chunks have embeddings, and all chunks have non-empty
+  `embedding_input_text`.
+- R5. A resume may use existing GraphQL `coreIds` / `languages` filters to
+  start at the known failure region, but it must not add a new ad hoc trigger
+  path outside the existing Admin backfill endpoint.
+- R6. The production resume should first target `1_jf-0-0` in all languages to
+  prove the confirm fix on the failure shape before expanding to the remaining
+  all-language work.
+
+**Operational evidence**
+
+- R7. The runbook must record the fix, validation, deploy, resume command shape,
+  and post-resume status counts.
+- R8. A compounding note must capture the generalizable Workflow lesson because
+  this was a production incident and repeated an event-log corruption pattern.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Bound confirm work at the workflow caller, not only inside the step:
+  slicing before `stepConfirmTranscriptEmbeddingIngests` keeps the persisted
+  step input small and avoids repeating the 620 KB CBOR payload shape.
+- KTD2. Rotate unresolved confirmations to the end of the pending list:
+  fairness matters because long `1_jf-0-0` Mastra runs can remain pending while
+  later runs complete.
+- KTD3. Keep resume on the existing GraphQL trigger: the operator path remains
+  `triggerTranscriptEmbeddingBackfill` with `mode: MODEL_UPGRADE` and scoped
+  `coreIds` when proving the fix.
+- KTD4. Skip healthy targets before Mastra launch during model-upgrade resume:
+  upserts make duplicate rows unlikely, but provider work and elapsed time are
+  the real operational cost.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Process target batch"] --> B["Collect new pending confirmations"]
+  B --> C["Take bounded pending slice"]
+  C --> D["Confirm slice in durable step"]
+  D --> E{"Resolved?"}
+  E -->|yes| F["Record succeeded outcome"]
+  E -->|no| G["Append unresolved to pending tail"]
+  F --> H{"More pending this cycle?"}
+  G --> H
+  H -->|yes| C
+  H -->|no| I["Workflow sleep before next poll cycle"]
+  I --> C
+```
+
+The resume selector runs before target processing:
+
+```mermaid
+flowchart TB
+  A["Enumerated target"] --> B{"Mode is model-upgrade?"}
+  B -->|no| C["Process normally"]
+  B -->|yes| D["Read transcript row health"]
+  D --> E{"Enriched healthy?"}
+  E -->|yes| F["Skip before Mastra launch"]
+  E -->|no| C
+```
+
+---
+
+## Implementation Units
+
+### U1. Bound pending confirmation steps
+
+- **Goal:** Ensure `stepConfirmTranscriptEmbeddingIngests` only receives a
+  bounded slice of pending confirmations and rotates unresolved items fairly.
+- **Requirements:** R1, R2.
+- **Dependencies:** None.
+- **Files:**
+  - `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts`
+  - `apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts`
+- **Approach:** Add a small runtime constant for confirmation batch size. Change
+  `confirmPendingTranscriptIngestsOnce` and the final wait loop to pass only the
+  next slice into `stepConfirmTranscriptEmbeddingIngests`, append unresolved
+  confirmations to the tail, and sleep only after a full pending cycle has been
+  checked.
+- **Execution note:** Start with a failing unit test that creates many pending
+  confirmations and asserts the confirm step never receives the full list.
+- **Patterns to follow:** Current process-step bounding in
+  `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts`; production
+  incident notes in
+  `docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md`.
+- **Test scenarios:**
+  - Many pending confirmations with no matching rows are confirmed in slices no
+    larger than the configured limit.
+  - A pending item unresolved in the first slice moves behind untouched pending
+    items so later items can be checked.
+  - A resolved item in a slice emits a succeeded outcome and is removed from the
+    pending list.
+- **Verification:** Workflow tests prove bounded step inputs and fair rotation.
+
+### U2. Bound pending failure projection
+
+- **Goal:** Prevent the final 20-minute timeout path from passing a large
+  pending list into one failure step.
+- **Requirements:** R3.
+- **Dependencies:** U1.
+- **Files:**
+  - `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts`
+  - `apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts`
+- **Approach:** Add a workflow helper that calls
+  `stepFailPendingTranscriptEmbeddingIngests` in the same bounded slices used
+  for confirmation.
+- **Test scenarios:**
+  - When the final confirmation window expires with more pending items than the
+    batch limit, failure outcomes are produced through multiple bounded calls.
+  - Existing single-pending timeout behavior still reports `network_error`.
+- **Verification:** Tests cover both multi-slice timeout and the existing
+  single-item timeout contract.
+
+### U3. Skip already healthy enriched transcript rows during resume
+
+- **Goal:** Avoid re-embedding rows already upgraded by prior failed runs.
+- **Requirements:** R4, R5.
+- **Dependencies:** None.
+- **Files:**
+  - `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts`
+  - `apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts`
+  - `apps/admin/src/graphql/mutations/transcript-embedding.ts`
+  - `apps/admin/src/graphql/mutations/transcript-embedding.test.ts`
+- **Approach:** Add an opt-in resume selector on the existing GraphQL mutation
+  or a model-upgrade-only target pruning path. The selector should check
+  current `video_transcript` / `video_transcript_chunk` health before launch and
+  omit healthy targets from the process batches. Keep direct ingest
+  `model-upgrade` semantics unchanged so lower-level services can still rewrite
+  when explicitly called.
+- **Test scenarios:**
+  - In resume/model-upgrade selection, a target with all enriched v2 chunks is
+    not sent to Mastra.
+  - A legacy row, incomplete chunk set, missing `embedding_input_text`, or no
+    transcript row remains eligible.
+  - `coreIds` and `languages` filters continue to apply before or with the
+    resume selector.
+- **Verification:** Dispatch-shape and workflow tests prove the existing
+  endpoint remains the trigger surface and that healthy rows are skipped.
+
+### U4. Document and compound the production fix
+
+- **Goal:** Preserve the incident learning and operator resume sequence.
+- **Requirements:** R7, R8.
+- **Dependencies:** U1, U2, U3.
+- **Files:**
+  - `docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md`
+  - A new or updated `docs/solutions/` note selected by `ce:compound`
+- **Approach:** Update the runbook with the bounded-confirm fix and exact
+  validation evidence. Run `ce:compound` after implementation to record the
+  general Workflow pattern.
+- **Test expectation:** none -- documentation unit.
+- **Verification:** The runbook names the root cause, code-level fix,
+  deployment state, and resume query shape.
+
+### U5. Ship and resume from the failure region
+
+- **Goal:** Deploy the hotfix and resume without replaying known healthy rows.
+- **Requirements:** R5, R6, R7.
+- **Dependencies:** U1, U2, U3, U4.
+- **Files:**
+  - No source file changes expected beyond deployment metadata and docs.
+- **Approach:** After tests and review pass, ship the Admin and Admin worker
+  change. Trigger the existing Admin GraphQL backfill with
+  `mode: MODEL_UPGRADE`, `coreIds: ["1_jf-0-0"]`, and no language filter. Confirm
+  current storage health before and after the run, then decide whether to run
+  the remaining corpus with the same skip-healthy selector.
+- **Test expectation:** none -- operational rollout unit.
+- **Verification:** Production storage shows a new run id, bounded step
+  durations, no repeated 300s confirm tasks, and no provider calls for already
+  healthy transcript rows.
+
+---
+
+## Risks & Dependencies
+
+- The existing report still accumulates per-target outcomes in memory. If the
+  resumed run expands beyond `1_jf-0-0`, watch report payload size and consider
+  a follow-up summarized-report change before another full 208k-target run.
+- The Gateway/provider may still reject some long `1_jf-0-0` languages. This
+  fix prevents Admin Workflow corruption; it does not guarantee provider
+  success for every long transcript.
+- Production deploy must include both `@forge/admin` and
+  `@forge/admin/worker`, because the web service starts runs and the worker
+  executes durable steps.
+
+---
+
+## Documentation / Operational Notes
+
+The first resume should not use an unfiltered all-language mutation. It should
+use the existing GraphQL endpoint with `coreIds: ["1_jf-0-0"]`, omitted
+`languages`, and `mode: MODEL_UPGRADE`, after confirming the healthy-skip
+selector is present in the deployed worker. Only expand scope after the new run
+proves confirm steps stay well under the Graphile task boundary.
+
+---
+
+## Sources / Research
+
+- `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts`
+- `apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts`
+- `apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts`
+- `apps/admin/src/graphql/mutations/transcript-embedding.ts`
+- `docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md`
+- `apps/admin/AGENTS.md`
+- `apps/admin/CLAUDE.md`

--- a/docs/roadmap/content-discovery/feat-192-enriched-transcript-semantic-search.md
+++ b/docs/roadmap/content-discovery/feat-192-enriched-transcript-semantic-search.md
@@ -9,6 +9,7 @@ duration: 5
 depends_on: []
 blocks:
   - "feat-193"
+  - "feat-198"
 tags:
   - "admin"
   - "mastra"

--- a/docs/roadmap/content-discovery/feat-198-keyword-first-brand-entity-search.md
+++ b/docs/roadmap/content-discovery/feat-198-keyword-first-brand-entity-search.md
@@ -1,0 +1,151 @@
+---
+id: "feat-198"
+title: "Keyword-first brand and entity search ranking"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-06-22"
+duration: 4
+depends_on:
+  - "feat-192"
+blocks: []
+tags:
+  - "admin"
+  - "watch"
+  - "search"
+  - "keyword-first"
+  - "semantic-search"
+  - "evals"
+  - "embeddings"
+  - "launch-readiness"
+---
+
+## Problem
+
+Keyword-first search still fuses semantic-video and lexical retrievers through
+RRF. After feat-192, semantic-video is transcript-only and production backfills
+can mutate that live signal while they run. For brand/entity queries such as
+`Bible Project`, generic fusion can let unrelated lexical matches combine with
+semantic hits and outrank the known BibleProject corpus.
+
+The observed culprit is that `Bible` + `Project` in a description can be
+treated too strongly. For example, "Rescue Project" rows can satisfy the token
+shape lexically while BibleProject rows whose titles do not literally say
+BibleProject depend on slug, core id, description, collection, or source
+membership evidence. The ranker needs to understand BibleProject as a
+source/corpus entity, not only as title text.
+
+## Evidence
+
+- Baseline export:
+  `docs/search-eval-baselines/temporary/prod-seed-baseline-2026-06-02-export.json`
+  includes `seed-bible-project` results where `The BibleProject Collection`
+  ranked first, but adjacent leakage already existed.
+- Mastra eval report:
+  `docs/search-eval-reports/2026-06-03-local-english-post-batch-search-eval.json`
+  passed in broad `hybrid` mode, but did not protect keyword-first brand/entity
+  ranking.
+- Current Watch/Admin path:
+  `apps/web/src/lib/search.ts` requests `keyword-first`; Admin fuses
+  `semantic-video`, `keyword-weighted-video`, `trigram-video`, and
+  `exact-title-video` in `apps/admin/src/services/hybrid-search.service.ts`.
+- Fusion is handled by `apps/admin/src/services/hybrid-search-fusion.ts`;
+  retriever SQL is in `apps/admin/src/services/hybrid-search-retrievers.ts`.
+- BibleProject videos often have identifying slug/core id/description/source
+  evidence even when the visible title does not say `BibleProject`.
+
+## What To Build
+
+1. Add a brand/entity recognition path before generic RRF for multi-token
+   proper-name queries such as `Bible Project`.
+2. When an exact title, known source, collection, slug, or corpus-membership
+   match fires, rank that entity set first and let generic semantic retrieval
+   fill after.
+3. Treat description-only token matches as weaker than title/source/collection
+   membership. Description text containing both `Bible` and `Project` must not
+   outrank known BibleProject corpus rows by itself.
+4. Expand source/corpus membership for BibleProject using the available Admin
+   data: collection rows, slugs, core ids, descriptions, and any source
+   metadata that reliably identifies BibleProject content.
+5. Change semantic interaction for brand/entity queries: either downweight
+   semantic contribution when entity evidence fires, or only allow semantic
+   reranking inside the matched entity set before appending generic semantic
+   fill results.
+6. Add keyword-first eval cases for `Bible Project`, `the Bible project`,
+   `BibleProject`, and agreed aliases. These evals must run against the
+   keyword-first production-like path, not only broad `hybrid` mode.
+7. Design the staged/versioned embedding promotion path needed before future
+   relevance-affecting backfills. Search should not automatically read a new
+   embedding generation before eval passes and an active generation is switched.
+
+## Entry Points - Read These First
+
+- `apps/admin/src/services/hybrid-search.service.ts` - keyword-first
+  orchestration, retriever fusion, and public `semantic-video` family routing.
+- `apps/admin/src/services/hybrid-search-fusion.ts` - RRF scoring and result
+  merge behavior.
+- `apps/admin/src/services/hybrid-search-retrievers.ts` - semantic transcript,
+  lexical, trigram, and exact-title SQL retrievers.
+- `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts` -
+  keyword-first lexical weighting patterns.
+- `apps/admin/src/services/hybrid-search-retrievers.test.ts` and
+  `apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts` -
+  existing retriever assertions.
+- `apps/web/src/lib/search.ts` - Watch/Web caller that requests
+  `keyword-first`.
+- `docs/search-eval-baselines/temporary/prod-seed-baseline-2026-06-02-export.json`
+  - baseline evidence for `seed-bible-project`.
+- `docs/search-eval-reports/2026-06-03-local-english-post-batch-search-eval.json`
+  - broad hybrid eval report that missed this brand/entity regression.
+
+## Grep These
+
+- `rg -n "keyword-first|keywordFirst|semantic-video|exact-title-video" apps/admin/src/services apps/web/src`
+- `rg -n "BibleProject|Bible Project|Rescue Project|seed-bible-project" docs apps/admin/src`
+- `rg -n "reciprocal|RRF|fuse|weighted" apps/admin/src/services/hybrid-search*`
+- `rg -n "collection|source|slug|core_id|description" apps/admin/src/services/hybrid-search* apps/admin/prisma/schema.prisma`
+
+## Constraints
+
+- Preserve the existing frontend API contract; Watch should continue using the
+  current search endpoint and mode.
+- Do not re-enable scene embedding retrieval. `semantic-video` is the public
+  family name, but its evidence should remain transcript-backed after feat-192.
+- Brand/entity exactness should outrank description-only token coincidence, but
+  generic semantic fill should still work after the entity set is exhausted.
+- Add eval coverage that runs the keyword-first path specifically; broad
+  `hybrid` eval passing is not sufficient.
+- Treat staged/versioned embedding promotion as a relevance safety requirement.
+  If not implemented in this ticket, file or link the follow-up before another
+  relevance-affecting production backfill.
+
+## Acceptance Criteria
+
+- `Bible Project`, `the Bible project`, and `BibleProject` return
+  `The BibleProject Collection` or known BibleProject corpus children in the
+  top slots.
+- Rescue Project rows do not outrank known BibleProject corpus rows for
+  BibleProject brand/entity queries unless the query adds Rescue-specific
+  terms.
+- Description-only `Bible` + `Project` evidence is weaker than
+  title/source/collection/corpus-membership evidence.
+- Semantic-video still contributes useful fill results, but it does not
+  override strong brand/entity evidence.
+- Keyword-first eval coverage fails before the ranking fix and passes after
+  the fix.
+- The eval report names the exact search mode, data source, and retriever
+  strategy under test.
+- A staged/versioned embedding promotion plan exists before the next
+  relevance-affecting backfill, either implemented here or captured as a
+  separate follow-up ticket with this ticket depending on it.
+
+## Verification
+
+- Add focused Admin service tests around entity detection, retriever weighting,
+  and fusion behavior.
+- Add or update Mastra/search eval fixtures so brand/entity queries are judged
+  in keyword-first mode.
+- Run a production-like eval before and after the ranking change and compare
+  BibleProject/Rescue Project ordering.
+- Confirm the Watch frontend continues to call the same search API contract;
+  this should be a backend ranking/eval change, not a frontend API change.

--- a/docs/solutions/runtime-errors/mastra-launch-timeout-env-string-network-error.md
+++ b/docs/solutions/runtime-errors/mastra-launch-timeout-env-string-network-error.md
@@ -1,0 +1,90 @@
+---
+title: Mastra launch timeout env strings caused instant network errors
+date: 2026-06-19
+category: runtime-errors
+module: apps/admin Mastra embedding launch clients
+problem_type: runtime_error
+component: service_object
+symptoms:
+  - Transcript embedding launch failed in about 1ms with reason network_error
+  - Admin diagnostics logged TypeError delay argument must be number
+  - Production env contained a numeric timeout value as a string
+root_cause: config_error
+resolution_type: code_fix
+severity: high
+tags: [mastra, transcript-embeddings, env, timeout]
+---
+
+# Mastra Launch Timeout Env Strings Caused Instant Network Errors
+
+## Problem
+
+The production transcript embedding smoke still failed after AI Gateway health
+was proven and Admin launch diagnostics were deployed. The new diagnostics
+showed the actual throw happened before any Mastra request was sent:
+`AbortSignal.timeout` received the string value `"1200000"` instead of a
+number.
+
+## Symptoms
+
+- The workflow report showed `reason: "network_error"` for the target.
+- The per-target duration was about 1ms, so the request was not waiting on a
+  long AI Gateway embedding call.
+- Admin logs emitted `mastra_transcript_embedding_launch_threw` with
+  `TypeError: The "delay" argument must be of type number`.
+
+## What Didn't Work
+
+- Changing production env values alone would not address the class of bug:
+  Node env vars are strings, and some runtime paths can still surface string
+  values even when schema definitions use numeric coercion.
+- Continuing the full backfill would have repeated the same instant failure
+  for every target.
+
+## Solution
+
+Normalize timeout values at the Admin to Mastra launch boundary before passing
+them into `AbortSignal.timeout`.
+
+```ts
+export function resolveMastraLaunchTimeoutMs(
+  value: number | string | undefined,
+  fallbackMs = 120_000,
+): number {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isInteger(parsed) && parsed > 0) return parsed
+  }
+
+  return fallbackMs
+}
+```
+
+Use that resolver in the transcript, scene, and experience Admin launch
+clients so all Mastra embedding launchers tolerate numeric env strings.
+
+## Why This Works
+
+`AbortSignal.timeout` validates its `delay` argument at call time. If a runtime
+env value reaches it as a string, the function throws synchronously and the
+launch client reports a retryable network error without opening a network
+connection. Coercing at the call boundary converts valid numeric env strings
+and falls back safely for invalid values.
+
+## Prevention
+
+- Treat env-derived timeout and delay values as untrusted at the boundary where
+  they enter Node timer APIs.
+- Add regression tests for production-shaped numeric strings, not only typed
+  number inputs.
+- When a target fails in 1-2ms, inspect synchronous client setup before blaming
+  the downstream provider.
+
+## Related Issues
+
+- PR #1320: `fix(admin): normalize Mastra launch timeout env values`
+- `docs/solutions/runtime-errors/mastra-transcript-launch-network-error-diagnostics.md`

--- a/docs/solutions/runtime-errors/mastra-transcript-launch-network-error-diagnostics.md
+++ b/docs/solutions/runtime-errors/mastra-transcript-launch-network-error-diagnostics.md
@@ -1,0 +1,123 @@
+---
+title: Mastra transcript launch network errors need upstream diagnostics
+date: 2026-06-19
+category: runtime-errors
+module: apps/admin transcript embedding backfill
+problem_type: runtime_error
+component: service_object
+symptoms:
+  - Production transcript embedding smoke returned failed targets with reason network_error
+  - Direct AI Gateway model and embedding probes were healthy
+  - Admin logs did not show the upstream Mastra status or response body
+root_cause: missing_tooling
+resolution_type: code_fix
+severity: high
+tags: [transcript-embeddings, mastra, ai-gateway, railway]
+---
+
+# Mastra Transcript Launch Network Errors Need Upstream Diagnostics
+
+## Problem
+
+The production transcript embedding backfill smoke failed with `network_error`
+even after direct AI Gateway probes proved the gateway could serve embedding
+requests. The Admin launch client collapsed thrown fetches and non-workflow
+Mastra responses into the same retryable result, so operators could not tell
+whether the failure was DNS, auth, route registration, a bad upstream status, or
+another handoff problem.
+
+## Symptoms
+
+- A one-target Admin GraphQL trigger returned HTTP 200 but reported the target
+  as failed with reason `network_error`.
+- Direct production probes from the Mastra environment to `/v1/models` and
+  `/v1/embeddings` returned healthy responses.
+- Mastra route logs did not show a matching transcript embedding request.
+- The Admin workflow emitted target failure logs, but the launch client did not
+  preserve thrown fetch messages or non-OK response details.
+
+## What Didn't Work
+
+- Treating `network_error` as proof that AI Gateway was down did not hold once
+  direct model and embedding probes succeeded.
+- Retrying the broad backfill would have been noisy and potentially expensive
+  because the single-target smoke still failed through the same opaque launch
+  path.
+- Checking only service-level Railway health was not enough: Admin, Admin
+  worker, Mastra, and AI Gateway could all be online while the Admin to Mastra
+  launch contract still failed.
+
+## Solution
+
+Add structured diagnostics at the Admin launch boundary in
+`apps/admin/src/services/mastra-transcript-embedding-client.ts`:
+
+```ts
+try {
+  response = await fetch(endpoint, request)
+} catch (error) {
+  console.error(
+    JSON.stringify({
+      event: "mastra_transcript_embedding_launch_threw",
+      name: error instanceof Error ? error.name : "unknown",
+      message:
+        error instanceof Error
+          ? error.message.slice(0, 240)
+          : String(error).slice(0, 240),
+    }),
+  )
+  return { ok: false, reason: "network_error", retryable: true }
+}
+```
+
+Read the response body once, parse it as a workflow result when possible, and
+log a short status/body prefix when Mastra returns a non-workflow non-OK
+response:
+
+```ts
+const responseBody = await response.text().catch(() => undefined)
+const result = parseWorkflowResult(parseJsonBody(responseBody))
+if (result) return result
+
+if (!response.ok) {
+  logMastraLaunchFailure({
+    status: response.status,
+    statusText: response.statusText,
+    contentType: response.headers.get("content-type"),
+    body: responseBody,
+  })
+  return { ok: false, reason: "network_error", retryable: true }
+}
+```
+
+The runtime result semantics stay unchanged: callers still receive
+`network_error`, `auth_failed`, or `parse_error` as before. The difference is
+that production logs now preserve enough upstream context to decide the next
+fix.
+
+## Why This Works
+
+The embedding system has multiple health boundaries. AI Gateway health proves
+the provider can embed text; it does not prove Admin can launch a Mastra
+transcript embedding workflow. Logging the launch boundary separates provider
+health from route/auth/network failures between Admin and Mastra.
+
+Keeping the caller-facing result stable avoids changing retry behavior during a
+production incident, while preserving the upstream failure details needed to
+debug safely.
+
+## Prevention
+
+- Before retrying a full transcript embedding backfill, prove the smallest
+  representative target works end to end.
+- When direct AI Gateway probes are green but Admin still reports
+  `network_error`, inspect Admin to Mastra launch diagnostics instead of
+  assuming the provider is down.
+- Keep broad backfill retries behind a one-target smoke until logs show the
+  launch request reaches Mastra and the workflow returns a typed result.
+
+## Related Issues
+
+- PR #1319: `fix(admin): log Mastra transcript launch failures`
+- `docs/solutions/runtime-errors/useworkflow-nested-group-step-event-log-corruption.md`
+- `docs/solutions/architecture-patterns/provider-bound-content-embedding-backfill-gate-pattern.md`

--- a/docs/solutions/runtime-errors/useworkflow-nested-group-step-event-log-corruption.md
+++ b/docs/solutions/runtime-errors/useworkflow-nested-group-step-event-log-corruption.md
@@ -1,6 +1,7 @@
 ---
 title: "useworkflow group fanout must run inside one durable step"
 date: "2026-06-18"
+last_updated: "2026-06-20"
 category: runtime-errors
 module: apps/admin
 problem_type: runtime_error
@@ -113,11 +114,23 @@ The split also keeps the workflow file import graph cleaner. `transcriptEmbeddin
 
 ## Prevention
 
-- Treat grouped backfill fanout as one durable step boundary. Do not call the same `"use step"` function dynamically from `groups.map(...)`.
-- Keep the repeated per-group operation as a plain helper inside the plural step module.
+- Do not call the same `"use step"` function dynamically from
+  `groups.map(...)` or any other parallel fanout in workflow scope.
+- Keep repeated in-step group work as plain helpers when the whole workload can
+  finish comfortably inside the worker step runtime budget.
+- If one plural step grows too large for production, split the workload into
+  target-bounded sequential step calls at workflow scope. Keep each step's
+  internal fanout small, and use workflow-level `sleep()` for long waits.
 - If the fanout needs Node-only services, put the plural wrapper in an external `_steps/*` module and import only that single wrapper from the workflow file.
 - Add a structural guard test when fixing this class of bug. It should assert the workflow calls the plural external step wrapper once and no longer performs `Promise.allSettled(groups.map(...step...))` in workflow scope.
 - Build or smoke the production workflow enough to exercise workflow manifest and step discovery. Local unit tests are still useful, but they cannot prove production event-log validity.
+
+Update on 2026-06-20: the enriched transcript backfill outgrew the single
+plural step and failed at the Graphile worker boundary around 300 seconds.
+That newer fix keeps the event-log lesson here, but changes the shape from
+"one giant plural step" to "sequential target-bounded plural steps." See
+[Transcript embedding backfills need cancellable resume batches](../workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md)
+for the operational pattern.
 
 ## Related
 

--- a/docs/solutions/workflow-issues/bound-durable-workflow-step-payloads-before-persistence.md
+++ b/docs/solutions/workflow-issues/bound-durable-workflow-step-payloads-before-persistence.md
@@ -1,0 +1,134 @@
+---
+title: "Bound durable workflow step payloads before persistence"
+date: "2026-06-22"
+category: workflow-issues
+module: apps/admin workflow backfills
+problem_type: workflow_issue
+component: background_job
+severity: high
+applies_when:
+  - "A useworkflow step receives a growing list of pending work or confirmations"
+  - "A durable backfill polls external provider work after the launch request returns"
+  - "A resume flow must skip only rows already written by the current embedding generation"
+tags:
+  - admin
+  - useworkflow
+  - graphile
+  - backfill
+  - transcript-embeddings
+  - resume
+  - step-payloads
+  - hotfix
+---
+
+# Bound durable workflow step payloads before persistence
+
+## Context
+
+The June 2026 enriched transcript embedding backfill was already split into
+target-bounded processing steps, but the confirm-ingest phase still passed the
+entire pending confirmation list into one durable step. When enough Mastra
+launches timed out at the Admin request boundary, the pending list grew large
+and confirm-ingest steps crossed the Graphile worker task boundary. Production
+then failed the Workflow run with an unconsumed `step_started` event even
+though many individual transcript ingests had succeeded.
+
+The root issue was not AI Gateway availability. The workflow was asking the
+durable runtime to persist too much step input/output around a long-running
+confirmation boundary.
+
+## Guidance
+
+Treat every `"use step"` argument and return value as a persisted event-log
+contract. If a list can grow with corpus size, slice it before the durable step
+call.
+
+Bad shape:
+
+```ts
+// The step may batch internally, but Workflow still persists the whole list.
+const confirmed = await stepConfirmTranscriptEmbeddingIngests(pending)
+```
+
+Better shape:
+
+```ts
+const { slice, remainder } = splitPendingConfirmations(
+  pending,
+  confirmationBatchLimit,
+)
+
+const confirmed = await stepConfirmTranscriptEmbeddingIngests(slice)
+const unresolved = removeConfirmed(slice, confirmed)
+pending = [...remainder, ...unresolved]
+```
+
+Use the same rule for terminal failure marking. If unresolved pending work
+must be converted into failed outcomes, call the failure step with bounded
+slices rather than one final all-pending array.
+
+For long confirmation windows, track budget in full queue cycles, not raw step
+calls. A queue of 26 pending confirmations with a limit of 25 needs two slices
+per poll cycle. A fixed "max polls plus one" budget can fail the tail before it
+gets the same number of chances as the head.
+
+Resume guards need the same precision. A row is safe to skip only when it was
+written by the current generation and has complete searchable data:
+
+- current `generation_mode`
+- accepted model stamp
+- expected embedding dimensions
+- current embedding provider
+- non-empty source provenance
+- every chunk has an embedding
+- every chunk has non-empty embedded input text
+
+Do not call legacy, stale provider/model, `force`, zero-chunk, or incomplete
+rows "healthy" for resume-skip purposes.
+
+## Why This Matters
+
+Batching inside a step does not protect the durable runtime when the step
+itself receives the full payload. The event log must still persist that input,
+then persist the output. Once the worker crosses its task boundary, retry and
+replay can produce duplicate or unconsumed step events, which turns a recoverable
+provider wait into a failed parent Workflow run.
+
+Slicing before the step keeps each persisted event bounded. Rotating unresolved
+items to the tail gives every target a chance to confirm without starving later
+items, while a cycle-based wait budget avoids prematurely failing large queues.
+
+Strict resume predicates protect cost and relevance. The operator can safely
+resume from the latest known failed core without rerunning already-current
+language rows, and without accidentally skipping stale embeddings that still
+need the hotfixed path.
+
+## When to Apply
+
+- A background workflow has a `pending`, `failed`, `unconfirmed`, or
+  `toProcess` list that can grow with the production corpus.
+- The workflow waits for external systems after launching work, especially
+  provider jobs that can complete after the caller times out.
+- A broad backfill needs resume semantics that preserve already-current rows
+  while retrying legacy or incomplete rows.
+- Local tests pass but production useworkflow or Graphile logs show
+  `step_started`, unconsumed-event, event-log, or task-boundary failures.
+
+## Test Checklist
+
+- Assert the step receives at most the configured batch size, not just that a
+  helper returns the right count.
+- Cover a multi-slice final wait before the first sleep.
+- Cover queues whose length exceeds exactly one batch.
+- Cover resume predicates for stale generation mode, stale model, stale
+  provider, missing provider, stale dimensions, missing source kind, empty
+  source kind, incomplete chunks, missing embedded input text, and zero chunks.
+- Cover the production resume trigger shape: scoped by the latest failed core
+  id, no language filter, and `MODEL_UPGRADE` mode.
+
+## Related
+
+- [Transcript embedding backfills need cancellable resume batches](transcript-embedding-backfill-cancel-and-resume-operations.md)
+- [useworkflow group fanout must run inside one durable step](../runtime-errors/useworkflow-nested-group-step-event-log-corruption.md)
+- [Mastra transcript launch network error diagnostics](../runtime-errors/mastra-transcript-launch-network-error-diagnostics.md)
+- [Bounded parallelism pattern for admin per-target useworkflow loops](../best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md)

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -594,7 +594,7 @@ The June 22 hotfix changed the transcript backfill runner in two places:
    `already_enriched_healthy` only when the existing row has the current
    model-upgrade provenance: `generation_mode = 'model-upgrade'`, the accepted
    transcript embedding model stamp, `embedding_provider =
-   'jesus-film-ai-gateway'`, expected dimensions, a non-null source kind, every
+'jesus-film-ai-gateway'`, expected dimensions, a non-null source kind, every
    chunk has an embedding, and every chunk has non-empty
    `embedding_input_text`. Legacy, incomplete, missing, stale `force`, stale
    provider/model, or v1 rows remain eligible.
@@ -606,10 +606,7 @@ filter:
 
 ```graphql
 mutation ResumeTranscriptEmbeddingBackfill {
-  triggerTranscriptEmbeddingBackfill(
-    mode: MODEL_UPGRADE
-    coreIds: ["1_jf-0-0"]
-  )
+  triggerTranscriptEmbeddingBackfill(mode: MODEL_UPGRADE, coreIds: ["1_jf-0-0"])
 }
 ```
 

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -1,7 +1,7 @@
 ---
 title: "Transcript embedding backfills need cancellable resume batches"
 date: "2026-06-19"
-last_updated: "2026-06-20"
+last_updated: "2026-06-22"
 category: workflow-issues
 module: apps/admin transcript embedding backfill
 problem_type: workflow_issue
@@ -478,6 +478,151 @@ Deploy both `@forge/admin` and `@forge/admin/worker` before retrying this
 class of hotfix. The GraphQL surface starts the run, but the worker service is
 the process executing the target-sharded steps.
 
+### Monitor checkpoint: 2026-06-21 paused live babysitting
+
+After the target-sharded hotfix was deployed, a fresh production all-language
+run `wrun_01KVJ5MSF2V6EEMG7FDQQKFF84` was started through the existing Admin
+GraphQL trigger with no `coreIds` and no `languages` filters. The start log
+reported `totalTargets=208073`, `groupCount=1452`, `groupBatchCount=4162`,
+`stepTargetLimit=50`, `stepMaxDurationMs=220000`, `launchTimeoutMs=120000`,
+`concurrency=5`, and `languageFilter=null`.
+
+Live monitoring through 2026-06-21 08:23 UTC showed the parent Workflow run
+still `running`, with 516 completed durable steps and one running step. The
+latest step had no error. Admin storage showed 4,992 transcript rows touched
+since the run start, spanning 303 languages and 121 videos. The current
+`1_jf-0-0` section had written 39 transcript rows in this run window. The
+latest observed write was `1_jf-0-0` language `mxj` at
+2026-06-21 08:02:16 UTC from `manager-transcript` using
+`jesus-film-ai-gateway`.
+
+Many completed steps did not increase the transcript-row counter. Do not call
+those "skipped embeddings" without stronger evidence. In this monitor window,
+that phrase only meant "Workflow step completed without a new
+`video_transcript.updated_at >= run.started_at` row becoming the latest write."
+It can represent target batches with no usable subtitle/transcript source,
+already-satisfied rows, or other no-write outcomes; it is not by itself proof
+that valid embeddings were dropped or failed.
+
+At the operator's request, live babysitting was stopped after this checkpoint.
+The rough ETA from 516 of 4,162 reported group batches was June 27-28 UTC, but
+the estimate is sensitive to write-heavy versus no-write batches. Resume the
+status check around June 28, 2026 UTC by querying the Workflow row for
+`wrun_01KVJ5MSF2V6EEMG7FDQQKFF84`; do not start a new backfill unless the
+operator explicitly asks.
+
+### Terminal checkpoint: 2026-06-21 morning follow-up
+
+At 2026-06-21 20:46 UTC, production storage showed
+`wrun_01KVJ5MSF2V6EEMG7FDQQKFF84` as `failed`. The run started at
+2026-06-20 09:26:33 UTC and failed at 2026-06-21 12:20:19 UTC. The Workflow
+row had no JSON `error` or `output`, but Admin worker logs around the failure
+window showed the runtime cause:
+
+```text
+[Workflow] Workflow run failed with 1 uncommitted operation(s): step
+"step//./src/workflows/_steps/process-transcript-embedding-group//stepProcessTranscriptEmbeddingGroups".
+Did you forget to `await` a step, hook, or sleep call?
+
+WorkflowRuntimeError: Unconsumed event in event log:
+eventType=step_started,
+correlationId=step_01KVJ5MWKPA0TW759HW4VPBSAR,
+eventId=wevt_01KVN1Z8DSY297DP8T4C7RMWF3.
+```
+
+Immediately before that, Graphile worker logs showed confirm-ingest tasks
+hitting the roughly five-minute task boundary with `fetch failed`. The
+Workflow ledger showed all recorded step rows as `completed`, but the event log
+had more `step_started` events than consumable step completions:
+
+- 567 completed step rows.
+- 314 completed `stepProcessTranscriptEmbeddingGroups` rows.
+- 250 completed `stepConfirmTranscriptEmbeddingIngests` rows.
+- 570 `step_started` events, 568 `step_created` events, 567
+  `step_completed` events, and one `run_failed` event.
+- Three step ids had duplicate `step_started` events.
+
+This means the target-sharded run still hit the useworkflow/Graphile event-log
+corruption shape once confirm-ingest steps crossed the worker task boundary.
+It was not a clean all-language completion.
+
+Admin transcript storage nevertheless continued receiving late Mastra ingests
+after the parent Workflow failed. Since this run started, Admin showed 5,167
+transcript rows touched across 451 languages, 121 videos, and 177 video
+editions. The latest observed transcript write was 2026-06-21 17:18:58 UTC,
+and there were zero transcript writes in the following three hours as of the
+20:46 UTC check.
+
+Touched rows were mostly Manager transcript fallback writes:
+
+- 5,139 `manager-transcript` / `model-upgrade` rows.
+- 28 `subtitle` / `model-upgrade` rows.
+- 214 touched rows for `1_jf-0-0` across 211 languages.
+
+Global transcript health at that checkpoint was:
+
+- 9,311 enriched-healthy transcript rows.
+- 42,634 legacy or incomplete transcript rows.
+- 51,945 total transcript rows.
+- 5,463 transcript rows whose chunks all had demographics.
+- 4,897 transcript rows whose chunks all had felt-needs.
+
+Mastra workflow snapshots since the Admin run start showed 6,721
+`transcript-embedding` snapshots: 5,249 succeeded and 1,472 failed. The failed
+snapshots were all for `1_jf-0-0` with `provider_failed`: 1,383 marked
+non-retryable and 89 marked retryable. This confirms the earlier long-Jesus
+Film payload/provider-failure concentration persisted, even though some
+`1_jf-0-0` languages later succeeded and ingested.
+
+Do not call the production all-language backfill complete from this run. The
+next operational move needs another bounded-runner fix or a different resume
+surface before retrying the remaining all-language work. A plain rerun with the
+same confirm-ingest step shape risks recreating the same event-log corruption.
+
+### Hotfix checkpoint: 2026-06-22 bounded confirm and resume skip
+
+The June 22 hotfix changed the transcript backfill runner in two places:
+
+1. `stepConfirmTranscriptEmbeddingIngests` and
+   `stepFailPendingTranscriptEmbeddingIngests` are now called with bounded
+   pending-confirmation slices. The workflow caller slices before entering the
+   durable step, so Workflow storage no longer persists the full 600 KB+
+   pending list as one step input/output pair. Unresolved confirmations rotate
+   to the tail so long Mastra runs cannot starve later pending runs.
+2. `MODEL_UPGRADE` backfill processing now checks Admin transcript storage
+   before launching Mastra. A target is skipped with
+   `already_enriched_healthy` only when the existing row has the current
+   model-upgrade provenance: `generation_mode = 'model-upgrade'`, the accepted
+   transcript embedding model stamp, `embedding_provider =
+   'jesus-film-ai-gateway'`, expected dimensions, a non-null source kind, every
+   chunk has an embedding, and every chunk has non-empty
+   `embedding_input_text`. Legacy, incomplete, missing, stale `force`, stale
+   provider/model, or v1 rows remain eligible.
+
+Use the existing Admin GraphQL trigger for recovery. Do not start Mastra
+directly. To prove the fix at the latest known failure point without replaying
+already-upgraded rows, resume with the known failing core id and no language
+filter:
+
+```graphql
+mutation ResumeTranscriptEmbeddingBackfill {
+  triggerTranscriptEmbeddingBackfill(
+    mode: MODEL_UPGRADE
+    coreIds: ["1_jf-0-0"]
+  )
+}
+```
+
+The expected early signals are:
+
+- The start log includes `confirmationBatchLimit`.
+- Confirm-ingest step inputs stay bounded by that limit.
+- Healthy enriched `1_jf-0-0` language rows log
+  `reason=already_enriched_healthy` instead of launching provider work again.
+- Legacy or incomplete `1_jf-0-0` language rows still launch through Mastra and
+  ingest normally.
+- No confirm-ingest Graphile task runs near the 300 second boundary.
+
 ## Cleanup and Versioning Strategy
 
 Successful enriched transcript writes are upserts on the transcript identity
@@ -556,7 +701,8 @@ process needs to be restarted.
 
 ### Sizing resume work
 
-Count enriched versus legacy transcript rows before resuming:
+Count rows that the `MODEL_UPGRADE` resume guard will skip versus rows that
+still need processing before resuming:
 
 ```sql
 with transcript_health as (
@@ -564,6 +710,9 @@ with transcript_health as (
     vt.id,
     vt.source_kind,
     vt.generation_mode,
+    vt.model,
+    vt.dimensions,
+    vt.embedding_provider,
     vt.total_chunks,
     count(vtc.*) filter (
       where vtc.embedding is not null
@@ -578,28 +727,44 @@ with transcript_health as (
 )
 select
   count(*) filter (
-    where generation_mode in ('force', 'model-upgrade')
+    where generation_mode = 'model-upgrade'
+      and model in (
+        'openai/text-embedding-3-small',
+        'text-embedding-3-small',
+        'embeddings'
+      )
+      and dimensions = 1536
+      and embedding_provider = 'jesus-film-ai-gateway'
       and source_kind is not null
       and chunks_with_embedding_input_text = total_chunks
       and chunks_with_embedding = total_chunks
-  ) as enriched_healthy,
+  ) as resume_skip_eligible,
   count(*) filter (
     where not (
-      generation_mode in ('force', 'model-upgrade')
+      generation_mode = 'model-upgrade'
+      and model in (
+        'openai/text-embedding-3-small',
+        'text-embedding-3-small',
+        'embeddings'
+      )
+      and dimensions = 1536
+      and embedding_provider = 'jesus-film-ai-gateway'
       and source_kind is not null
       and chunks_with_embedding_input_text = total_chunks
       and chunks_with_embedding = total_chunks
     )
-  ) as legacy_or_incomplete
+  ) as needs_resume_processing
 from transcript_health;
 ```
 
-In the June 2026 recovery, this showed 2,228 enriched healthy transcript rows
-and 49,111 legacy-but-vector-healthy rows. The correct continuation was to
-resume the legacy set, not restart the full 208,073-target catalog.
+Earlier June 2026 recovery counts used a broader "enriched healthy" predicate
+that included `force` rows. That is useful for storage health, but it is not
+the resume-skip predicate. For resume sizing, use `resume_skip_eligible` above
+so operators and agents do not overestimate how much work will be skipped.
 
 ## Related
 
+- [Bound durable workflow step payloads before persistence](bound-durable-workflow-step-payloads-before-persistence.md)
 - [useworkflow group fanout must run inside one durable step](../runtime-errors/useworkflow-nested-group-step-event-log-corruption.md)
 - [Mastra transcript launch network error diagnostics](../runtime-errors/mastra-transcript-launch-network-error-diagnostics.md)
 - [Admin Postgres workflow operations pattern](../best-practices/admin-postgres-workflow-operations-pattern-20260501.md)

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -338,6 +338,45 @@ The regression coverage is split across the two services:
 The formal review for this hotfix is staged at
 `/tmp/compound-engineering/ce-code-review/20260620-071501-launch-timeout-correlation/report.md`.
 
+### Hotfix checkpoint: thrown launch timeouts must preserve run ids
+
+After the Admin worker received the launch-timeout correlation hotfix, the
+all-language run resumed and successfully wrote fresh `1_jf-0-0` transcript
+rows. Progress later paused with no Admin ingest writes after
+2026-06-20 07:45:27 UTC while two transcript Workflow runs still held locked
+Graphile jobs. A scoped recovery run was still active beside the original
+all-language run, so it was cancelled through Workflow's native CLI while
+preserving the original all-language run:
+
+```bash
+WORKFLOW_TARGET_WORLD='@workflow/world-postgres' \
+WORKFLOW_POSTGRES_URL="$DATABASE_PUBLIC_URL" \
+pnpm --filter @forge/admin exec workflow cancel \
+  wrun_01KVHRYGJMW6QP4TBD70HS39GT \
+  --backend @workflow/world-postgres
+```
+
+The focused code gap was in Admin's Mastra launch client. The previous
+correlation bridge preserved the caller run id for HTTP 5xx/429 responses and
+parse errors, but the `fetch` catch branch still returned a retryable
+`network_error` without `mastraRunId`. That branch is the one hit by thrown
+timeouts such as `TimeoutError`, so the backfill step could not poll Admin
+storage for a late successful ingest. It would classify the target as failed
+even though Admin had already generated a stable run id before the request.
+
+The fix in `apps/admin/src/services/mastra-transcript-embedding-client.ts`
+returns the generated `runId` on thrown `network_error` results and includes
+the same run id in the scrubbed launch-threw diagnostic log. Regression
+coverage in `apps/admin/src/services/mastra-transcript-embedding-client.test.ts`
+now simulates a thrown `TimeoutError` and asserts that the result preserves
+`mastraRunId`.
+
+When this hotfix is deployed, restart or redeploy `@forge/admin/worker` after
+the scoped run cancellation. The cancelled run's Workflow status changes
+immediately, but an already locked Graphile job can remain held until the
+running worker process unwinds. Restarting the worker kills the stale in-flight
+JavaScript loop and lets the runtime re-enqueue only active runs.
+
 ### Deployment checkpoint: Admin worker must receive Admin-side hotfixes
 
 The launch-timeout correlation hotfix changed both Admin web code and Admin

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -338,6 +338,40 @@ The regression coverage is split across the two services:
 The formal review for this hotfix is staged at
 `/tmp/compound-engineering/ce-code-review/20260620-071501-launch-timeout-correlation/report.md`.
 
+### Deployment checkpoint: Admin worker must receive Admin-side hotfixes
+
+The launch-timeout correlation hotfix changed both Admin web code and Admin
+workflow/backfill code. Deploying `@forge/admin` alone is not enough in
+production: the durable transcript backfill loop runs on the separate
+`@forge/admin/worker` Railway service. After the web and Mastra services were
+updated, `@forge/admin/worker` was still on the June 19 deployment from `main`,
+so re-enqueued transcript runs could continue using the old launch behavior.
+
+The operational fix was to deploy the same hotfix commit to the worker service:
+
+```bash
+railway up \
+  --project 98952497-a4d9-4714-8fe8-0cdbff3147c9 \
+  --environment production \
+  --service '@forge/admin/worker' \
+  --detach \
+  --message 'hotfix transcript embedding launch timeout correlation f4b48379'
+```
+
+Deployment `46f2c673-f3a3-4af7-b117-1b314989679b` reached `SUCCESS` on
+2026-06-20. Startup logs showed `No pending migrations to apply` followed by
+`[world-postgres] Re-enqueued 3 active run(s) on startup`, which confirmed the
+worker was live and had picked up active durable runs on the new code.
+
+When an Admin-side hotfix touches workflow steps, launch clients, ingest
+helpers, or any code reachable from a `"use workflow"` body, verify all three
+runtime surfaces before retrying production work:
+
+- `@forge/admin` for GraphQL trigger and internal Mastra ingest routes.
+- `@forge/admin/worker` for the durable Workflow loop and per-target launch
+  logic.
+- `@forge/mastra` for provider chunking, embedding, and Admin callback behavior.
+
 ## Cleanup and Versioning Strategy
 
 Successful enriched transcript writes are upserts on the transcript identity

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -238,6 +238,47 @@ broaden this hotfix into a chunking contract change during incident recovery;
 add a reviewed follow-up if operators need a hard max override or split-attempt
 budget.
 
+### Hotfix checkpoint: 2026-06-20 invalid Gateway envelopes and singleton retry
+
+After the split-batch hotfix was deployed, scoped retries were started through
+the existing Admin GraphQL mutation, one `coreId` at a time with only that
+core's failed languages. This avoided a corpus restart, but new
+`1_jf-0-0` snapshots still failed after the deploy with `provider_failed` and
+`retryable=false`.
+
+The important reproduction result was negative: the exact stored workflow input
+for a failed `1_jf-0-0/chk` run planned 35 chunks in five provider batches
+`[8, 8, 8, 8, 3]` with about 18.9k total chunk tokens, and every batch
+succeeded against the same AI Gateway when replayed in isolation. That proves
+the transcript payload itself was not intrinsically unembeddable. The remaining
+failure shape was load- or response-shape-sensitive: Gateway could still return
+an error that Mastra collapsed to `provider_failed retryable=false`, but the
+first split hotfix only recovered `upstream_failed` multi-chunk errors.
+
+The second Mastra hotfix keeps recovery narrow:
+
+- Treat `EmbeddingProviderError` codes `upstream_failed` and `invalid_response`
+  as recoverable Gateway provider errors.
+- Split only non-retryable recoverable multi-chunk errors. Retryable overload
+  errors are retried in place and are not split after retry exhaustion, because
+  splitting retryable 429/5xx-style failures amplifies load.
+- Retry unsplittable singleton recoverable errors with bounded exponential
+  backoff. This handles transient Gateway envelopes once a batch has already
+  been reduced to one chunk.
+- Keep the catch boundary around the provider call only. Post-provider
+  validation errors, such as a child batch returning the wrong number of
+  vectors, remain hard failures and cannot be hidden by further splitting.
+- Log scrubbed `transcript_embedding_batch_provider_retry` diagnostics with
+  run id, target, language, model, provider, request model, error code,
+  retryable flag, attempt, delay, chunk count, and token count. Do not log
+  transcript text, embedding input text, vectors, keys, or raw provider bodies.
+
+The formal review for this second hotfix is staged at
+`/tmp/compound-engineering/ce-code-review/20260620-053700-transcript-provider-retry/report.md`.
+It caught the retryable-error fanout risk before deploy; the fix now preserves
+the split fallback for non-retryable Gateway envelopes while avoiding extra
+load during retryable overload incidents.
+
 ## Cleanup and Versioning Strategy
 
 Successful enriched transcript writes are upserts on the transcript identity

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -19,6 +19,7 @@ tags:
   - cancellation
   - resume
   - railway
+  - timeout
 ---
 
 # Transcript embedding backfills need cancellable resume batches
@@ -278,6 +279,64 @@ The formal review for this second hotfix is staged at
 It caught the retryable-error fanout risk before deploy; the fix now preserves
 the split fallback for non-retryable Gateway envelopes while avoiding extra
 load during retryable overload incidents.
+
+### Hotfix checkpoint: 2026-06-20 launch timeout correlation and ingest retry
+
+After the provider split/retry hotfixes, fresh all-language backfill logs
+showed a different failure shape. Admin received a Mastra HTTP 504 after about
+180 seconds and recorded `transcript_index_failed reason=network_error`, but
+the corresponding Mastra workflow could continue past the Admin request
+boundary and ingest transcript rows later. Admin's own timeout was already set
+higher than the observed 180 second cutoff, so the likely boundary was the
+private HTTP/proxy path between Admin and Mastra, not the local fetch timeout.
+
+This creates a false-negative launch result: the target looks failed in the
+backfill report even though the run may still complete and write vectors.
+Retried targets can then overlap with an in-flight Mastra run, which also
+showed up as transient serializable/deadlock conflicts during transcript
+ingest (`P2034` and `P2010` with `40001`/`40P01`-style messages).
+
+The third hotfix keeps the synchronous endpoint but adds a correlation bridge:
+
+- Admin generates or accepts a caller run id for each Mastra launch and sends
+  the route body as `{ runId, input }`.
+- Mastra's `/forge-transcript-embeddings` route accepts that envelope and uses
+  the caller run id when creating the workflow run. Legacy callers can still
+  send the original raw workflow input body.
+- When Admin receives a retryable launch network error with a run id, the
+  backfill step polls Admin transcript storage for an exact
+  `video_edition_id`, `language`, and `mastra_run_id` match before marking the
+  target failed.
+- The confirmation query only succeeds when the transcript row has all chunks
+  present with non-null embeddings, so a partial write is not counted as a
+  successful backfill target.
+- Admin ingest retries the serializable transaction up to three attempts for
+  retryable Prisma transaction conflicts, logging only scrubbed correlation
+  fields.
+
+The important implementation boundary is that this is a bridge, not the final
+architecture. It prevents successful-but-slow Mastra runs from being reported
+as failed, but a first-class operator surface should eventually launch Mastra
+as an asynchronous job with a durable ledger or callback instead of waiting for
+the full workflow result through one HTTP request.
+
+The regression coverage is split across the two services:
+
+- `apps/mastra/src/mastra/workflows/transcript-embedding.test.ts` proves the
+  route accepts the caller run-id envelope and passes the same run id into the
+  workflow launcher.
+- `apps/admin/src/services/mastra-transcript-embedding-client.test.ts` proves
+  Admin preserves the caller run id on 504/network launch failures.
+- `apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts` proves a
+  timed-out launch is converted back to success when the exact Mastra run later
+  appears as a healthy transcript ingest row.
+- `apps/admin/src/services/transcript-embedding-ingest.service.test.ts` proves
+  retryable transcript transaction conflicts are retried, including the edge
+  case where the retryable Prisma code is on the top-level error and a nested
+  cause is non-retryable.
+
+The formal review for this hotfix is staged at
+`/tmp/compound-engineering/ce-code-review/20260620-071501-launch-timeout-correlation/report.md`.
 
 ## Cleanup and Versioning Strategy
 

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -1,0 +1,364 @@
+---
+title: "Transcript embedding backfills need cancellable resume batches"
+date: "2026-06-19"
+last_updated: "2026-06-20"
+category: workflow-issues
+module: apps/admin transcript embedding backfill
+problem_type: workflow_issue
+component: background_job
+severity: high
+applies_when:
+  - "Operating long-running embedding backfills through Admin Workflow"
+  - "Recovering after a GraphQL client timeout while the durable run continues"
+  - "Resuming enriched transcript embeddings without rewriting already-enriched rows"
+tags:
+  - admin
+  - useworkflow
+  - transcript-embeddings
+  - backfill
+  - cancellation
+  - resume
+  - railway
+---
+
+# Transcript embedding backfills need cancellable resume batches
+
+## Context
+
+The enriched transcript embedding backfill was triggered through
+`triggerTranscriptEmbeddingBackfill`, which starts a useworkflow run and then
+waits on `run.returnValue`. For small smokes that is fine. For full-corpus
+work, the HTTP caller can time out while the Workflow run keeps executing.
+
+On June 19, 2026, an unfiltered production `MODEL_UPGRADE` run enumerated
+208,073 transcript targets and 1,452 groups. The GraphQL caller received a
+Cloudflare 524 after roughly 125 seconds, but the Workflow run continued. The
+run had to be found from `workflow.workflow_runs`, cancelled by run id, and the
+Admin worker had to be restarted because the current step body kept launching
+work after the run was marked cancelled.
+
+## Guidance
+
+Treat a full transcript embedding backfill as an operator-controlled resume
+process, not as one giant GraphQL call.
+
+Use these rules when recovering or designing the next surface:
+
+- Return or record the Workflow run id immediately. Do not rely on a
+  long-lived GraphQL request to be the operator's only handle.
+- Select remaining work from storage state. Rows whose transcript chunks already
+  have enriched v2 fields such as `embedding_input_text`, structured metadata,
+  and source provenance should be skipped by resume mode.
+- Prefer bounded batches scoped by language and core id over the full
+  data-derived target catalog. The production data set can contain many more
+  target candidates than rows that actually need rewrite.
+- Make cancellation stop future launches promptly. A Workflow `run_cancelled`
+  event marks the run terminal, but it does not automatically interrupt an
+  already-running JavaScript loop inside a long step body.
+- If a run is already inside a giant step and still writing after cancellation,
+  restart the worker to kill the in-flight process, then verify that transcript
+  write logs stop.
+
+The safe recovery sequence used in production was:
+
+```text
+1. Find the active run in workflow.workflow_runs.
+2. Call Workflow's native cancel path for that run id.
+3. Verify the run status is cancelled.
+4. Watch worker logs for continued transcript writes.
+5. If writes continue, restart @forge/admin/worker.
+6. Verify fresh worker and Admin web log windows show no transcript writes.
+7. Resume with scoped language/coreId batches selected from legacy rows.
+```
+
+## Why This Matters
+
+The transcript backfill has side effects outside the Workflow event log:
+Mastra launches provider work and Admin ingest writes vectors. Once a long step
+has started, Workflow cancellation protects future replay, but it does not
+rewind or preempt arbitrary code already running inside that step.
+
+That distinction matters operationally. In the June 2026 recovery, the run was
+successfully marked `cancelled`, but the worker still wrote additional
+`transcript_index_complete` events until the worker deployment was restarted.
+Only a fresh log window with zero transcript writes confirmed containment.
+
+It also matters for cost and relevance. Existing enriched rows are upserts, so
+rerunning does not duplicate transcript rows, but it can still spend provider
+work rewriting healthy rows. A resume selector should preserve completed
+enriched rows and process only legacy or incomplete transcript embeddings.
+
+## June 20, 2026 All-Language Run Notes
+
+The production all-language run `wrun_01KVFXCQ9QWP17H2F8Q4FWZ64G` was started
+with no `coreIds` filter and no `languages` filter, so the Admin enumerator
+used the intended all-language/default path. Its start log reported
+`totalTargets=208073`, `groupCount=1452`, `languageFilter=null`, and
+`concurrency=5`. The GraphQL trigger request still returned a 524 because the
+resolver waits on the Workflow return value, but the Workflow row and worker
+logs proved the run continued.
+
+Do not confuse "the run is still writing" with "the all-language backfill is
+healthy." During the June 20 monitor window, Admin kept writing successful
+short transcript targets while long transcript targets such as `1_jf-0-0`
+repeatedly failed at the launch boundary. Admin recorded those as
+`transcript_index_failed` with `reason=network_error` and `durationMs` around
+180 seconds. Mastra storage showed the deeper state: many corresponding
+`transcript-embedding` workflow snapshots failed in `embed-transcript-chunks`
+with `provider_failed`, while other snapshots remained `running` after Admin
+had already moved on.
+
+The causal shape is:
+
+1. Admin launches Mastra through `/forge-transcript-embeddings`.
+2. The Mastra route starts `transcriptEmbeddingWorkflow` and waits for the full
+   workflow result before returning.
+3. Long transcript targets can exceed the request boundary, so Admin receives a
+   504/network failure and records the target failed.
+4. The Mastra workflow may keep running after Admin has already recorded the
+   failed launch, which can leave orphaned in-flight work and incomplete Admin
+   transcript rows.
+5. Mastra's provider client currently collapses non-OK provider responses into
+   `provider_failed` without persisting the provider HTTP status/body in the
+   workflow result, so operators cannot distinguish gateway rejections,
+   payload-size issues, and provider policy failures from storage alone.
+
+That means the final outcome report for this run must include both Admin row
+health and Mastra workflow snapshot health. Parent Workflow status alone is too
+weak: a `running` or eventually `completed` parent run can coexist with failed
+per-target launches.
+
+### Interim checkpoint: 2026-06-20 03:20 UTC
+
+The parent Workflow row was still `running` at 2026-06-20 03:16 UTC, and Admin
+storage was still receiving transcript writes through 03:17 UTC. At 03:17 UTC,
+Admin showed 4,278 transcript rows touched since the run start, spanning 369
+languages, 114 videos, and 162 video editions. The current enriched-healthy
+count was 8,119 transcript rows, with 43,513 rows still legacy or incomplete by
+the v2 health predicate.
+
+The live app logs showed the same split-brain shape as storage. Admin worker
+logs reported successful short-target completions for `1_jf6101-0-0` and
+`1_jf6102-0-0` while adjacent `1_jf-0-0` launches failed with Mastra HTTP 504
+responses and then `transcript_index_failed` events:
+
+```text
+2026-06-20T03:17:16Z mastra_transcript_embedding_launch_failed status=504 body={"error":"Gateway Timeout"}
+2026-06-20T03:17:16Z transcript_index_failed coreId=1_jf-0-0 language=bkq reason=network_error durationMs=180005
+2026-06-20T03:20:13Z transcript_index_failed coreId=1_jf-0-0 language=bla reason=network_error durationMs=180006
+```
+
+Mastra snapshots and app logs pointed at the deeper failure. Since 2026-06-20
+01:20 UTC, `transcript-embedding` snapshots showed 484 successes, 247 failures,
+and 39 running snapshots. All 247 failures were `1_jf-0-0` with
+`provider_failed` and `retryable=false`; their median transcript text length was
+about 58k characters. In the same window, `1_jf6101-0-0` had 340 successes and
+`1_jf6102-0-0` had 144 successes. This proves the gateway/provider path was not
+globally down; the failure concentrated on the long `1_jf-0-0` payload shape.
+
+Mastra app logs matched the snapshot result:
+
+```text
+Error executing step workflow.transcript-embedding.step.embed-transcript-chunks:
+TRANSCRIPT_EMBEDDING_WORKFLOW_FAILED:{"ok":false,"reason":"provider_failed","retryable":false}
+```
+
+The run was not terminal at this checkpoint. Do not treat these counts as the
+final outcome; use them to preserve the root-cause trail for the eventual final
+report.
+
+### Interim checkpoint: 2026-06-20 04:07 UTC
+
+The parent Workflow row was still `running` at 2026-06-20 04:07 UTC and Admin
+continued to receive transcript writes. The latest observed write was
+2026-06-20 04:07:24 UTC. At that point Admin showed 4,356 transcript rows
+touched since the run start, spanning 410 languages, 114 videos, and 162 video
+editions. The enriched-healthy count had moved to 8,197 transcript rows, while
+43,440 rows remained legacy or incomplete by the v2 health predicate.
+
+Mastra snapshots in the same recent monitor window showed 719 successes, 340
+failures, and 39 running `transcript-embedding` snapshots. The failure signature
+had not changed: failures were still concentrated on the long `1_jf-0-0`
+payload with `provider_failed` and `retryable=false`, while shorter
+`1_jf6101-0-0` and `1_jf6102-0-0` targets continued to complete successfully.
+
+This checkpoint is progress evidence, not completion evidence. The final report
+still needs the parent Workflow terminal state plus final Admin and Mastra
+health counts.
+
+### Hotfix checkpoint: 2026-06-20 split long provider batches
+
+The long-target failure was not a global AI Gateway outage. Direct gateway
+health checks worked, and short transcript targets kept succeeding. The
+production failure concentrated on long `1_jf-0-0` transcript payloads where
+Mastra returned `provider_failed` with `retryable=false` after the
+multi-chunk embedding request reached the provider.
+
+The targeted Mastra hotfix is in
+`apps/mastra/src/mastra/workflows/transcript-embedding.ts`:
+
+- Split fallback is narrow: only multi-chunk batches, only
+  `EmbeddingProviderError`, only `code === "upstream_failed"`, and only when
+  `retryable=false`.
+- Fallback recursively halves the batch until the provider accepts the smaller
+  requests or the error reaches a single chunk and propagates.
+- Every successful child response is validated against that child batch size
+  before combining, so compensating count mismatches cannot shift vectors onto
+  the wrong transcript chunks.
+- Combined split responses must agree exactly on dimensions, model, provider,
+  request model, native dimensions, and transform version before Admin ingest.
+- Split diagnostics are logged with scrubbed correlation fields:
+  `mastraRunId`, target identity, language, model, provider, request model,
+  error code, retryable flag, split depth/path, chunk count, and token count.
+  The log must not include transcript text, embedding input text, vectors,
+  API keys, request bodies, or raw provider bodies.
+
+The regression coverage is in
+`apps/mastra/src/mastra/workflows/transcript-embedding.test.ts`:
+
+- Recursive split from 4 chunks to singleton requests preserves Admin chunk
+  order and vector assignment.
+- Malformed child responses fail before Admin ingest.
+- Inconsistent split-child provenance fails before Admin ingest.
+- Split fallback warning logs contain safe operator correlation fields and do
+  not leak transcript text, embedding text, vectors, keys, or raw provider
+  messages.
+
+The formal review for this hotfix is staged at
+`/tmp/compound-engineering/ce-code-review/20260620-043548-hotfix/report.md`.
+Reviewers found and the hotfix addressed child count validation, strict
+provenance combination, recursive-depth test coverage, and scrubbed operator
+diagnostics.
+
+One residual operational risk remains: the default top-level provider batch is
+bounded by `DEFAULT_MAX_BATCH_CHUNKS = 8`, so worst-case split fallback is
+small on the normal path. A caller-supplied larger `maxBatchChunks` override
+can still amplify one rejected batch into up to `2N - 1` provider calls. Do not
+broaden this hotfix into a chunking contract change during incident recovery;
+add a reviewed follow-up if operators need a hard max override or split-attempt
+budget.
+
+## Cleanup and Versioning Strategy
+
+Successful enriched transcript writes are upserts on the transcript identity
+and chunk identity, so a successful target should not create duplicate
+transcript rows. The cleanup problem after the all-language run is therefore
+not "delete duplicates"; it is "remove or exclude legacy/incomplete rows that
+remain search-visible after the v2 backfill."
+
+Use this sequence after the run reaches a terminal state:
+
+1. Produce a final run report from Admin storage: parent Workflow status,
+   rows touched since the run start, enriched-healthy row count,
+   legacy/incomplete row count, and last write timestamp.
+2. Produce a Mastra-side target failure report: failed/running/success counts
+   for `transcript-embedding` snapshots since the run start, grouped by
+   `coreId`, reason, retryable flag, chunk count, and token count.
+3. Classify remaining legacy/incomplete rows into retryable provider failures,
+   source gaps/skips, and obsolete rows that should no longer participate in
+   semantic search.
+4. Do not run a manual delete as the first move. Prefer a reviewed cleanup
+   migration or operator job that takes an explicit final report as input and
+   deletes or disables only rows proven to be legacy/incomplete.
+5. Until a first-class backfill generation exists, treat the run start timestamp
+   plus v2 health fields (`generation_mode`, `source_kind`,
+   `embedding_input_text`, chunk embedding completeness) as the operational
+   version stamp.
+6. For the durable fix, add explicit embedding schema/version metadata such as
+   `embeddingSchemaVersion` and `backfillRunId` to transcript rows/chunks, or a
+   separate backfill generation table. Cleanup can then target all rows whose
+   version/run id is older than the accepted generation without relying on
+   inference from timestamps and nullable fields.
+
+Scoped retries can be useful after the final report identifies failed/missing
+targets, but they are recovery work. They should not be used to redefine an
+intended all-language run as complete.
+
+## When to Apply
+
+- A transcript or scene embedding backfill is large enough to exceed an HTTP
+  request budget.
+- A GraphQL trigger times out but Workflow storage shows the run still pending
+  or running.
+- A backfill must continue after an outage without rewriting already-upgraded
+  rows.
+- A useworkflow step wraps many provider launches or database writes inside one
+  step body.
+
+## Examples
+
+### Detecting the active run
+
+Use the Workflow ledger, not the timed-out GraphQL client, as source of truth:
+
+```sql
+select id, status, created_at, started_at, completed_at
+from workflow.workflow_runs
+where name ilike '%transcript%'
+order by created_at desc;
+```
+
+### Cancelling the run
+
+Use Workflow's native cancellation API when the run id is known:
+
+```ts
+import { getRun } from "workflow/api"
+
+await getRun(runId).cancel()
+```
+
+Then verify storage shows `status = 'cancelled'`. If worker logs still emit
+`transcript_index_complete`, the current step is still running and the worker
+process needs to be restarted.
+
+### Sizing resume work
+
+Count enriched versus legacy transcript rows before resuming:
+
+```sql
+with transcript_health as (
+  select
+    vt.id,
+    vt.source_kind,
+    vt.generation_mode,
+    vt.total_chunks,
+    count(vtc.*) filter (
+      where vtc.embedding is not null
+    ) as chunks_with_embedding,
+    count(vtc.*) filter (
+      where vtc.embedding_input_text is not null
+        and length(vtc.embedding_input_text) > 0
+    ) as chunks_with_embedding_input_text
+  from video_transcript vt
+  left join video_transcript_chunk vtc on vtc.transcript_id = vt.id
+  group by vt.id
+)
+select
+  count(*) filter (
+    where generation_mode in ('force', 'model-upgrade')
+      and source_kind is not null
+      and chunks_with_embedding_input_text = total_chunks
+      and chunks_with_embedding = total_chunks
+  ) as enriched_healthy,
+  count(*) filter (
+    where not (
+      generation_mode in ('force', 'model-upgrade')
+      and source_kind is not null
+      and chunks_with_embedding_input_text = total_chunks
+      and chunks_with_embedding = total_chunks
+    )
+  ) as legacy_or_incomplete
+from transcript_health;
+```
+
+In the June 2026 recovery, this showed 2,228 enriched healthy transcript rows
+and 49,111 legacy-but-vector-healthy rows. The correct continuation was to
+resume the legacy set, not restart the full 208,073-target catalog.
+
+## Related
+
+- [useworkflow group fanout must run inside one durable step](../runtime-errors/useworkflow-nested-group-step-event-log-corruption.md)
+- [Mastra transcript launch network error diagnostics](../runtime-errors/mastra-transcript-launch-network-error-diagnostics.md)
+- [Admin Postgres workflow operations pattern](../best-practices/admin-postgres-workflow-operations-pattern-20260501.md)
+- Linear follow-up: AI-67, transcript embedding backfill operator surface with resume, cancel, and progress controls.

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -411,6 +411,73 @@ runtime surfaces before retrying production work:
   logic.
 - `@forge/mastra` for provider chunking, embedding, and Admin callback behavior.
 
+### Hotfix checkpoint: target-sharded workflow batches avoid the 300s step ceiling
+
+A fresh all-language `MODEL_UPGRADE` run,
+`wrun_01KVJ27XMP17800AZY5R3FHJ0V`, was started through the existing Admin
+GraphQL trigger with no `coreIds` and no `languages` filters. That was the
+right all-language trigger shape, but it exposed a different Workflow runtime
+boundary: one giant `stepProcessTranscriptEmbeddingGroups` step attempted to
+own 208k targets and 1,452 groups.
+
+The worker logs showed the same durable step failing twice at roughly five
+minutes:
+
+```text
+[Graphile Worker] Failed task 27779 (workflow_steps, 300561.18ms, attempt 1 of 3) with error 'fetch failed'
+[Graphile Worker] Failed task 27779 (workflow_steps, 300457.84ms, attempt 2 of 3) with error 'fetch failed'
+```
+
+Workflow storage then showed the run on attempt 3 for
+`step//./src/workflows/_steps/process-transcript-embedding-group//stepProcessTranscriptEmbeddingGroups`.
+The run was cancelled before the last retry could burn more provider work.
+This failure was not an AI Gateway outage and not the earlier `1_jf-0-0`
+provider batch failure: Admin storage continued receiving transcript writes,
+and the failure was concentrated at the Workflow/Graphile task boundary.
+
+No reliable timeout knob was found in `@workflow/world-postgres` for this
+boundary. The queue worker posts each step to the local Workflow HTTP route,
+and the local execution failed around the same 300 second window. The fix is to
+make each step small enough that it naturally returns before that boundary:
+
+- Split each `(video, edition, language)` target into a one-target shard.
+- Persist runtime knobs in `stepResolveTranscriptEmbeddingRuntimeConfig` before
+  batching so workflow replay keeps the same partitioning even if Railway env
+  changes during a long run.
+- Pack shards into target-bounded batches using the default step target limit
+  of 50.
+- Call `stepProcessTranscriptEmbeddingGroups` sequentially per batch from the
+  workflow body. Parallelism stays inside each small batch, not across dynamic
+  workflow step fanout.
+- Inside a durable batch step, launch targets in waves capped by
+  `TRANSCRIPT_EMBEDDING_CONCURRENCY`. Stop launching new waves once the step
+  has spent the default 220 second budget, return unprocessed groups, and let
+  the workflow call the next durable step.
+- Pass a 120 second Admin-side launch timeout to Mastra. A long Mastra run can
+  continue and ingest later, but the Admin Workflow step returns before the
+  Graphile five-minute boundary.
+- Convert Mastra launch network errors that include a run id into pending
+  ingest confirmations instead of sleeping inside the worker step.
+- Check pending confirmations opportunistically between launch batches, then
+  drain any remaining pending confirmations with short
+  `stepConfirmTranscriptEmbeddingIngests` calls separated by workflow-level
+  `sleep()`, so the wait is durable and does not hold one Graphile task open.
+- Convert unresolved confirmations to `network_error` outcomes only after the
+  20 minute confirmation window.
+
+The tradeoff is deliberate. Manager fallback artifacts may be read once per
+durable step per `cmsVideoId` during a full backfill rather than once per
+whole run. The step-local loader caches source artifacts while a batch is
+active, but later batches may reread the same Manager artifact. That costs
+extra S3 reads, but it keeps every Workflow step bounded and avoids replaying a
+giant step after a five-minute worker failure. A future first-class
+ledger/generation table can optimize source reuse without putting the whole
+corpus back inside one step.
+
+Deploy both `@forge/admin` and `@forge/admin/worker` before retrying this
+class of hotfix. The GraphQL surface starts the run, but the worker service is
+the process executing the target-sharded steps.
+
 ## Cleanup and Versioning Strategy
 
 Successful enriched transcript writes are upserts on the transcript identity
@@ -457,6 +524,8 @@ intended all-language run as complete.
   rows.
 - A useworkflow step wraps many provider launches or database writes inside one
   step body.
+- A Graphile-backed Workflow step fails near 300 seconds even though per-target
+  provider and database work can still succeed.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

The production transcript embedding backfill can now be resumed from the latest known failed core without replaying already-current language rows. The fix keeps every durable confirm/fail step payload bounded before Workflow persists it, then uses strict current-generation provenance to decide when `MODEL_UPGRADE` can skip an existing transcript row.

This PR also carries the transcript/Mastra hotfix stack needed for the resume to work end to end: timed-out launch run ids are preserved for later Admin ingest confirmation, recoverable provider batch failures split and retry, and the runbooks now document the exact recovery path.

## Operational Shape

| Area | Now |
|---|---|
| Durable confirmations | Confirm-ingest and failure marking receive bounded slices, not the whole pending queue |
| Resume skip | Only current `model-upgrade` rows from `jesus-film-ai-gateway` with complete chunk embeddings and embedded input text are skipped |
| Latest failure retry | Resume via Admin GraphQL with `mode: MODEL_UPGRADE`, `coreIds: ["1_jf-0-0"]`, and no language filter |
| Operator docs | Runbook plus compound learning cover the Graphile/useworkflow task-boundary failure and recovery strategy |

## Verification

- `pnpm --filter @forge/admin test -- src/workflows/transcriptEmbeddingBackfill.test.ts src/graphql/mutations/transcript-embedding.test.ts src/services/transcript-embedding.service.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `git diff --check`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/workflow-issues/bound-durable-workflow-step-payloads-before-persistence.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
