### PR TITLE
fix(admin): bound transcript backfill targets within steps

### DIFF
--- a/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
+++ b/apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts
@@ -64,6 +64,17 @@ export type TranscriptIngestConfirmationBatchResult = {
   pendingConfirmations: PendingTranscriptIngestConfirmation[]
 }
 
+type TranscriptEmbeddingGroupResult =
+  TranscriptIngestConfirmationBatchResult & {
+    unprocessedGroup?: BackfillGroup
+  }
+
+type TranscriptEmbeddingDeferralBudget = {
+  elapsedMs: number
+  stepMaxDurationMs: number
+  launchTimeoutMs: number
+}
+
 type TranscriptIngestConfirmationRow = {
   total_chunks: number | bigint
   total_tokens: number | bigint
@@ -480,6 +491,34 @@ function logPendingConfirmation(
   }
 }
 
+function logTargetDeferral(
+  group: BackfillGroup,
+  targetIndex: number,
+  budget: TranscriptEmbeddingDeferralBudget,
+): void {
+  try {
+    console.log(
+      JSON.stringify({
+        workflow: "transcript-embedding-backfill",
+        event: "transcript_index_target_deferred",
+        coreId: group.coreId,
+        videoEditionId: group.videoEditionId,
+        processedTargets: targetIndex,
+        remainingTargets: group.targets.length - targetIndex,
+        elapsedMs: budget.elapsedMs,
+        stepMaxDurationMs: budget.stepMaxDurationMs,
+        launchTimeoutMs: budget.launchTimeoutMs,
+      }),
+    )
+  } catch (logErr) {
+    console.error(
+      `[transcript-embedding-backfill] logTargetDeferral failed: ${
+        logErr instanceof Error ? logErr.message : String(logErr)
+      }`,
+    )
+  }
+}
+
 /**
  * Plain per-group worker. This deliberately is NOT a `"use step"` function:
  * production useworkflow gives every call to the same step function the same
@@ -491,12 +530,43 @@ async function processTranscriptEmbeddingGroup(
   loadManagerSource: ManagerSourceLoader,
   launchTimeoutMs: number,
   healthyResumeTargets: ReadonlySet<string>,
-): Promise<TranscriptIngestConfirmationBatchResult> {
+  batchStartedAt: number,
+  stepMaxDurationMs: number,
+): Promise<TranscriptEmbeddingGroupResult> {
   const groupStartedAt = Date.now()
 
   const outcomes: BackfillOutcome[] = []
   const pendingConfirmations: PendingTranscriptIngestConfirmation[] = []
-  for (const target of group.targets) {
+  const deferFrom = (
+    targetIndex: number,
+    budget: TranscriptEmbeddingDeferralBudget,
+  ): TranscriptEmbeddingGroupResult => {
+    logTargetDeferral(group, targetIndex, budget)
+    return {
+      outcomes,
+      pendingConfirmations,
+      unprocessedGroup: {
+        ...group,
+        targets: group.targets.slice(targetIndex),
+      },
+    }
+  }
+
+  for (const [targetIndex, target] of group.targets.entries()) {
+    const preResolutionBudget = {
+      elapsedMs: Date.now() - batchStartedAt,
+      stepMaxDurationMs,
+      launchTimeoutMs,
+    }
+    if (
+      shouldDeferNextTranscriptEmbeddingLaunch({
+        launchesStarted: targetIndex,
+        ...preResolutionBudget,
+      })
+    ) {
+      return deferFrom(targetIndex, preResolutionBudget)
+    }
+
     const targetStartedAt = Date.now()
     if (
       mode === "model-upgrade" &&
@@ -561,6 +631,20 @@ async function processTranscriptEmbeddingGroup(
       )
     }
 
+    const preLaunchBudget = {
+      elapsedMs: Date.now() - batchStartedAt,
+      stepMaxDurationMs,
+      launchTimeoutMs,
+    }
+    if (
+      shouldDeferNextTranscriptEmbeddingLaunch({
+        launchesStarted: targetIndex,
+        ...preLaunchBudget,
+      })
+    ) {
+      return deferFrom(targetIndex, preLaunchBudget)
+    }
+
     const outcome = await launchTranscriptEmbedding(
       target,
       source,
@@ -613,8 +697,8 @@ export async function stepProcessTranscriptEmbeddingGroups(
 
   for (let i = 0; i < groups.length; i += safeConcurrency) {
     if (
-      shouldDeferNextTranscriptEmbeddingWave({
-        wavesStarted,
+      shouldDeferNextTranscriptEmbeddingLaunch({
+        launchesStarted: wavesStarted,
         elapsedMs: Date.now() - batchStartedAt,
         stepMaxDurationMs: safeStepMaxDurationMs,
         launchTimeoutMs,
@@ -634,6 +718,8 @@ export async function stepProcessTranscriptEmbeddingGroups(
           loadManagerSource,
           launchTimeoutMs,
           healthyResumeTargets,
+          batchStartedAt,
+          safeStepMaxDurationMs,
         ),
       ),
     )
@@ -643,6 +729,9 @@ export async function stepProcessTranscriptEmbeddingGroups(
       if (result.status === "fulfilled") {
         outcomes.push(...result.value.outcomes)
         pendingConfirmations.push(...result.value.pendingConfirmations)
+        if (result.value.unprocessedGroup) {
+          unprocessedGroups.push(result.value.unprocessedGroup)
+        }
         continue
       }
 
@@ -669,20 +758,20 @@ export async function stepProcessTranscriptEmbeddingGroups(
   return { outcomes, pendingConfirmations, unprocessedGroups }
 }
 
-export function shouldDeferNextTranscriptEmbeddingWave({
-  wavesStarted,
+export function shouldDeferNextTranscriptEmbeddingLaunch({
+  launchesStarted,
   elapsedMs,
   stepMaxDurationMs,
   launchTimeoutMs,
   safetyBufferMs = TRANSCRIPT_EMBEDDING_PROCESS_WAVE_SAFETY_BUFFER_MS,
 }: {
-  wavesStarted: number
+  launchesStarted: number
   elapsedMs: number
   stepMaxDurationMs: number
   launchTimeoutMs: number
   safetyBufferMs?: number
 }): boolean {
-  if (wavesStarted <= 0) return false
+  if (launchesStarted <= 0) return false
 
   const safeElapsedMs =
     Number.isFinite(elapsedMs) && elapsedMs > 0 ? elapsedMs : 0

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts
@@ -84,7 +84,7 @@ const {
   _internals,
 } = await import("./transcriptEmbeddingBackfill")
 const {
-  shouldDeferNextTranscriptEmbeddingWave,
+  shouldDeferNextTranscriptEmbeddingLaunch,
   stepProcessTranscriptEmbeddingGroups,
 } = await import("./_steps/process-transcript-embedding-group")
 
@@ -1042,10 +1042,190 @@ Subtitle transcript text.
     }
   })
 
+  it("defers remaining targets inside a large group when the next target launch would exceed the step budget", async () => {
+    vi.useFakeTimers()
+    vi.mocked(launchMastraTranscriptEmbedding).mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50_000))
+      return {
+        ok: true,
+        status: "created",
+        chunks: 1,
+        totalTokens: 4,
+        model: "openai/text-embedding-3-small",
+        provider: "openai",
+        dimensions: 1536,
+        mastraRunId: "run-1",
+        sourceContentHash: "sha256:test",
+      }
+    })
+
+    try {
+      const group = {
+        videoId: "v-a",
+        videoEditionId: "e-a",
+        coreId: "core-a",
+        cmsVideoId: 1,
+        targets: ["en", "es", "fr", "de"].map((language) =>
+          target("v-a", "e-a", "core-a", 1, language),
+        ),
+      }
+
+      const resultPromise = stepProcessTranscriptEmbeddingGroups(
+        [group],
+        "idempotent",
+        1,
+        100_000,
+        40_000,
+      )
+
+      await vi.advanceTimersByTimeAsync(50_000)
+      const result = await resultPromise
+
+      expect(result.outcomes.map((outcome) => outcome.language)).toEqual(["en"])
+      expect(result.pendingConfirmations).toEqual([])
+      expect(result.unprocessedGroups).toHaveLength(1)
+      expect(
+        result.unprocessedGroups[0]!.targets.map((target) => target.language),
+      ).toEqual(["es", "fr", "de"])
+      expect(launchMastraTranscriptEmbedding).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("keeps pending confirmations when deferring remaining targets inside a large group", async () => {
+    vi.useFakeTimers()
+    vi.mocked(launchMastraTranscriptEmbedding).mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50_000))
+      return {
+        ok: false,
+        reason: "network_error",
+        retryable: true,
+        mastraRunId: "run-timeout-continued",
+      }
+    })
+
+    try {
+      const group = {
+        videoId: "v-a",
+        videoEditionId: "e-a",
+        coreId: "core-a",
+        cmsVideoId: 1,
+        targets: ["en", "es", "fr", "de"].map((language) =>
+          target("v-a", "e-a", "core-a", 1, language),
+        ),
+      }
+
+      const resultPromise = stepProcessTranscriptEmbeddingGroups(
+        [group],
+        "idempotent",
+        1,
+        100_000,
+        40_000,
+      )
+
+      await vi.advanceTimersByTimeAsync(50_000)
+      const result = await resultPromise
+
+      expect(result.outcomes).toEqual([])
+      expect(result.pendingConfirmations).toHaveLength(1)
+      expect(result.pendingConfirmations[0]).toMatchObject({
+        language: "en",
+        mastraRunId: "run-timeout-continued",
+      })
+      expect(result.unprocessedGroups).toHaveLength(1)
+      expect(
+        result.unprocessedGroups[0]!.targets.map((target) => target.language),
+      ).toEqual(["es", "fr", "de"])
+      expect(launchMastraTranscriptEmbedding).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("rechecks the step budget after source resolution before launching later targets", async () => {
+    vi.useFakeTimers()
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+    let subtitleLookups = 0
+    ;(
+      prisma as unknown as {
+        videoSubtitle: { findMany: ReturnType<typeof vi.fn> }
+      }
+    ).videoSubtitle.findMany.mockImplementation(async () => {
+      subtitleLookups += 1
+      if (subtitleLookups === 2) {
+        await new Promise((resolve) => setTimeout(resolve, 35_000))
+      }
+      return []
+    })
+    vi.mocked(launchMastraTranscriptEmbedding).mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20_000))
+      return {
+        ok: true,
+        status: "created",
+        chunks: 1,
+        totalTokens: 4,
+        model: "openai/text-embedding-3-small",
+        provider: "openai",
+        dimensions: 1536,
+        mastraRunId: "run-1",
+        sourceContentHash: "sha256:test",
+      }
+    })
+
+    try {
+      const group = {
+        videoId: "v-a",
+        videoEditionId: "e-a",
+        coreId: "core-a",
+        cmsVideoId: 1,
+        targets: ["en", "es", "fr"].map((language) =>
+          target("v-a", "e-a", "core-a", 1, language),
+        ),
+      }
+
+      const resultPromise = stepProcessTranscriptEmbeddingGroups(
+        [group],
+        "idempotent",
+        1,
+        120_000,
+        40_000,
+      )
+
+      await vi.advanceTimersByTimeAsync(55_000)
+      const result = await resultPromise
+
+      expect(result.outcomes.map((outcome) => outcome.language)).toEqual(["en"])
+      expect(result.pendingConfirmations).toEqual([])
+      expect(result.unprocessedGroups).toHaveLength(1)
+      expect(
+        result.unprocessedGroups[0]!.targets.map((target) => target.language),
+      ).toEqual(["es", "fr"])
+      expect(launchMastraTranscriptEmbedding).toHaveBeenCalledTimes(1)
+      const deferralLog = logSpy.mock.calls
+        .map(
+          ([message]) => JSON.parse(String(message)) as Record<string, unknown>,
+        )
+        .find((message) => message.event === "transcript_index_target_deferred")
+      expect(deferralLog).toMatchObject({
+        coreId: "core-a",
+        videoEditionId: "e-a",
+        processedTargets: 1,
+        remainingTargets: 2,
+        stepMaxDurationMs: 120_000,
+        launchTimeoutMs: 40_000,
+      })
+      expect(deferralLog?.elapsedMs).toBe(55_000)
+    } finally {
+      logSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("keeps the first process wave eligible even when the configured budget is tight", () => {
     expect(
-      shouldDeferNextTranscriptEmbeddingWave({
-        wavesStarted: 0,
+      shouldDeferNextTranscriptEmbeddingLaunch({
+        launchesStarted: 0,
         elapsedMs: 90_000,
         stepMaxDurationMs: 100_000,
         launchTimeoutMs: 120_000,
@@ -1053,8 +1233,8 @@ Subtitle transcript text.
       }),
     ).toBe(false)
     expect(
-      shouldDeferNextTranscriptEmbeddingWave({
-        wavesStarted: 1,
+      shouldDeferNextTranscriptEmbeddingLaunch({
+        launchesStarted: 1,
         elapsedMs: 50_000,
         stepMaxDurationMs: 100_000,
         launchTimeoutMs: 40_000,
@@ -1062,8 +1242,8 @@ Subtitle transcript text.
       }),
     ).toBe(true)
     expect(
-      shouldDeferNextTranscriptEmbeddingWave({
-        wavesStarted: 1,
+      shouldDeferNextTranscriptEmbeddingLaunch({
+        launchesStarted: 1,
         elapsedMs: 49_999,
         stepMaxDurationMs: 100_000,
         launchTimeoutMs: 40_000,
@@ -1139,7 +1319,7 @@ describe("groupTargetsByVideoEdition", () => {
     expect(groups[1]?.targets.map((target) => target.language)).toEqual(["en"])
   })
 
-  it("batches groups by target count and shards oversized multilingual groups into single-target entries", () => {
+  it("batches groups by target count and shards oversized multilingual groups into target-limited chunks", () => {
     const groups = _internals.groupTargetsByVideoEdition([
       target("v-a", "e-a", "core-a", 1, "en"),
       target("v-a", "e-a", "core-a", 1, "es"),
@@ -1153,9 +1333,7 @@ describe("groupTargetsByVideoEdition", () => {
     const batches = _internals.batchGroupsByTargetLimit(groups, 5)
 
     expect(batches).toHaveLength(2)
-    expect(batches[0]?.map((group) => group.targets.length)).toEqual([
-      1, 1, 1, 1, 1,
-    ])
+    expect(batches[0]?.map((group) => group.targets.length)).toEqual([5])
     expect(
       batches[0]?.flatMap((group) =>
         group.targets.map((target) => target.language),

--- a/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
+++ b/apps/admin/src/workflows/transcriptEmbeddingBackfill.ts
@@ -274,8 +274,8 @@ export async function runTranscriptEmbeddingBackfill(
     : allTargets
 
   // Group flat targets by (video, edition) first so reporting and source-gap
-  // aggregation keep the same order. The runtime batcher below shards large
-  // groups by target so no single Workflow step owns a whole multilingual
+  // aggregation keep the same order. The runtime batcher below keeps target
+  // chunks bounded so no single Workflow step owns a whole multilingual
   // edition.
   const groups = groupTargetsByVideoEdition(targets)
 
@@ -701,14 +701,23 @@ function batchGroupsByTargetLimit(
   }
 
   for (const group of groups) {
-    for (const target of group.targets) {
-      if (currentTargetCount >= safeLimit) flush()
+    for (let targetIndex = 0; targetIndex < group.targets.length; ) {
+      const remainingBatchCapacity = safeLimit - currentTargetCount
+      if (remainingBatchCapacity <= 0) {
+        flush()
+        continue
+      }
 
+      const targets = group.targets.slice(
+        targetIndex,
+        targetIndex + remainingBatchCapacity,
+      )
       current.push({
         ...group,
-        targets: [target],
+        targets,
       })
-      currentTargetCount += 1
+      currentTargetCount += targets.length
+      targetIndex += targets.length
     }
   }
 

--- a/docs/plans/2026-06-22-003-fix-transcript-target-budget-plan.md
+++ b/docs/plans/2026-06-22-003-fix-transcript-target-budget-plan.md
@@ -1,0 +1,136 @@
+---
+title: "fix: Defer transcript targets inside oversized backfill groups"
+type: fix
+date: "2026-06-22"
+---
+
+# fix: Defer transcript targets inside oversized backfill groups
+
+## Summary
+
+The first June 22 workflow hotfix bounded process waves between groups, but a
+scoped `1_jf-0-0` resume showed one `(video, edition)` group can still contain
+hundreds of language targets. The hotfix will keep production batches as
+target-limited group chunks, then stop launching additional language targets
+inside a group once the next target launch cannot safely fit inside the
+durable step budget.
+
+---
+
+## Problem Frame
+
+Production run `wrun_01KVPQTTTQJGSWKET22FB3V156` was started as the intended
+scoped recovery shape: `MODEL_UPGRADE`, `coreIds: ["1_jf-0-0"]`, and no
+language filter. Early process and confirm steps were healthy, but a later
+process step again approached the workflow task-boundary corruption shape.
+
+The remaining gap was both batching shape and inner-loop runtime. The outer
+process step now defers later group waves, but `1_jf-0-0` is one large group
+whose `targets` loop can still launch many language targets sequentially inside
+one durable step. The production batcher must therefore preserve bounded
+multi-target group chunks instead of converting every target into a singleton
+group, otherwise the target-loop guard would not be exercised by the normal
+GraphQL trigger path.
+
+---
+
+## Requirements
+
+- R1. A process step must not start another language target inside a group when
+  the configured launch timeout plus safety buffer cannot fit inside the
+  remaining step budget.
+- R2. The first target in a group must remain eligible so a tight budget cannot
+  deadlock the workflow.
+- R3. Remaining targets from a partially processed group must be returned as an
+  `unprocessedGroup` so the workflow can continue in a fresh durable step.
+- R4. Existing `MODEL_UPGRADE` resume health checks must keep skipping only
+  already-enriched healthy rows.
+- R5. Production batching must preserve target-limited multi-target group
+  chunks, rather than singleton groups, so the inner target-loop guard is
+  reachable from the existing backfill trigger.
+- R6. The compound learning and operations runbook must record that nested
+  provider-launch loops need the same runtime guard as outer waves.
+
+---
+
+## Key Technical Decisions
+
+- **Guard every launch boundary:** The same projected-runtime rule applies both
+  between group waves and inside a group's target loop. If a loop can call
+  Mastra, it can consume the full launch timeout.
+- **Preserve bounded group chunks:** The batcher still caps step inputs by
+  target count, but it keeps contiguous targets from the same `(video, edition)`
+  together until the target limit is reached. This restores source-artifact
+  reuse and makes the inner target-loop guard part of the production path.
+- **Return remainder at the same granularity:** When the target loop stops, the
+  result carries the same group identity with `targets` sliced to the
+  unprocessed language targets.
+- **Keep resume scoped:** After deploy, retry only the known failed core id
+  with no language filter. Healthy enriched rows should skip from storage state
+  instead of being re-embedded.
+
+---
+
+## Implementation Units
+
+### U1. Defer Remaining Targets Within One Group
+
+- **Goal:** Bound `processTranscriptEmbeddingGroup` runtime when a single group
+  contains many language targets.
+- **Requirements:** R1, R2, R3, R4, R5.
+- **Dependencies:** Existing projected runtime helper from
+  `apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts`.
+- **Files:** `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts`,
+  `apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts`,
+  `apps/admin/src/workflows/transcriptEmbeddingBackfill.test.ts`.
+- **Approach:** Preserve target-limited group chunks in
+  `batchGroupsByTargetLimit`. Track how many targets have started inside the
+  group. Before starting later targets, compare elapsed step time against the
+  launch timeout and safe step budget. Return outcomes, pending confirmations,
+  and the sliced unprocessed group when the next target no longer fits.
+- **Test scenarios:** A four-language group whose first target consumes most of
+  the budget processes only the first target and returns the remaining three
+  languages as one unprocessed group. A pending ingest confirmation from the
+  processed target is preserved while the remaining targets are deferred. The
+  production batcher turns a six-language group into target-limited chunks, not
+  singleton groups. Existing process-wave, resume-skip, and pending-confirmation
+  tests continue to pass.
+- **Verification:** Focused Admin workflow tests pass.
+
+### U2. Update Operational Learning
+
+- **Goal:** Preserve the production failure shape and the target-loop fix for
+  future operators and agents.
+- **Requirements:** R6.
+- **Dependencies:** U1.
+- **Files:** `docs/solutions/workflow-issues/budget-durable-workflow-steps-by-projected-runtime.md`,
+  `docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md`.
+- **Approach:** Update the existing projected-runtime compound note instead of
+  creating a duplicate learning. Add an operations checkpoint for the cancelled
+  scoped run and the expected retry signal.
+- **Test scenarios:** Documentation-only update.
+- **Verification:** Compound frontmatter validation passes for modified
+  solution notes.
+
+---
+
+## Risks & Dependencies
+
+- A single very slow first target can still consume the configured launch
+  timeout. The guard prevents follow-on launches from compounding that delay; a
+  detached Mastra launch/status model remains separate follow-up work.
+- The retry must wait until both `@forge/admin` and `@forge/admin/worker` are
+  deployed, because the workflow body runs on the worker service.
+
+---
+
+## Operational Notes
+
+Before this hotfix is deployed, do not retry the scoped `1_jf-0-0` resume. The
+previous scoped run was cancelled after 56 transcript rows were touched and no
+new transcript writes were observed in the later containment window.
+
+After deploy, use the existing Admin GraphQL mutation with
+`mode: MODEL_UPGRADE`, `coreIds: ["1_jf-0-0"]`, and no language filter. The
+expected proof is that process steps complete below the worker boundary and
+healthy enriched language rows skip instead of relaunching Mastra.

--- a/docs/solutions/workflow-issues/budget-durable-workflow-steps-by-projected-runtime.md
+++ b/docs/solutions/workflow-issues/budget-durable-workflow-steps-by-projected-runtime.md
@@ -1,6 +1,7 @@
 ---
 title: "Budget durable workflow steps by projected runtime"
 date: "2026-06-22"
+last_updated: "2026-06-22"
 category: workflow-issues
 module: apps/admin transcript embedding backfill
 problem_type: workflow_issue
@@ -37,6 +38,21 @@ target-bounded, but one process step could still launch more than one Mastra
 wave. The guard checked elapsed time before a wave; it did not reserve enough
 budget for the next wave's launch timeout plus worker overhead.
 
+A follow-up scoped resume for `1_jf-0-0` exposed the same lesson one level
+deeper. The outer process-wave guard bounded work between groups, but
+`1_jf-0-0` is one large `(video, edition)` group with many language targets.
+`processTranscriptEmbeddingGroup` could still launch those targets
+sequentially inside one durable step. The projected-runtime guard therefore has
+to apply to every nested loop that can launch provider work, not only to the
+outer batch loop.
+
+During review of that follow-up hotfix, the production batcher shape mattered
+as much as the guard. If `batchGroupsByTargetLimit` rewrites every target into
+a singleton group, an inner target-loop guard becomes defensive dead code for
+the normal GraphQL trigger path. Keep batches target-limited, but preserve
+contiguous multi-target group chunks so the production path exercises the same
+loop that owns the provider launches.
+
 ## Guidance
 
 For durable steps that launch external work, gate each additional wave by
@@ -71,9 +87,30 @@ progress. After that, defer the remaining groups into the workflow's next
 durable process step whenever the projected next launch no longer fits inside
 the step budget.
 
-Return the deferred work explicitly, for example as `unprocessedGroups`, so the
-parent workflow can prepend or requeue it without losing ordering, skip
-semantics, or operator visibility.
+Return the deferred work explicitly at the same granularity where the loop
+stopped. For outer group waves, return `unprocessedGroups`. For a target loop
+inside one large group, return the same group identity with its `targets` sliced
+to the unprocessed language targets. That lets the parent workflow continue in
+a fresh durable step without losing ordering, skip semantics, or operator
+visibility.
+
+Make sure upstream batching does not erase the loop you intend to guard. A
+target-bounded batch can still preserve group chunks:
+
+```ts
+const targets = group.targets.slice(
+  targetIndex,
+  targetIndex + remainingBatchCapacity,
+)
+
+current.push({
+  ...group,
+  targets,
+})
+```
+
+Avoid changing every target into `{ ...group, targets: [target] }` unless the
+inner group loop is intentionally no longer part of the production design.
 
 ## Why This Matters
 
@@ -113,8 +150,8 @@ the remaining groups are returned as deferred work:
 
 ```ts
 if (
-  shouldDeferNextTranscriptEmbeddingWave({
-    wavesStarted,
+  shouldDeferNextTranscriptEmbeddingLaunch({
+    launchesStarted: wavesStarted,
     elapsedMs: Date.now() - batchStartedAt,
     stepMaxDurationMs: safeStepMaxDurationMs,
     launchTimeoutMs,
@@ -125,11 +162,47 @@ if (
 }
 ```
 
+The same check also belongs inside a group's target loop when that loop can
+launch Mastra target-by-target:
+
+```ts
+for (const [targetIndex, target] of group.targets.entries()) {
+  if (
+    shouldDeferNextTranscriptEmbeddingLaunch({
+      launchesStarted: targetsStarted,
+      elapsedMs: Date.now() - batchStartedAt,
+      stepMaxDurationMs,
+      launchTimeoutMs,
+    })
+  ) {
+    return {
+      outcomes,
+      pendingConfirmations,
+      unprocessedGroup: {
+        ...group,
+        targets: group.targets.slice(targetIndex),
+      },
+    }
+  }
+
+  targetsStarted += 1
+  await launchTarget(target)
+}
+```
+
 Regression coverage should include both sides of the boundary:
 
 - first wave still runs even when the configured step budget is tight
 - later waves defer when `remainingBudget <= launchTimeout + safetyBuffer`
 - deferred groups are returned as `unprocessedGroups`
+- remaining language targets inside a large group are returned as a sliced
+  `unprocessedGroup`
+- target-limited production batching preserves multi-target group chunks rather
+  than singletonizing every target
+- pending ingest confirmations survive when the processed target is followed by
+  a sliced remainder group
+- deferral branches emit structured, scrubbed logs with processed and remaining
+  counts plus budget fields so operators can prove the path is active
 - the resume guard still skips only already-healthy enriched rows
 
 ## Related

--- a/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
+++ b/docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md
@@ -618,6 +618,80 @@ The expected early signals are:
   `reason=already_enriched_healthy` instead of launching provider work again.
 - Legacy or incomplete `1_jf-0-0` language rows still launch through Mastra and
   ingest normally.
+
+### Hotfix checkpoint: 2026-06-22 large groups must defer remaining targets
+
+After the bounded-confirm/resume-skip hotfix deployed, the intended scoped
+resume was started through the existing Admin GraphQL mutation:
+`MODEL_UPGRADE`, `coreIds: ["1_jf-0-0"]`, and no language filter. The GraphQL
+request timed out, but Workflow run `wrun_01KVPQTTTQJGSWKET22FB3V156` started
+successfully at 2026-06-22 04:01 UTC.
+
+Early process and confirm steps were healthy. Process steps completed around
+the expected two-minute range, confirm steps stayed short, and the event log
+had no duplicate `step_started` entries in the early window. The later failure
+shape was different: `1_jf-0-0` is one very large `(video, edition)` group, so
+the outer process-wave budget guard did not stop
+`processTranscriptEmbeddingGroup` from launching many language targets
+sequentially inside one durable step.
+
+The run was cancelled through Workflow's native CLI and production containment
+was verified before applying the next hotfix:
+
+```bash
+WORKFLOW_POSTGRES_URL="$DATABASE_PUBLIC_URL" \
+pnpm --filter @forge/admin exec workflow cancel \
+  wrun_01KVPQTTTQJGSWKET22FB3V156 \
+  --backend @workflow/world-postgres --json
+```
+
+The cancelled run reached terminal `cancelled` status at
+2026-06-22 09:00:19 UTC. Admin transcript storage showed 56 rows touched since
+that scoped run started, with the latest observed write at
+2026-06-22 09:20:05 UTC, and no transcript writes in the later containment
+window.
+
+The follow-up Admin hotfix applies the projected-runtime guard inside the group
+target loop as well as between outer group waves. The production batcher also
+preserves target-limited multi-target group chunks instead of rewriting every
+language target into a singleton group, so the existing GraphQL trigger path
+actually exercises the guarded loop. When the next language target cannot fit
+inside the remaining step budget, the step returns the same group with
+`targets` sliced to the unprocessed languages. The parent workflow then
+processes that remainder group in a fresh durable step.
+
+Do not retry the scoped `1_jf-0-0` resume until both `@forge/admin` and
+`@forge/admin/worker` have the target-loop hotfix. After deploy, retry the same
+scoped shape rather than restarting the broad all-language corpus:
+
+```graphql
+mutation ResumeTranscriptEmbeddingBackfill {
+  triggerTranscriptEmbeddingBackfill(mode: MODEL_UPGRADE, coreIds: ["1_jf-0-0"])
+}
+```
+
+The expected proof is that long `1_jf-0-0` process steps return under the
+worker boundary, healthy enriched rows log `already_enriched_healthy`, and any
+remaining language targets continue through sliced remainder groups instead of
+one oversized durable step. The target-loop hotfix emits a scrubbed structured
+log when it defers a suffix:
+
+```text
+event=transcript_index_target_deferred
+coreId=<core id>
+videoEditionId=<edition id>
+processedTargets=<count already handled in this group>
+remainingTargets=<count returned as the sliced remainder>
+elapsedMs=<step elapsed before deferral>
+stepMaxDurationMs=<configured step budget>
+launchTimeoutMs=<configured Mastra launch timeout>
+```
+
+Use that event, plus short `stepProcessTranscriptEmbeddingGroups` durations,
+to prove the sliced remainder path is actually active. The log must not include
+transcript text, embedding input text, vectors, request bodies, raw provider
+responses, or API keys.
+
 - No confirm-ingest Graphile task runs near the 300 second boundary.
 
 ### Hotfix checkpoint: 2026-06-22 projected process-step budget


### PR DESCRIPTION
## Summary

- preserve target-limited multi-target group chunks so the production backfill path exercises the group target loop instead of singletonizing every target
- add projected-runtime guards before source resolution and again immediately before later Mastra launches, returning sliced `unprocessedGroup` remainders when the next launch no longer fits the step budget
- emit a scrubbed `transcript_index_target_deferred` event and document the scoped resume/monitoring path for `1_jf-0-0`

## Context

The first June 22 hotfix bounded outer process waves, but the scoped `1_jf-0-0` resume exposed a deeper shape: one `(video, edition)` group can contain many language targets. A single process step could keep launching targets inside that group long enough to approach the Graphile/useworkflow task boundary.

This PR keeps the existing GraphQL trigger path but makes the process step return a sliced remainder group before launching more target work when the projected runtime no longer fits.

## Formal CE Artifacts

- Plan: `docs/plans/2026-06-22-003-fix-transcript-target-budget-plan.md`
- Compound learning: `docs/solutions/workflow-issues/budget-durable-workflow-steps-by-projected-runtime.md`
- Ops runbook checkpoint: `docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md`
- Review artifact: `/tmp/compound-engineering/ce-code-review/20260622-141438-target-budget/report.md`

## Validation

- `pnpm --filter @forge/admin exec vitest run --reporter=dot src/workflows/transcriptEmbeddingBackfill.test.ts` -> 42 passed
- `pnpm --filter @forge/admin lint` -> passed
- `pnpm --filter @forge/admin typecheck` -> passed
- compound frontmatter validation for modified solution notes -> passed
- `git diff --check --cached` -> passed

## Deployment / Resume Notes

Deploy both `@forge/admin` and `@forge/admin/worker` before retrying the scoped backfill. Resume with the existing Admin GraphQL mutation:

```graphql
mutation ResumeTranscriptEmbeddingBackfill {
  triggerTranscriptEmbeddingBackfill(mode: MODEL_UPGRADE, coreIds: ["1_jf-0-0"])
}
```

Expected early proof:

- `stepProcessTranscriptEmbeddingGroups` durations stay under the worker boundary
- healthy enriched rows log `already_enriched_healthy`
- `transcript_index_target_deferred` appears when the sliced remainder path activates
- no duplicate `step_started` event-log shape appears
