### PR TITLE
fix(search): use canonical Chinese slug in eval seed

### DIFF
--- a/apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/seed-prompt-set.test.ts
@@ -216,6 +216,11 @@ describe("search eval seed prompt set", () => {
           locale: "ar",
           languageSlug: "arabic-modern-standard",
         }),
+        expect.objectContaining({
+          id: "seed-chinese-vegetable-animation",
+          locale: "zh",
+          languageSlug: "mandarin-china",
+        }),
       ]),
     )
   })

--- a/apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts
+++ b/apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts
@@ -619,7 +619,7 @@ export const SEARCH_EVAL_SEED_PROMPTS: readonly SeedPromptCase[] = [
   seedPrompt({
     id: "seed-chinese-vegetable-animation",
     locale: "zh",
-    languageSlug: "chinese-mandarin-simplified",
+    languageSlug: "mandarin-china",
     websiteLocale: "en",
     queryText: "蔬菜总动员",
     tags: [


### PR DESCRIPTION
## Summary
The public Watch search readiness eval no longer aborts on the Chinese no-result seed. That seed now uses the canonical `zh` public Watch language slug (`mandarin-china`), which prod Admin resolves as a searchable language before running keyword-first search.

This keeps the existing no-result regression case intact while removing the invented `chinese-mandarin-simplified` slug that caused Admin to return `400: languageSlug must reference a searchable language`.

## Test Plan
- `pnpm --filter @forge/mastra test -- seed-prompt-set`
- `pnpm --filter @forge/mastra typecheck`
- Prod-backed focused eval probe for `callerTrack: public-watch`, `locales: ["zh"]`, `searchMode: keyword-first`: 1 query, 0 search failures, `languageSlug: "mandarin-china"`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
