### PR TITLE
fix(admin): default section request timeout when env value is undefined

### DIFF
--- a/apps/admin/src/services/experience-ai/mastra-experience-section-client.ts
+++ b/apps/admin/src/services/experience-ai/mastra-experience-section-client.ts
@@ -110,6 +110,24 @@ function describeFetchError(error: unknown): string {
 
 type RawResponse = { status: number; bodyText: string }
 
+/** Fallback when the env-configured section timeout is missing/invalid. */
+const DEFAULT_SECTION_TIMEOUT_MS = 75_000
+
+/**
+ * Normalize the request timeout to a positive number. `env.MASTRA_SECTION_TIMEOUT_MS`
+ * is TYPED `number`, but at runtime it can arrive `undefined` (or a string)
+ * because t3-env's `skipValidation` path returns raw `process.env` without
+ * applying the Zod default — and passing that to `req.setTimeout` /
+ * `AbortSignal.timeout` throws `ERR_INVALID_ARG_TYPE`. Takes `unknown` so the
+ * runtime guards aren't elided by the (wrong) static type.
+ */
+function resolveTimeoutMs(value: unknown): number {
+  const ms = typeof value === "string" ? Number(value) : value
+  return typeof ms === "number" && Number.isFinite(ms) && ms > 0
+    ? ms
+    : DEFAULT_SECTION_TIMEOUT_MS
+}
+
 /**
  * POST the request over `node:http` instead of the global `fetch`.
  *
@@ -239,7 +257,9 @@ export async function launchMastraExperienceSection(
     "content-type": "application/json",
   }
   const bodyText = JSON.stringify(body)
-  const timeoutMs = options.timeoutMs ?? env.MASTRA_SECTION_TIMEOUT_MS
+  const timeoutMs = resolveTimeoutMs(
+    options.timeoutMs ?? env.MASTRA_SECTION_TIMEOUT_MS,
+  )
 
   let raw: RawResponse
   try {
@@ -304,4 +324,5 @@ export async function launchMastraExperienceSection(
 
 export const _internals = {
   parseSectionRouteResult,
+  resolveTimeoutMs,
 }

--- a/apps/admin/src/services/experience-ai/section-generator.test.ts
+++ b/apps/admin/src/services/experience-ai/section-generator.test.ts
@@ -174,3 +174,25 @@ describe("section client parseSectionRouteResult", () => {
     expect(_internals.parseSectionRouteResult({ foo: "bar" })).toBeNull()
   })
 })
+
+describe("section client resolveTimeoutMs", () => {
+  it("passes a valid positive number through", () => {
+    expect(_internals.resolveTimeoutMs(75_000)).toBe(75_000)
+  })
+
+  it("defaults when the value is undefined (skipValidation drops the env default)", () => {
+    expect(_internals.resolveTimeoutMs(undefined)).toBe(75_000)
+  })
+
+  it("coerces a numeric string (raw process.env value)", () => {
+    expect(_internals.resolveTimeoutMs("90000")).toBe(90_000)
+  })
+
+  it("defaults for non-numeric, zero, negative, or NaN inputs", () => {
+    expect(_internals.resolveTimeoutMs("not-a-number")).toBe(75_000)
+    expect(_internals.resolveTimeoutMs(0)).toBe(75_000)
+    expect(_internals.resolveTimeoutMs(-1)).toBe(75_000)
+    expect(_internals.resolveTimeoutMs(Number.NaN)).toBe(75_000)
+    expect(_internals.resolveTimeoutMs(null)).toBe(75_000)
+  })
+})


### PR DESCRIPTION
## What & why

After #1339 deployed, "Generate section from video" **still** errored in prod with "AI section service is unavailable" — but the diagnostic log #1339 added pinpointed the real cause:

```
[mastra-experience-section] event=fetch_failed host=forgemastra.railway.internal:8080
transport=node-http name=TypeError code=ERR_INVALID_ARG_TYPE
message=The "msecs" argument must be of type number. Received undefined
```

So #1339 worked — `node:http` now **reaches** mastra — but `req.setTimeout(env.MASTRA_SECTION_TIMEOUT_MS, …)` got `undefined` and threw. `MASTRA_SECTION_TIMEOUT_MS` is typed `number` with a Zod `.default(75000)`, but **t3-env's `skipValidation` path returns raw `process.env` without applying defaults**, so at runtime the value is `undefined` (or a bare string). The wrong static type hid it from the type-checker.

## Fix

`resolveTimeoutMs(value: unknown)` normalizes the timeout before it reaches `req.setTimeout` / `AbortSignal.timeout`: `undefined`/non-numeric/zero/negative → `75000`; numeric string → number; valid number passes through. Takes `unknown` so the runtime guards aren't elided by the (wrong) static `number` type.

One file changed (+ tests). No behavior change other than: the timeout is now always a valid positive number.

## Verification
- `pnpm --filter @forge/admin typecheck` — clean.
- `section-generator` test — 12 passed (incl. 4 new `resolveTimeoutMs` cases: valid number, undefined, numeric string, and non-numeric/0/negative/NaN/null → default).
- ESLint `--max-warnings=0` clean.

## Notes — @tataihono
- This is the **final blocker** for "Generate section from video" in prod. With this merged + deployed (on top of #1339 + #1341, both already on main), choosing a video → Generate produces a real grounded section.
- **Same latent bug** exists in the draft + chat clients (`AbortSignal.timeout(env.MASTRA_DRAFT_TIMEOUT_MS / _CHAT_TIMEOUT_MS)`) — out of scope here since those flags are off, but worth a follow-up before enabling them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBrM8gC5uohxdnJZ5WKgS
