### PR TITLE
fix(admin): portal AI-chat video picker so it isn't clipped to the chat column

### DIFF
--- a/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.test.tsx
@@ -59,9 +59,11 @@ function setInputValue(input: HTMLInputElement, value: string) {
   })
 }
 
-function rowKeys(container: HTMLElement): string[] {
+// The picker renders through a portal at <body>, so query the document, not
+// the mount container.
+function rowKeys(root: ParentNode = document.body): string[] {
   return Array.from(
-    container.querySelectorAll('[data-testid="anchor-video-picker-row"]'),
+    root.querySelectorAll('[data-testid="anchor-video-picker-row"]'),
   ).map((el) => el.getAttribute("data-video-key") ?? "")
 }
 
@@ -88,8 +90,30 @@ describe("AnchorVideoPicker", () => {
     )
     cleanup = view.cleanup
     expect(
+      document.body.querySelector('[data-testid="anchor-video-picker"]'),
+    ).toBeNull()
+  })
+
+  it("portals the overlay to <body>, not inside the mount container (escapes the chat panel's overflow-hidden aside)", () => {
+    const view = mount(
+      <AnchorVideoPicker
+        videoLibrary={[makeVideo({ key: "vid1" })]}
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    )
+    cleanup = view.cleanup
+
+    // The whole point of the fix: the fixed-position overlay must render at
+    // document.body so it isn't trapped/clipped by an overflow-hidden ancestor.
+    // It must NOT be a descendant of the component's own mount container.
+    expect(
       view.container.querySelector('[data-testid="anchor-video-picker"]'),
     ).toBeNull()
+    expect(
+      document.body.querySelector('[data-testid="anchor-video-picker"]'),
+    ).not.toBeNull()
   })
 
   it("badges ready videos and sorts them ahead of non-ready ones (Covers AE2)", () => {
@@ -124,22 +148,18 @@ describe("AnchorVideoPicker", () => {
     cleanup = view.cleanup
 
     // Ready video sorts first even though it was listed second.
-    expect(rowKeys(view.container)).toEqual([
-      "ready",
-      "not-ready",
-      "playable-only",
-    ])
+    expect(rowKeys()).toEqual(["ready", "not-ready", "playable-only"])
 
-    const badges = view.container.querySelectorAll(
+    const badges = document.body.querySelectorAll(
       '[data-testid="anchor-video-picker-ready-badge"]',
     )
     expect(badges).toHaveLength(1)
 
-    const readyRow = view.container.querySelector(
+    const readyRow = document.body.querySelector(
       '[data-video-key="ready"]',
     ) as HTMLElement
     expect(readyRow.getAttribute("data-ready")).toBe("true")
-    const playableRow = view.container.querySelector(
+    const playableRow = document.body.querySelector(
       '[data-video-key="playable-only"]',
     ) as HTMLElement
     // Playable but not grounded is NOT ready.
@@ -161,15 +181,15 @@ describe("AnchorVideoPicker", () => {
     )
     cleanup = view.cleanup
 
-    const search = view.container.querySelector(
+    const search = document.body.querySelector(
       '[data-testid="anchor-video-picker-search"]',
     ) as HTMLInputElement
 
     setInputValue(search, "nativ")
-    expect(rowKeys(view.container)).toEqual(["b"])
+    expect(rowKeys()).toEqual(["b"])
 
     setInputValue(search, "core-aaa")
-    expect(rowKeys(view.container)).toEqual(["a"])
+    expect(rowKeys()).toEqual(["a"])
   })
 
   it("calls onSelect with the row item and then onClose when a row is clicked", () => {
@@ -186,7 +206,7 @@ describe("AnchorVideoPicker", () => {
     )
     cleanup = view.cleanup
 
-    const row = view.container.querySelector(
+    const row = document.body.querySelector(
       '[data-video-key="pick-me"]',
     ) as HTMLButtonElement
     act(() => {
@@ -215,7 +235,7 @@ describe("AnchorVideoPicker", () => {
     )
     cleanup = view.cleanup
 
-    const row = view.container.querySelector(
+    const row = document.body.querySelector(
       '[data-video-key="bare"]',
     ) as HTMLButtonElement
     expect(row.getAttribute("data-ready")).toBe("false")
@@ -236,8 +256,8 @@ describe("AnchorVideoPicker", () => {
     )
     cleanup = view.cleanup
     expect(
-      view.container.querySelector('[data-testid="anchor-video-picker-empty"]'),
+      document.body.querySelector('[data-testid="anchor-video-picker-empty"]'),
     ).not.toBeNull()
-    expect(rowKeys(view.container)).toEqual([])
+    expect(rowKeys()).toEqual([])
   })
 })

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/anchor-video-picker.tsx
@@ -15,6 +15,7 @@
 
 import { CirclePlay, Search, Sparkles, X } from "lucide-react"
 import { useMemo, useState } from "react"
+import { createPortal } from "react-dom"
 
 import type { VideoLibraryItem } from "./block-helpers"
 
@@ -59,15 +60,20 @@ export function AnchorVideoPicker({
       .map((entry) => entry.item)
   }, [videoLibrary, query])
 
-  if (!open) return null
+  if (!open || typeof document === "undefined") return null
 
-  return (
+  // Render the overlay in a portal at <body>. The picker lives deep inside the
+  // chat panel's `sticky`, `overflow-hidden` <aside>; left in place, its
+  // `fixed inset-0` overlay is trapped + clipped to the ~380px chat column
+  // instead of covering the viewport. Portaling escapes that ancestor chain.
+  // Mirrors background-color-picker.tsx / bible-quote-card.tsx.
+  const overlay = (
     <div
       role="dialog"
       aria-modal="true"
       aria-labelledby="anchor-video-picker-title"
       data-testid="anchor-video-picker"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/40 p-4"
     >
       <div className="flex max-h-[80vh] w-full max-w-2xl flex-col overflow-hidden rounded-sm border border-[var(--color-hairline-strong)] bg-[var(--color-surface)] shadow-xl">
         {/* Header */}
@@ -192,4 +198,6 @@ export function AnchorVideoPicker({
       </div>
     </div>
   )
+
+  return createPortal(overlay, document.body)
 }

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-cross-locale-modal.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-cross-locale-modal.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { AlertTriangle, X } from "lucide-react"
+import { createPortal } from "react-dom"
 
 export function ExperienceChatCrossLocaleModal({
   open,
@@ -13,14 +14,17 @@ export function ExperienceChatCrossLocaleModal({
   onCancel: () => void
   onConfirm: () => void
 }) {
-  if (!open) return null
+  if (!open || typeof document === "undefined") return null
 
-  return (
+  // Portal at <body>: this modal renders inside the chat panel's `sticky`,
+  // `overflow-hidden` <aside>, which traps + clips a `fixed inset-0` overlay
+  // to the chat column. Same root cause + fix as AnchorVideoPicker.
+  const overlay = (
     <div
       role="dialog"
       aria-modal="true"
       aria-labelledby="cross-locale-modal-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-[120] flex items-center justify-center bg-black/40 p-4"
     >
       <div className="w-full max-w-md rounded-sm border border-[var(--color-hairline-strong)] bg-[var(--color-surface)] p-5 shadow-xl">
         <div className="flex items-start justify-between gap-3">
@@ -89,4 +93,6 @@ export function ExperienceChatCrossLocaleModal({
       </div>
     </div>
   )
+
+  return createPortal(overlay, document.body)
 }

--- a/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.test.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor/experience-chat-panel.test.tsx
@@ -234,7 +234,7 @@ describe("ExperienceChatPanel", () => {
     await act(async () => {
       chooseBtn.click()
     })
-    const row = view.container.querySelector(
+    const row = document.querySelector(
       '[data-video-key="vid1"]',
     ) as HTMLButtonElement
     await act(async () => {
@@ -310,7 +310,7 @@ describe("ExperienceChatPanel", () => {
     await act(async () => {
       chooseBtn.click()
     })
-    const row = view.container.querySelector(
+    const row = document.querySelector(
       '[data-video-key="vid1"]',
     ) as HTMLButtonElement
     await act(async () => {
@@ -360,7 +360,7 @@ describe("ExperienceChatPanel", () => {
       chooseBtn.click()
     })
     // A non-ready video is still selectable — the badge does not gate.
-    const row = view.container.querySelector(
+    const row = document.querySelector(
       '[data-video-key="bare"]',
     ) as HTMLButtonElement
     await act(async () => {


### PR DESCRIPTION
## Problem

In the admin Experience editor's **AI Chat** panel, clicking **Choose a video** opened the anchor-video picker, but the picker rendered as a narrow clipped slice trapped inside the ~380px chat column instead of covering the screen. The backdrop never covered the viewport and the dialog was cut off — effectively the picker was unusable. Reported as a production issue on `main`.

## Root cause

`AnchorVideoPicker` (and the sibling `ExperienceChatCrossLocaleModal`) render `fixed inset-0` overlays, but they live deep inside the chat panel's `<aside>`, which is `position: sticky` + `overflow-hidden`. That ancestor traps the fixed overlay to its box and clips it.

## Fix

- Render both overlays through `createPortal(overlay, document.body)`, guarded by `typeof document === "undefined"` — the same portal pattern already used by `background-color-picker.tsx` and `bible-quote-card.tsx` in the same folder.
- Raise the overlay to `z-[120]` (matching `bible-quote-card`) so it sits explicitly above the app shell's other `z-50` overlays rather than relying on DOM order.
- Both `fixed` overlays in the chat-panel subtree were affected; both are fixed (scanned to confirm there are no others).

## Verification

- `pnpm --filter @forge/admin typecheck` — clean
- eslint — clean; pre-commit hook (eslint + prettier) passed
- vitest: **27 pass**, including a new regression test asserting the overlay renders at `document.body` and **not** inside the component's mount container (locks in the portal-escape that is the whole point of the fix)
- Adversarial correctness review: no bugs; its two hardening suggestions (explicit z-index + portal-escape test) are applied

Not yet visually confirmed against a running stack (local stack was down); the change follows the established codebase portal pattern and is covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)