### PR TITLE
fix(admin): reliably persist watch-route manifest after experience publish

### DIFF
--- a/apps/admin/src/services/experience.service.test.ts
+++ b/apps/admin/src/services/experience.service.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from "vitest"
+import { after } from "next/server"
 import type { Principal } from "@/auth/principal"
 import { ExperienceService } from "./experience.service"
 import { refreshWatchRouteManifest } from "./watch-route-manifest-refresh.service"
+
+// Override only `after` so the service's manifest-refresh scheduling is
+// observable; everything else in next/server stays real.
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>()
+  return { ...actual, after: vi.fn() }
+})
 
 vi.mock("./watch-route-manifest-refresh.service", () => ({
   refreshWatchRouteManifest: vi.fn().mockResolvedValue({ status: "refreshed" }),
@@ -69,6 +77,7 @@ describe("ExperienceService", () => {
     prisma = mockPrisma()
     service = new ExperienceService(prisma)
     vi.mocked(refreshWatchRouteManifest).mockClear()
+    vi.mocked(after).mockClear()
   })
 
   // ---------------------------------------------------------------------------
@@ -701,6 +710,50 @@ describe("ExperienceService", () => {
       expect(refreshWatchRouteManifest).toHaveBeenCalledWith({
         prisma,
         reason: "experience.publish",
+      })
+    })
+
+    it("schedules the manifest refresh through after() so it survives the response", async () => {
+      const localeRow = {
+        id: "loc-1",
+        experienceId: "exp-1",
+        locale: "en",
+        slug: "publish-after",
+        isHomepage: false,
+        pathSegment: null,
+        status: "DRAFT",
+        title: "Before publish",
+        metaDescription: null,
+        ogTitle: null,
+        ogDescription: null,
+        ogImageUrl: null,
+        blocks: [],
+        publishedAt: null,
+        createdAt: new Date("2026-04-15T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-15T12:00:00.000Z"),
+        experience: { ownerId: "alice", archivedAt: null },
+      }
+      prisma.experienceLocale.findUniqueOrThrow.mockResolvedValueOnce(localeRow)
+      prisma.experienceLocale.update.mockResolvedValueOnce({
+        ...localeRow,
+        status: "PUBLISHED",
+      })
+
+      await service.publishLocale({
+        input: { id: "loc-1" },
+        user: EDITOR_ALICE,
+      })
+
+      // The refresh is handed to after() rather than left as a bare detached
+      // promise — that is what keeps it alive past a standalone Server Action
+      // response so newly published slugs reach the persisted snapshot.
+      expect(after).toHaveBeenCalledTimes(1)
+      const scheduled = vi.mocked(after).mock.calls[0]?.[0] as () => unknown
+      expect(typeof scheduled).toBe("function")
+      // Invoking the scheduled task resolves to the refresh outcome and never
+      // throws (refreshWatchRouteManifest returns a typed outcome).
+      await expect(Promise.resolve(scheduled())).resolves.toEqual({
+        status: "refreshed",
       })
     })
 

--- a/apps/admin/src/services/experience.service.ts
+++ b/apps/admin/src/services/experience.service.ts
@@ -4,6 +4,7 @@
 // Read methods: (1) tier check, (2) role-based WHERE filtering, (3) Prisma call.
 // Resolvers delegate here; they never call Prisma directly for mutations.
 
+import { after } from "next/server"
 import { Prisma, type PrismaClient } from "@prisma/client"
 import { isEditorOrAdmin, type Principal } from "@/auth/principal"
 import {
@@ -42,6 +43,33 @@ function snapshotEnvelope(
   data: Prisma.InputJsonObject,
 ): Prisma.InputJsonObject {
   return { v: 1, data }
+}
+
+/**
+ * Refresh the watch-route manifest snapshot reliably without blocking the
+ * editor response.
+ *
+ * The refresh regenerates AND persists the snapshot apps/web reads to admit
+ * `/watch` routes, so it MUST run to completion — but the editor must not wait
+ * on it. A bare `void` is dropped when a Next standalone Server Action / route
+ * handler returns before the detached promise settles, which left freshly
+ * published experiences absent from the snapshot and their watch preview 404'd
+ * until the next refresh happened to land. We start the refresh immediately and
+ * hand the in-flight promise to `after()`, which keeps the runtime alive until
+ * it settles after the response is flushed. Outside a request scope (unit
+ * tests, CLIs) `after()` throws, so we fall back to the detached promise.
+ * `refreshWatchRouteManifest` never rejects (it returns a typed outcome), so
+ * neither path risks an unhandled rejection.
+ */
+function refreshManifestAfterResponse(
+  args: Parameters<typeof refreshWatchRouteManifest>[0],
+): void {
+  const refresh = refreshWatchRouteManifest(args)
+  try {
+    after(() => refresh)
+  } catch {
+    void refresh
+  }
 }
 
 function snapshotExperienceLocale(locale: {
@@ -319,7 +347,7 @@ export class ExperienceService {
           locale: updated.locale,
         })
       }
-      void refreshWatchRouteManifest({
+      refreshManifestAfterResponse({
         prisma: this.prisma,
         reason: "experience.update",
       })
@@ -400,7 +428,7 @@ export class ExperienceService {
         locale: published.locale,
       })
     }
-    void refreshWatchRouteManifest({
+    refreshManifestAfterResponse({
       prisma: this.prisma,
       reason: "experience.publish",
     })
@@ -558,7 +586,7 @@ export class ExperienceService {
       slug: null,
       locale: null,
     })
-    void refreshWatchRouteManifest({
+    refreshManifestAfterResponse({
       prisma: this.prisma,
       reason: "experience.archive",
     })


### PR DESCRIPTION
## Problem

Publishing an experience could leave its public **Preview** link 404'ing even though the locale showed **PUBLISHED** and met every admission rule.

`apps/web` only serves `/watch` URLs whose slug is in the route manifest snapshot that admin generates and persists. On publish / update / archive, `ExperienceService` refreshed that snapshot **fire-and-forget**:

```ts
void refreshWatchRouteManifest({ prisma: this.prisma, reason: "experience.publish" })
```

`refreshWatchRouteManifest` regenerates **and persists** the snapshot (a few DB queries), then webhooks web. In a Next standalone Server Action / GraphQL handler, that detached promise can be dropped when the response returns — so the regenerate+persist never completes and the freshly published slug never lands in the snapshot. Web then 404s the preview until some later refresh happens to run. Web's own manifest cache is only a 60s TTL, so this is an **admin-snapshot** durability bug, not web staleness.

Reproduced live: experience `hope-in-christ` showed PUBLISHED, non-template, non-homepage, not archived (fully eligible), yet `GET https://watch.jesusfilm.org/watch/hope-in-christ.html/english.html` → **404**, while the same URL shape for an admitted slug (`easter.html/english.html`) → 200.

## Fix

Schedule the refresh through `after()` so the runtime keeps it alive until it settles **after** the response is flushed. The editor still never blocks on it. Outside a request scope (unit tests, CLIs) `after()` throws, so we fall back to the detached promise — and `refreshWatchRouteManifest` never rejects, so neither path risks an unhandled rejection.

```ts
function refreshManifestAfterResponse(args) {
  const refresh = refreshWatchRouteManifest(args)
  try {
    after(() => refresh)   // kept alive past the response in standalone
  } catch {
    void refresh           // tests / CLIs: no request scope
  }
}
```

Applied to all three call sites: `publishLocale`, `updateLocale` (PUBLISHED path), and `archive`. The `emitRevalidateWebhook` calls are intentionally left fire-and-forget (web self-heals within its 60s TTL).

## Scope of recurrence

This is the recurring class of "new experience previews 404 until something else republishes." After this lands, a publish reliably writes the snapshot before the runtime can reclaim the work.

## Note (operational)

This fixes the durability going forward. An experience already missing from the **current** persisted snapshot (e.g. `hope-in-christ`) is re-admitted the next time any experience publish/update/archive regenerates the manifest — e.g. re-saving + re-publishing it.

## Testing

- `apps/admin` typecheck: clean
- `apps/admin` lint (changed files): clean
- `experience.service.test.ts`: 48/48 pass, including a new test asserting the refresh is scheduled through `after()` and that invoking the scheduled task resolves to the refresh outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
