### PR TITLE
feat(admin): anchor video picker for Generate section from video

### DIFF
--- a/apps/admin/src/app/dashboard/experiences/experience-editor-with-chat.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor-with-chat.tsx
@@ -193,6 +193,7 @@ export function ExperienceEditorWithChat({
         canvasController={canvasController}
         actions={chatActions}
         suggestedPrompts={suggestedPrompts}
+        videoLibrary={videoLibrary}
         generateDraftAction={generateDraftAction}
         generateSectionAction={generateSectionAction}
       />

--- a/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor.test.tsx
@@ -74,6 +74,7 @@ function renderEditorElement(
           durationSeconds: 754,
           previewImageUrl: "https://example.com/image.jpg",
           previewStreamUrl: "https://example.com/video.mp4",
+          hasGrounding: true,
         },
       ]}
       mediaLibrary={[

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AnchorVideoPicker } from "./anchor-video-picker"
+import type { VideoLibraryItem } from "./block-helpers"
+;(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+function makeVideo(overrides: Partial<VideoLibraryItem>): VideoLibraryItem {
+  return {
+    key: "video-1",
+    title: "Untitled",
+    description: null,
+    id: "core-1",
+    label: null,
+    labelLabel: null,
+    sourceLabel: "Core",
+    sourceTone: "success",
+    dubs: "1 dub",
+    updated: "2026-06-01T00:00:00.000Z",
+    duration: "10:00",
+    durationSeconds: 600,
+    previewImageUrl: null,
+    previewStreamUrl: null,
+    hasGrounding: false,
+    ...overrides,
+  }
+}
+
+function mount(node: React.ReactNode) {
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+  const root: Root = createRoot(container)
+  act(() => {
+    root.render(node)
+  })
+  return {
+    container,
+    cleanup() {
+      act(() => root.unmount())
+      container.remove()
+    },
+  }
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set
+  act(() => {
+    setter?.call(input, value)
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+    input.dispatchEvent(new Event("change", { bubbles: true }))
+  })
+}
+
+function rowKeys(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll('[data-testid="anchor-video-picker-row"]'),
+  ).map((el) => el.getAttribute("data-video-key") ?? "")
+}
+
+describe("AnchorVideoPicker", () => {
+  let cleanup: (() => void) | null = null
+
+  beforeEach(() => {
+    cleanup = null
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = null
+  })
+
+  it("renders nothing when closed", () => {
+    const view = mount(
+      <AnchorVideoPicker
+        videoLibrary={[makeVideo({})]}
+        open={false}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    )
+    cleanup = view.cleanup
+    expect(
+      view.container.querySelector('[data-testid="anchor-video-picker"]'),
+    ).toBeNull()
+  })
+
+  it("badges ready videos and sorts them ahead of non-ready ones (Covers AE2)", () => {
+    const library = [
+      makeVideo({
+        key: "not-ready",
+        title: "Plain Clip",
+        previewStreamUrl: null,
+        hasGrounding: false,
+      }),
+      makeVideo({
+        key: "ready",
+        title: "Grounded Film",
+        previewStreamUrl: "https://example.com/v.m3u8",
+        hasGrounding: true,
+      }),
+      makeVideo({
+        key: "playable-only",
+        title: "Playable Only",
+        previewStreamUrl: "https://example.com/p.m3u8",
+        hasGrounding: false,
+      }),
+    ]
+    const view = mount(
+      <AnchorVideoPicker
+        videoLibrary={library}
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    )
+    cleanup = view.cleanup
+
+    // Ready video sorts first even though it was listed second.
+    expect(rowKeys(view.container)).toEqual([
+      "ready",
+      "not-ready",
+      "playable-only",
+    ])
+
+    const badges = view.container.querySelectorAll(
+      '[data-testid="anchor-video-picker-ready-badge"]',
+    )
+    expect(badges).toHaveLength(1)
+
+    const readyRow = view.container.querySelector(
+      '[data-video-key="ready"]',
+    ) as HTMLElement
+    expect(readyRow.getAttribute("data-ready")).toBe("true")
+    const playableRow = view.container.querySelector(
+      '[data-video-key="playable-only"]',
+    ) as HTMLElement
+    // Playable but not grounded is NOT ready.
+    expect(playableRow.getAttribute("data-ready")).toBe("false")
+  })
+
+  it("filters by title and Core ID as the query changes", () => {
+    const library = [
+      makeVideo({ key: "a", title: "Resurrection", id: "core-aaa" }),
+      makeVideo({ key: "b", title: "Nativity", id: "core-bbb" }),
+    ]
+    const view = mount(
+      <AnchorVideoPicker
+        videoLibrary={library}
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    )
+    cleanup = view.cleanup
+
+    const search = view.container.querySelector(
+      '[data-testid="anchor-video-picker-search"]',
+    ) as HTMLInputElement
+
+    setInputValue(search, "nativ")
+    expect(rowKeys(view.container)).toEqual(["b"])
+
+    setInputValue(search, "core-aaa")
+    expect(rowKeys(view.container)).toEqual(["a"])
+  })
+
+  it("calls onSelect with the row item and then onClose when a row is clicked", () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    const target = makeVideo({ key: "pick-me", title: "Pick Me" })
+    const view = mount(
+      <AnchorVideoPicker
+        videoLibrary={[target]}
+        open
+        onClose={onClose}
+        onSelect={onSelect}
+      />,
+    )
+    cleanup = view.cleanup
+
+    const row = view.container.querySelector(
+      '[data-video-key="pick-me"]',
+    ) as HTMLButtonElement
+    act(() => {
+      row.click()
+    })
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect.mock.calls[0][0]).toMatchObject({ key: "pick-me" })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("lets a non-ready video be selected (badge is advisory, not a gate — supports R5)", () => {
+    const onSelect = vi.fn()
+    const target = makeVideo({
+      key: "bare",
+      previewStreamUrl: null,
+      hasGrounding: false,
+    })
+    const view = mount(
+      <AnchorVideoPicker
+        videoLibrary={[target]}
+        open
+        onClose={vi.fn()}
+        onSelect={onSelect}
+      />,
+    )
+    cleanup = view.cleanup
+
+    const row = view.container.querySelector(
+      '[data-video-key="bare"]',
+    ) as HTMLButtonElement
+    expect(row.getAttribute("data-ready")).toBe("false")
+    act(() => {
+      row.click()
+    })
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows an empty state when the library is empty", () => {
+    const view = mount(
+      <AnchorVideoPicker
+        videoLibrary={[]}
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    )
+    cleanup = view.cleanup
+    expect(
+      view.container.querySelector('[data-testid="anchor-video-picker-empty"]'),
+    ).not.toBeNull()
+    expect(rowKeys(view.container)).toEqual([])
+  })
+})

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+/**
+ * Slim anchor-video picker for "Generate section from video".
+ *
+ * A search + select variant of the editor's media-library modal: it lists
+ * the whole video library, badges + sorts-first the videos that are "ready"
+ * to anchor a section (playable AND grounded), and emits the chosen video.
+ *
+ * Deliberately omits the block-attachment picker's playback/trim/loop/audio
+ * configuration — anchoring a section only needs a video id, not a clip
+ * config. The "ready" badge is advisory: every row stays selectable so the
+ * section action remains the authoritative eligibility gate (R5).
+ */
+
+import { CirclePlay, Search, Sparkles, X } from "lucide-react"
+import { useMemo, useState } from "react"
+
+import type { VideoLibraryItem } from "./block-helpers"
+
+/** A video is "ready" to anchor a section when it is playable AND grounded. */
+export function isAnchorReady(item: VideoLibraryItem): boolean {
+  return item.previewStreamUrl != null && item.hasGrounding
+}
+
+export type AnchorVideoPickerProps = {
+  videoLibrary: VideoLibraryItem[]
+  open: boolean
+  onClose: () => void
+  onSelect: (item: VideoLibraryItem) => void
+}
+
+export function AnchorVideoPicker({
+  videoLibrary,
+  open,
+  onClose,
+  onSelect,
+}: AnchorVideoPickerProps) {
+  const [query, setQuery] = useState("")
+
+  const rows = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    const filtered = videoLibrary.filter((item) => {
+      if (normalized.length === 0) return true
+      const haystack =
+        `${item.title} ${item.id} ${item.sourceLabel} ${item.dubs}`.toLowerCase()
+      return haystack.includes(normalized)
+    })
+    // Stable sort: ready videos first, preserving the incoming order
+    // (recently-updated) within each group.
+    return filtered
+      .map((item, index) => ({ item, index }))
+      .sort((left, right) => {
+        const readyLeft = isAnchorReady(left.item) ? 0 : 1
+        const readyRight = isAnchorReady(right.item) ? 0 : 1
+        if (readyLeft !== readyRight) return readyLeft - readyRight
+        return left.index - right.index
+      })
+      .map((entry) => entry.item)
+  }, [videoLibrary, query])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="anchor-video-picker-title"
+      data-testid="anchor-video-picker"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-sm border border-[var(--color-hairline-strong)] bg-[var(--color-surface)] shadow-xl">
+        {/* Header */}
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-[var(--color-hairline)] px-5 py-4">
+          <div>
+            <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-[var(--color-text-muted)]">
+              Choose a video
+            </div>
+            <h2
+              id="anchor-video-picker-title"
+              className="mt-2 text-[16px] font-semibold tracking-[-0.02em] text-[var(--color-text-primary)]"
+            >
+              Anchor a section to a video
+            </h2>
+            <p className="mt-1 max-w-md text-[12px] leading-5 text-[var(--color-text-muted)]">
+              Videos marked “ready” are playable and have study questions or
+              scripture to ground a section.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            data-testid="anchor-video-picker-close"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-[var(--color-hairline)] text-[var(--color-text-muted)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-raised)]"
+            aria-label="Close video picker"
+          >
+            <X className="h-4 w-4" strokeWidth={1.5} />
+          </button>
+        </div>
+
+        {/* Search */}
+        <div className="shrink-0 border-b border-[var(--color-hairline)] px-5 py-3">
+          <label className="grid gap-1.5">
+            <span className="sr-only">Search videos</span>
+            <div className="flex h-10 items-center gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface-raised)] px-3">
+              <Search className="h-4 w-4 text-[var(--color-text-muted)]" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                data-testid="anchor-video-picker-search"
+                className="w-full border-0 bg-transparent text-[13px] text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-disabled)]"
+                placeholder="Search title, Core ID, source, or dub coverage"
+              />
+            </div>
+          </label>
+        </div>
+
+        {/* Results */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2 [scrollbar-color:rgba(255,255,255,0.12)_transparent] [scrollbar-width:thin]">
+          {rows.length === 0 ? (
+            <div
+              data-testid="anchor-video-picker-empty"
+              className="m-3 rounded-sm border border-dashed border-[var(--color-hairline)] px-4 py-8 text-center"
+            >
+              <div className="text-[14px] font-medium text-[var(--color-text-primary)]">
+                No videos match these filters
+              </div>
+              <div className="mt-2 text-[12px] leading-5 text-[var(--color-text-muted)]">
+                Try widening the search or clearing the current query.
+              </div>
+            </div>
+          ) : (
+            <ul className="grid gap-1">
+              {rows.map((video) => {
+                const ready = isAnchorReady(video)
+                return (
+                  <li key={video.key}>
+                    <button
+                      type="button"
+                      data-testid="anchor-video-picker-row"
+                      data-video-key={video.key}
+                      data-ready={ready ? "true" : "false"}
+                      onClick={() => {
+                        onSelect(video)
+                        onClose()
+                      }}
+                      className="grid w-full min-w-0 cursor-pointer grid-cols-[112px_minmax(0,1fr)] gap-3 overflow-hidden rounded-sm border border-transparent px-3 py-2.5 text-left transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline)] hover:bg-[color-mix(in_oklab,var(--color-surface)_92%,white)]"
+                    >
+                      <div className="relative aspect-video w-full overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[linear-gradient(180deg,#1c2027,#121419)]">
+                        {video.previewImageUrl ? (
+                          <div
+                            className="absolute inset-0 bg-cover bg-center"
+                            style={{
+                              backgroundImage: `url("${video.previewImageUrl}")`,
+                            }}
+                          />
+                        ) : null}
+                        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(10,12,18,0.04),rgba(6,8,12,0.56))]" />
+                        <div className="absolute bottom-1.5 left-1.5 inline-flex h-6 w-6 items-center justify-center rounded-full border border-white/20 bg-[rgba(4,6,10,0.56)] text-white backdrop-blur-[4px]">
+                          <CirclePlay className="h-3 w-3" strokeWidth={1.5} />
+                        </div>
+                      </div>
+                      <div className="min-w-0 overflow-hidden">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <div className="truncate text-[14px] font-medium text-[var(--color-text-primary)]">
+                            {video.title}
+                          </div>
+                          {ready ? (
+                            <span
+                              data-testid="anchor-video-picker-ready-badge"
+                              className="inline-flex h-5 shrink-0 items-center gap-1 rounded-pill border border-[color-mix(in_oklab,var(--color-success)_45%,transparent)] bg-[color-mix(in_oklab,var(--color-success)_14%,transparent)] px-2 text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--color-success)]"
+                            >
+                              <Sparkles className="h-3 w-3" strokeWidth={1.5} />
+                              Ready
+                            </span>
+                          ) : null}
+                        </div>
+                        <div className="mt-1 truncate text-[12px] leading-5 text-[var(--color-text-muted)]">
+                          {video.id} • {video.duration}
+                        </div>
+                        <div className="mt-0.5 truncate text-[12px] leading-5 text-[var(--color-text-muted)]">
+                          {video.sourceLabel} • {video.dubs}
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/block-helpers.test.ts
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/block-helpers.test.ts
@@ -30,6 +30,7 @@ const videoLibrary: VideoLibraryItem[] = [
     durationSeconds: 754,
     previewImageUrl: "https://example.com/image.jpg",
     previewStreamUrl: "https://example.com/video.mp4",
+    hasGrounding: true,
   },
 ]
 

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/block-helpers.ts
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/block-helpers.ts
@@ -84,6 +84,7 @@ export type VideoLibraryItem = {
   durationSeconds: number | null
   previewImageUrl: string | null
   previewStreamUrl: string | null
+  hasGrounding: boolean
 }
 
 export type VideoHeroHeadingSource = "manual" | "videoTitle"

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.test.tsx
@@ -14,6 +14,7 @@ import {
   type ExperienceCanvasController,
   type ExperienceChatPanelActions,
 } from "./experience-chat-panel"
+import type { VideoLibraryItem } from "./block-helpers"
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
@@ -72,6 +73,27 @@ function makeStreamFactory(events: ChatStreamEvent[]) {
   })
 }
 
+function makeVideo(overrides: Partial<VideoLibraryItem>): VideoLibraryItem {
+  return {
+    key: "vid1",
+    title: "The Resurrection",
+    description: null,
+    id: "core-vid1",
+    label: null,
+    labelLabel: null,
+    sourceLabel: "Core",
+    sourceTone: "success",
+    dubs: "1 dub",
+    updated: "2026-06-01T00:00:00.000Z",
+    duration: "10:00",
+    durationSeconds: 600,
+    previewImageUrl: null,
+    previewStreamUrl: "https://example.com/v.m3u8",
+    hasGrounding: true,
+    ...overrides,
+  }
+}
+
 async function flush() {
   // Drain pending microtasks so async effects/promises resolve.
   await act(async () => {
@@ -106,18 +128,6 @@ function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
     setter?.call(textarea, value)
     textarea.dispatchEvent(new Event("input", { bubbles: true }))
     textarea.dispatchEvent(new Event("change", { bubbles: true }))
-  })
-}
-
-function setInputValue(input: HTMLInputElement, value: string) {
-  const setter = Object.getOwnPropertyDescriptor(
-    HTMLInputElement.prototype,
-    "value",
-  )?.set
-  act(() => {
-    setter?.call(input, value)
-    input.dispatchEvent(new Event("input", { bubbles: true }))
-    input.dispatchEvent(new Event("change", { bubbles: true }))
   })
 }
 
@@ -210,16 +220,28 @@ describe("ExperienceChatPanel", () => {
         locale="en"
         canvasController={canvas}
         actions={makeActions()}
+        videoLibrary={[makeVideo({ key: "vid1", title: "The Resurrection" })]}
         generateSectionAction={generateSectionAction}
       />,
     )
     cleanup = view.cleanup
     await flush()
 
-    const input = view.container.querySelector(
-      '[data-testid="experience-chat-anchor-input"]',
-    ) as HTMLInputElement
-    setInputValue(input, "vid1")
+    // Open the picker, choose a video — no raw id is typed (Covers AE1).
+    const chooseBtn = view.container.querySelector(
+      '[data-testid="experience-chat-choose-video"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      chooseBtn.click()
+    })
+    const row = view.container.querySelector(
+      '[data-video-key="vid1"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      row.click()
+    })
+    await flush()
+
     const genBtn = view.container.querySelector(
       '[data-testid="experience-chat-generate-section"]',
     ) as HTMLButtonElement
@@ -247,6 +269,121 @@ describe("ExperienceChatPanel", () => {
     expect(arg.blocks).toHaveLength(1 + sectionBlocks.length)
     expect(arg.blocks[0]).toMatchObject({ heading: "Existing" })
     expect(arg.blocks[1]).toMatchObject({ t: "videoHero" })
+  })
+
+  it("video-anchored section: Generate is disabled until a video is chosen, and no raw-id input remains", async () => {
+    const generateSectionAction = vi.fn()
+    const view = mount(
+      <ExperienceChatPanel
+        experienceLocaleId="locale-1"
+        locale="en"
+        canvasController={makeCanvasController()}
+        actions={makeActions()}
+        videoLibrary={[makeVideo({ key: "vid1", title: "The Resurrection" })]}
+        generateSectionAction={generateSectionAction}
+      />,
+    )
+    cleanup = view.cleanup
+    await flush()
+
+    // The old raw-id text input is gone.
+    expect(
+      view.container.querySelector(
+        '[data-testid="experience-chat-anchor-input"]',
+      ),
+    ).toBeNull()
+
+    const genBtn = view.container.querySelector(
+      '[data-testid="experience-chat-generate-section"]',
+    ) as HTMLButtonElement
+    expect(genBtn.disabled).toBe(true)
+    // Clicking while disabled is a no-op.
+    await act(async () => {
+      genBtn.click()
+    })
+    expect(generateSectionAction).not.toHaveBeenCalled()
+
+    // Choose a video → button enables.
+    const chooseBtn = view.container.querySelector(
+      '[data-testid="experience-chat-choose-video"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      chooseBtn.click()
+    })
+    const row = view.container.querySelector(
+      '[data-video-key="vid1"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      row.click()
+    })
+    await flush()
+
+    expect(genBtn.disabled).toBe(false)
+    // The chosen video's title is surfaced.
+    const chosen = view.container.querySelector(
+      '[data-testid="experience-chat-anchor-chosen"]',
+    ) as HTMLElement
+    expect(chosen.textContent).toContain("The Resurrection")
+  })
+
+  it("video-anchored section: surfaces the backend error for an ineligible pick (Covers AE3)", async () => {
+    const generateSectionAction = vi.fn().mockResolvedValue({
+      ok: false,
+      code: "NO_GROUNDING",
+      error:
+        "This video has no study questions or scripture to ground a section.",
+    })
+    const view = mount(
+      <ExperienceChatPanel
+        experienceLocaleId="locale-1"
+        locale="en"
+        canvasController={makeCanvasController()}
+        actions={makeActions()}
+        videoLibrary={[
+          makeVideo({
+            key: "bare",
+            title: "Bare Clip",
+            previewStreamUrl: null,
+            hasGrounding: false,
+          }),
+        ]}
+        generateSectionAction={generateSectionAction}
+      />,
+    )
+    cleanup = view.cleanup
+    await flush()
+
+    const chooseBtn = view.container.querySelector(
+      '[data-testid="experience-chat-choose-video"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      chooseBtn.click()
+    })
+    // A non-ready video is still selectable — the badge does not gate.
+    const row = view.container.querySelector(
+      '[data-video-key="bare"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      row.click()
+    })
+    await flush()
+
+    const genBtn = view.container.querySelector(
+      '[data-testid="experience-chat-generate-section"]',
+    ) as HTMLButtonElement
+    await act(async () => {
+      genBtn.click()
+    })
+    await flush()
+
+    expect(generateSectionAction).toHaveBeenCalledWith({
+      anchorVideoId: "bare",
+    })
+    const error = view.container.querySelector(
+      '[data-testid="experience-chat-draft-workflow-error"]',
+    ) as HTMLElement
+    expect(error).not.toBeNull()
+    expect(error.textContent).toContain("no study questions or scripture")
   })
 
   it("keeps the rail viewport-bound with an independently scrollable message list", async () => {

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.tsx
@@ -49,6 +49,7 @@ import {
   type ChatThreadDTO,
 } from "@/app/dashboard/experiences/experience-chat-actions"
 
+import type { VideoLibraryItem } from "./block-helpers"
 import { ExperienceChatCrossLocaleModal } from "./experience-chat-cross-locale-modal"
 import {
   presentChatError,
@@ -102,6 +103,12 @@ export type ExperienceChatPanelProps = {
    * populate these context-aware; v1 wiring may pass an empty array.
    */
   suggestedPrompts?: ReadonlyArray<string>
+  /**
+   * Video library used by the anchor-video picker behind the "Generate
+   * section from video" control. Threaded from the same already-loaded
+   * `loadVideoRows` result the editor canvas uses — no extra fetch.
+   */
+  videoLibrary?: VideoLibraryItem[]
   /**
    * Optional multi-step draft workflow trigger. When present, the
    * chat panel exposes a "Generate full page" button that runs the

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.tsx
@@ -16,6 +16,7 @@
 import {
   Archive,
   ChevronRight,
+  Clapperboard,
   MessageSquarePlus,
   Send,
   Sparkles,
@@ -49,6 +50,7 @@ import {
   type ChatThreadDTO,
 } from "@/app/dashboard/experiences/experience-chat-actions"
 
+import { AnchorVideoPicker } from "./anchor-video-picker"
 import type { VideoLibraryItem } from "./block-helpers"
 import { ExperienceChatCrossLocaleModal } from "./experience-chat-cross-locale-modal"
 import {
@@ -214,6 +216,7 @@ export function ExperienceChatPanel({
   canvasController,
   actions,
   suggestedPrompts = [],
+  videoLibrary = [],
   generateDraftAction,
   generateSectionAction,
   streamFactory = openChatStream,
@@ -235,8 +238,13 @@ export function ExperienceChatPanel({
   const [stagedDraft, setStagedDraft] = useState<StagedDraftPreview | null>(
     null,
   )
-  /** Anchor-video id/slug for video-anchored section generation. */
-  const [anchorVideoId, setAnchorVideoId] = useState("")
+  /**
+   * Video chosen via the picker to anchor a generated section. Its `key`
+   * (the video Database id) is what `generateSectionAction` receives.
+   */
+  const [anchorVideo, setAnchorVideo] = useState<VideoLibraryItem | null>(null)
+  /** Whether the anchor-video picker modal is open. */
+  const [anchorPickerOpen, setAnchorPickerOpen] = useState(false)
   // Active user's ratings keyed by messageId. Seeded from
   // GET /threads/{threadId}/ratings on mount / thread switch so the
   // 👍/👎 widget reflects prior state without per-message fetches.
@@ -782,7 +790,7 @@ export function ExperienceChatPanel({
 
   const handleGenerateSection = useCallback(async () => {
     if (!generateSectionAction) return
-    const anchor = anchorVideoId.trim()
+    const anchor = anchorVideo?.key
     if (!anchor) return
     setDraftWorkflowStatus("generating")
     setDraftWorkflowError(null)
@@ -806,14 +814,14 @@ export function ExperienceChatPanel({
         mode: "append",
       })
       setDraftWorkflowStatus("idle")
-      setAnchorVideoId("")
+      setAnchorVideo(null)
     } catch (err) {
       setDraftWorkflowStatus("error")
       setDraftWorkflowError(
         err instanceof Error ? err.message : "Section generation failed.",
       )
     }
-  }, [generateSectionAction, anchorVideoId, canvasController])
+  }, [generateSectionAction, anchorVideo, canvasController])
 
   // -- Render -------------------------------------------------------------
   const inFlightAssistantTokens =
@@ -1028,27 +1036,54 @@ export function ExperienceChatPanel({
 
         {generateSectionAction ? (
           <div
-            className="mt-2 flex items-center gap-2"
+            className="mt-2 flex flex-col gap-2"
             data-testid="experience-chat-section-row"
           >
-            <input
-              type="text"
-              value={anchorVideoId}
-              onChange={(e) => setAnchorVideoId(e.target.value)}
-              placeholder="Anchor video id or slug…"
-              data-testid="experience-chat-anchor-input"
-              className="h-9 flex-1 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] px-3 text-[12px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-disabled)] focus:outline-none focus:ring-1 focus:ring-[var(--color-brand)]"
-            />
+            {anchorVideo ? (
+              <div
+                className="flex min-w-0 items-center gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] px-2 py-1.5"
+                data-testid="experience-chat-anchor-chosen"
+              >
+                <div
+                  className="h-8 w-12 shrink-0 overflow-hidden rounded-sm border border-[var(--color-hairline)] bg-[linear-gradient(180deg,#1c2027,#121419)] bg-cover bg-center"
+                  style={
+                    anchorVideo.previewImageUrl
+                      ? {
+                          backgroundImage: `url("${anchorVideo.previewImageUrl}")`,
+                        }
+                      : undefined
+                  }
+                />
+                <div className="min-w-0 flex-1 truncate text-[12px] font-medium text-[var(--color-text-primary)]">
+                  {anchorVideo.title}
+                </div>
+                <button
+                  type="button"
+                  data-testid="experience-chat-choose-video"
+                  onClick={() => setAnchorPickerOpen(true)}
+                  className="shrink-0 rounded-sm px-1.5 py-0.5 text-[11px] font-medium text-[var(--color-text-secondary)] underline-offset-2 transition-all duration-[120ms] ease-out hover:underline"
+                >
+                  Change
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                data-testid="experience-chat-choose-video"
+                onClick={() => setAnchorPickerOpen(true)}
+                className="inline-flex h-9 items-center justify-center gap-1.5 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] px-3 text-[12px] font-medium text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-inset)]"
+              >
+                <Clapperboard className="h-3.5 w-3.5" strokeWidth={1.5} />
+                Choose a video
+              </button>
+            )}
             <button
               type="button"
               data-testid="experience-chat-generate-section"
-              disabled={
-                draftWorkflowStatus === "generating" ||
-                anchorVideoId.trim().length === 0
-              }
+              disabled={draftWorkflowStatus === "generating" || !anchorVideo}
               onClick={() => void handleGenerateSection()}
               title="Generate one grounded section from this video (its study questions + scripture). Staged to append; verse text resolves at render."
-              className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-sm border border-[var(--color-hairline-strong)] bg-[var(--color-surface)] px-3 text-[12px] font-medium text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-inset)] disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-sm border border-[var(--color-hairline-strong)] bg-[var(--color-surface)] px-3 text-[12px] font-medium text-[var(--color-text-primary)] transition-all duration-[120ms] ease-out hover:bg-[var(--color-surface-inset)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               {draftWorkflowStatus === "generating"
                 ? "Working…"
@@ -1212,6 +1247,13 @@ export function ExperienceChatPanel({
         affectedLocales={[locale]}
         onCancel={() => setCrossLocaleModalOpen(false)}
         onConfirm={() => void submitWithConfirmation()}
+      />
+
+      <AnchorVideoPicker
+        videoLibrary={videoLibrary}
+        open={anchorPickerOpen}
+        onClose={() => setAnchorPickerOpen(false)}
+        onSelect={(item) => setAnchorVideo(item)}
       />
     </aside>
   )

--- a/apps/admin/src/app/dashboard/live-data.test.ts
+++ b/apps/admin/src/app/dashboard/live-data.test.ts
@@ -17,6 +17,12 @@ const { prismaMock, videoListMock } = vi.hoisted(() => ({
     videoRelation: {
       findMany: vi.fn(),
     },
+    videoStudyQuestion: {
+      findMany: vi.fn(),
+    },
+    bibleCitation: {
+      findMany: vi.fn(),
+    },
   },
   videoListMock: vi.fn(),
 }))
@@ -68,6 +74,8 @@ describe("dashboard live data", () => {
     vi.clearAllMocks()
     prismaMock.videoDub.findMany.mockResolvedValue([])
     prismaMock.videoRelation.findMany.mockResolvedValue([])
+    prismaMock.videoStudyQuestion.findMany.mockResolvedValue([])
+    prismaMock.bibleCitation.findMany.mockResolvedValue([])
   })
 
   it("extracts video ids from nested experience blocks", () => {
@@ -214,5 +222,75 @@ describe("dashboard live data", () => {
       },
     })
     expect(rows.map((row) => row.key)).toEqual(["recent-video", "older-video"])
+  })
+
+  it("flags hasGrounding for a video with at least one study question", async () => {
+    videoListMock.mockResolvedValue([
+      videoRow("grounded-video", "core-grounded", "grounded"),
+    ])
+    prismaMock.videoLocale.findMany.mockResolvedValue([
+      {
+        videoId: "grounded-video",
+        locale: "en",
+        title: "Grounded Video",
+        description: null,
+        updatedAt: now,
+      },
+    ])
+    prismaMock.videoImage.findMany.mockResolvedValue([])
+    prismaMock.videoStudyQuestion.findMany.mockResolvedValue([
+      { videoId: "grounded-video" },
+    ])
+
+    const rows = await loadVideoRows(principal)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.key).toBe("grounded-video")
+    expect(rows[0]?.hasGrounding).toBe(true)
+  })
+
+  it("flags hasGrounding for a video with a citation but no study questions", async () => {
+    videoListMock.mockResolvedValue([
+      videoRow("cited-video", "core-cited", "cited"),
+    ])
+    prismaMock.videoLocale.findMany.mockResolvedValue([
+      {
+        videoId: "cited-video",
+        locale: "en",
+        title: "Cited Video",
+        description: null,
+        updatedAt: now,
+      },
+    ])
+    prismaMock.videoImage.findMany.mockResolvedValue([])
+    prismaMock.videoStudyQuestion.findMany.mockResolvedValue([])
+    prismaMock.bibleCitation.findMany.mockResolvedValue([
+      { videoId: "cited-video" },
+    ])
+
+    const rows = await loadVideoRows(principal)
+
+    expect(rows[0]?.hasGrounding).toBe(true)
+  })
+
+  it("leaves hasGrounding false when a video has neither study questions nor citations", async () => {
+    videoListMock.mockResolvedValue([
+      videoRow("bare-video", "core-bare", "bare"),
+    ])
+    prismaMock.videoLocale.findMany.mockResolvedValue([
+      {
+        videoId: "bare-video",
+        locale: "en",
+        title: "Bare Video",
+        description: null,
+        updatedAt: now,
+      },
+    ])
+    prismaMock.videoImage.findMany.mockResolvedValue([])
+
+    const rows = await loadVideoRows(principal)
+
+    expect(rows[0]?.key).toBe("bare-video")
+    expect(rows[0]?.hasGrounding).toBe(false)
   })
 })

--- a/apps/admin/src/app/dashboard/live-data.ts
+++ b/apps/admin/src/app/dashboard/live-data.ts
@@ -1808,6 +1808,8 @@ async function loadVideoRowSlice({
   let videoDubs: VideoDubRow[] = []
   let videoImages: VideoImageRow[] = []
   let videoChildRelations: Array<{ parentId: string }> = []
+  let groundingStudyQuestions: Array<{ videoId: string }> = []
+  let groundingBibleCitations: Array<{ videoId: string }> = []
   let routeManifest: Awaited<ReturnType<typeof loadLatestWatchRouteManifest>> =
     null
   try {
@@ -1816,6 +1818,8 @@ async function loadVideoRowSlice({
       videoDubs,
       videoImages,
       videoChildRelations,
+      groundingStudyQuestions,
+      groundingBibleCitations,
       routeManifest,
     ] = await Promise.all([
       prisma.videoLocale.findMany({
@@ -1874,6 +1878,20 @@ async function loadVideoRowSlice({
         },
         select: { parentId: true },
       }),
+      // Grounding signal: videos with ≥1 non-empty study question. Batched +
+      // distinct so the library list stays one query per relation regardless
+      // of catalogue size — no per-video content load.
+      prisma.videoStudyQuestion.findMany({
+        where: { videoId: { in: ids }, deletedAt: null, text: { not: "" } },
+        select: { videoId: true },
+        distinct: ["videoId"],
+      }),
+      // Grounding signal: videos with ≥1 non-deleted Bible citation.
+      prisma.bibleCitation.findMany({
+        where: { videoId: { in: ids }, deletedAt: null },
+        select: { videoId: true },
+        distinct: ["videoId"],
+      }),
       routeManifestPromise,
     ])
   } catch (error) {
@@ -1915,6 +1933,10 @@ async function loadVideoRowSlice({
     )
   }
 
+  const groundedIds = new Set<string>()
+  for (const item of groundingStudyQuestions) groundedIds.add(item.videoId)
+  for (const item of groundingBibleCitations) groundedIds.add(item.videoId)
+
   return videos.map((video) => {
     const localeRows = localesByVideo.get(video.id) ?? []
     const dubRows = dubsByVideo.get(video.id) ?? []
@@ -1951,6 +1973,7 @@ async function loadVideoRowSlice({
       previewImageUrl: preferredVideoImage(imageRows),
       previewStreamUrl:
         playbackDub?.hls ?? playbackDub?.dash ?? playbackDub?.share ?? null,
+      hasGrounding: groundedIds.has(video.id),
       visitorUrl: includeVisitorUrls
         ? resolveVideoVisitorUrl({
             contentSlug: video.slug,


### PR DESCRIPTION
## What & why

Editors anchoring a section with **"Generate section from video"** had to paste a raw video Database id (`cm…`) into a text box — with no in-context way to find it, a misleading "or slug" hint (only the id resolves), and no way to tell which videos can even produce a section until they tried and hit an error.

This replaces that text box with a **"Choose a video" button → slim picker** (search + pick only, no playback/trim settings). The picker shows the full library but **badges + sorts-first the "ready" videos** — playable AND having study questions/Bible citations. Selecting sets the anchor to the video's Database id; the editor still clicks **Generate section** to run.

Admin-UI only. No backend / mastra / GraphQL / section-action changes.

## How (4 units, plan-traced)

- **U1** — `live-data.ts` adds a cheap, batched `hasGrounding` signal per `VideoLibraryItem` (distinct study-question + citation lookups, one query each — no N+1). `key` stays `video.id` (the id the section action matches on).
- **U2** — new `anchor-video-picker.tsx`: self-contained modal, search by title/Core ID/source/dub, ready-first sort, advisory "Ready" badge, every row selectable (badge guides, doesn't gate).
- **U4** — threads the already-loaded `videoLibrary` into the chat panel (no extra fetch).
- **U3** — chat panel swaps the raw input for the "Choose a video" button + chosen-video chip; `handleGenerateSection` + the error surface are unchanged, so an ineligible pick still shows the existing backend error (R5).

## Verification

- `pnpm --filter @forge/admin typecheck` — clean.
- Tests: `live-data` (7), `anchor-video-picker` (6), `experience-chat-panel` (20), `block-helpers` (14) — **47 passed**. Acceptance examples covered: AE1 (choose→generate), AE2 (badge/sort), AE3 (error still surfaces).
- ESLint `--max-warnings=0` clean on all changed files.

## Notes — @tataihono

- **Independent of PR #1339.** This is editor-UX polish; #1339 is the fetch fix that makes "Generate section from video" actually function at all — that one is the real prerequisite for the feature to work in prod.
- Planning artifacts: `docs/brainstorms/2026-06-23-generate-section-anchor-video-picker-requirements.md` + `docs/plans/2026-06-23-001-feat-section-anchor-video-picker-plan.md` (not included in this branch's code commits).
- The "ready" badge is **advisory** (playable proxy = `previewStreamUrl != null` + `hasGrounding`); the section action stays authoritative. Tightening the badge to mirror `PLAYABLE_CANDIDATE_VIDEO_WHERE` exactly is a deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBrM8gC5uohxdnJZ5WKgS
