### PR TITLE
fix(admin): route video-section call to mastra over node:http

### DIFF
--- a/apps/admin/src/app/dashboard/experiences/generate-section-action.ts
+++ b/apps/admin/src/app/dashboard/experiences/generate-section-action.ts
@@ -161,6 +161,12 @@ export async function runGenerateSectionAction(
     },
   })
   if (!remote.ok) {
+    // Surface which leg of the remote call failed so the editor's opaque
+    // "service unavailable" can be traced to a concrete reason in prod logs
+    // (the client logs the connection-level cause on network_error).
+    console.warn(
+      `[runGenerateSectionAction] event=remote_failed reason=${remote.reason} retryable=${remote.retryable}`,
+    )
     switch (remote.reason) {
       case "config_missing":
         return fail("NOT_CONFIGURED")

--- a/apps/admin/src/services/experience-ai/mastra-experience-section-client.ts
+++ b/apps/admin/src/services/experience-ai/mastra-experience-section-client.ts
@@ -20,6 +20,9 @@
  * after this client returns.
  */
 
+import { request as httpRequest } from "node:http"
+import { request as httpsRequest } from "node:https"
+
 import { env } from "@/config/env"
 import {
   DraftVideoSectionSchema,
@@ -84,6 +87,97 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>
 }
 
+/**
+ * Render an unknown thrown value as a Railway-logsV2-safe plain string. For
+ * undici `fetch` failures the useful signal lives on `error.cause` (e.g.
+ * ECONNREFUSED / EAI_AGAIN / ETIMEDOUT / UND_ERR_*); for AbortSignal.timeout it
+ * is the `TimeoutError` name. NEVER JSON.stringify — Railway logsV2 silences
+ * stringified payloads from the Next.js runtime.
+ */
+function describeFetchError(error: unknown): string {
+  const err = error instanceof Error ? error : undefined
+  const cause = err?.cause instanceof Error ? err.cause : undefined
+  const rawCode =
+    (cause as { code?: unknown } | undefined)?.code ??
+    (err as { code?: unknown } | undefined)?.code
+  return (
+    `name=${err?.name ?? "unknown"} ` +
+    `code=${typeof rawCode === "string" ? rawCode : "none"} ` +
+    `cause=${cause?.name ?? "none"} ` +
+    `message=${err?.message ?? String(error)}`
+  )
+}
+
+type RawResponse = { status: number; bodyText: string }
+
+/**
+ * POST the request over `node:http` instead of the global `fetch`.
+ *
+ * Why: in the Next.js standalone runtime the framework-patched global `fetch`
+ * fails to reach `forge-mastra` over Railway's private network (a plain `node`
+ * process in the SAME container reaches it fine), so the editor only ever saw
+ * an opaque "service unavailable". `node:http` is NOT patched by Next, so it
+ * uses the same un-instrumented network stack that works from a raw process.
+ * The injected-`fetchImpl` path (tests/overrides) keeps using `fetch`.
+ */
+function postViaNode(
+  target: URL,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs: number,
+): Promise<RawResponse> {
+  const request = target.protocol === "https:" ? httpsRequest : httpRequest
+  return new Promise<RawResponse>((resolve, reject) => {
+    const req = request(
+      target,
+      {
+        method: "POST",
+        headers: {
+          ...headers,
+          "content-length": Buffer.byteLength(body).toString(),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on("data", (chunk: Buffer) => chunks.push(chunk))
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            bodyText: Buffer.concat(chunks).toString("utf8"),
+          }),
+        )
+        res.on("error", reject)
+      },
+    )
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(
+        Object.assign(new Error("section request timed out"), {
+          name: "TimeoutError",
+        }),
+      )
+    })
+    req.on("error", reject)
+    req.end(body)
+  })
+}
+
+/** Transport used when a caller injects `fetchImpl` (unit tests / overrides). */
+async function postViaFetch(
+  fetchImpl: typeof fetch,
+  target: URL,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs: number,
+): Promise<RawResponse> {
+  const response = await fetchImpl(target, {
+    method: "POST",
+    headers,
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  })
+  return { status: response.status, bodyText: await response.text() }
+}
+
 function parseSectionRouteResult(
   value: unknown,
 ): MastraExperienceSectionLaunchResult | null {
@@ -139,43 +233,72 @@ export async function launchMastraExperienceSection(
     },
   }
 
-  let response: Response
+  const target = new URL("/forge-experience-section", baseUrl)
+  const headers = {
+    authorization: `Bearer ${bearer}`,
+    "content-type": "application/json",
+  }
+  const bodyText = JSON.stringify(body)
+  const timeoutMs = options.timeoutMs ?? env.MASTRA_SECTION_TIMEOUT_MS
+
+  let raw: RawResponse
   try {
-    response = await (options.fetchImpl ?? fetch)(
-      new URL("/forge-experience-section", baseUrl),
-      {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${bearer}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(
-          options.timeoutMs ?? env.MASTRA_SECTION_TIMEOUT_MS,
-        ),
-      },
+    // Prod default is `node:http` to dodge the Next-patched global `fetch`
+    // that fails over Railway private networking; tests/overrides inject
+    // `fetchImpl` and keep the `fetch` path.
+    raw = options.fetchImpl
+      ? await postViaFetch(
+          options.fetchImpl,
+          target,
+          headers,
+          bodyText,
+          timeoutMs,
+        )
+      : await postViaNode(target, headers, bodyText, timeoutMs)
+  } catch (error) {
+    // The connection-level cause was previously swallowed here, leaving the
+    // editor with an opaque "service unavailable" and no way to tell a refused
+    // connection from a DNS miss from a timeout. Surface it (plain string;
+    // logsV2 drops JSON.stringify from the Next.js runtime).
+    console.error(
+      `[mastra-experience-section] event=fetch_failed host=${target.host} ` +
+        `transport=${options.fetchImpl ? "fetch" : "node-http"} ${describeFetchError(error)}`,
     )
-  } catch {
     return { ok: false, reason: "network_error", retryable: true }
   }
 
-  if (response.status === 401) {
+  if (raw.status === 401) {
+    console.warn(`[mastra-experience-section] event=auth_failed status=401`)
     return { ok: false, reason: "auth_failed", retryable: false }
   }
 
-  const parsed = parseSectionRouteResult(
-    await response.json().catch(() => undefined),
-  )
+  let payload: unknown
+  try {
+    payload = raw.bodyText.length > 0 ? JSON.parse(raw.bodyText) : undefined
+  } catch {
+    payload = undefined
+  }
+
+  const parsed = parseSectionRouteResult(payload)
   if (parsed) return parsed
 
-  if (!response.ok) {
+  if (raw.status < 200 || raw.status >= 300) {
+    console.warn(
+      `[mastra-experience-section] event=http_error status=${raw.status}`,
+    )
     return {
       ok: false,
       reason: "network_error",
-      retryable: response.status >= 500 || response.status === 429,
+      retryable: raw.status >= 500 || raw.status === 429,
     }
   }
 
+  // 2xx whose body did not match the discriminated envelope / the
+  // single-sourced DraftVideoSectionSchema (e.g. a generator↔admin schema skew).
+  console.warn(
+    `[mastra-experience-section] event=parse_error status=${raw.status} ` +
+      `bodyOk=${String(asRecord(payload)?.ok ?? "absent")}`,
+  )
   return { ok: false, reason: "parse_error", retryable: true }
 }
 


### PR DESCRIPTION
## What & why

The video-anchored **"Generate section from video"** editor action (#1333 / #1334) is **live but broken in production** — clicking it returns *"AI section service is unavailable."* This PR fixes the admin→mastra call so the feature works end-to-end.

## Root cause

The mastra backend is healthy — called directly it returns a real grounded section (HTTP 200: videoHero + FAQ from study questions + reference-first scripture). The break is admin-side:

- In the **Next.js standalone runtime, the framework-patched global `fetch` cannot reach `@forge/mastra` over Railway private networking**, while a raw `node` process in the **same container** reaches it fine.
- So `launchMastraExperienceSection` threw `network_error` **before the request ever left admin** — zero mastra route logs for UI attempts, and the editor only ever saw an opaque "service unavailable."

This is the first time the admin→mastra HTTP path (added in the #1330 consolidation) ran in prod, so it had never been exercised. The **draft + chat remote clients share this exact pattern** and will need the same change when enabled.

## The fix (2 files)

- `mastra-experience-section-client.ts` — default the transport to **`node:http` / `node:https`** (not patched by Next), keeping the injected `fetchImpl` path for tests/overrides. Also logs the previously-swallowed connection cause (`event=fetch_failed … code=… cause=…`) + 401/http/parse paths, plain-string (Railway logsV2-safe).
- `generate-section-action.ts` — logs `event=remote_failed reason=…` so the editor's opaque error is traceable in prod.

## Validation

Run against **production mastra from inside the admin container**:
- `node:http` GET `/health` → **200 on both IPv4 and IPv6**
- `node:http` POST `/forge-experience-section` → reaches mastra, returns the real route envelope
- eslint (`--max-warnings=0`) + prettier pass; existing `section-generator.test.ts` (`_internals.parseSectionRouteResult`) untouched/green.

## Deploy note — @tataihono

Merging to `main` auto-deploys `@forge/admin` on Railway (~3–5 min), at which point "Generate section from video" works for editors. **Looping you in for the prod-deploy (merge) decision** per our process — the engineering is done and verified; the merge is the human gate. A PR preview env lets you click it before merging.

**Minor follow-up (not a blocker):** an occasional slow generation hits mastra's 60s `TIME_BUDGET_MS.section` and returns "try again" — harmless retry; bump the budget if frequent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBrM8gC5uohxdnJZ5WKgS
