### PR TITLE
fix: keep watch search running when URL sync fails

### DIFF
--- a/apps/web/src/components/FloatingSearchController.tsx
+++ b/apps/web/src/components/FloatingSearchController.tsx
@@ -355,7 +355,11 @@ export function FloatingSearchController({
         // router.replace() here dispatches an App Router/RSC navigation, which
         // can remount the overlay and clear a newer debounced search while the
         // viewer is still typing.
-        window.history.replaceState(window.history.state, "", nextUrl)
+        try {
+          window.history.replaceState(window.history.state, "", nextUrl)
+        } catch (error) {
+          console.warn("[FloatingSearch] failed to sync search URL", error)
+        }
       }
 
       if (!trimmed) {

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -73,6 +73,7 @@ afterEach(() => {
   })
   container.remove()
   document.body.innerHTML = ""
+  vi.restoreAllMocks()
   vi.clearAllMocks()
   vi.useRealTimers()
 })
@@ -1060,6 +1061,8 @@ describe("FloatingSearchProvider — search mode", () => {
 
     const historyState = { next: "preserve" }
     window.history.replaceState(historyState, "", "/watch?q=bible&utm=campaign")
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState")
+    const pushStateSpy = vi.spyOn(window.history, "pushState")
 
     const searchButton = document.querySelector(
       '[data-testid="search-mode-harness-button"]',
@@ -1073,6 +1076,12 @@ describe("FloatingSearchProvider — search mode", () => {
     expect(window.location.pathname).toBe("/watch")
     expect(window.location.search).toBe("?q=jesus&utm=campaign")
     expect(window.history.state).toEqual(historyState)
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      historyState,
+      "",
+      "/watch?q=jesus&utm=campaign",
+    )
+    expect(pushStateSpy).not.toHaveBeenCalled()
     expect(navigationMocks.replace).not.toHaveBeenCalled()
   })
 
@@ -1089,6 +1098,8 @@ describe("FloatingSearchProvider — search mode", () => {
 
     const historyState = { next: "preserve" }
     window.history.replaceState(historyState, "", "/watch?q=jesus&utm=campaign")
+    const replaceStateSpy = vi.spyOn(window.history, "replaceState")
+    const pushStateSpy = vi.spyOn(window.history, "pushState")
 
     const clearButton = document.querySelector(
       '[data-testid="search-mode-harness-clear-button"]',
@@ -1102,6 +1113,12 @@ describe("FloatingSearchProvider — search mode", () => {
     expect(window.location.pathname).toBe("/watch")
     expect(window.location.search).toBe("?utm=campaign")
     expect(window.history.state).toEqual(historyState)
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      historyState,
+      "",
+      "/watch?utm=campaign",
+    )
+    expect(pushStateSpy).not.toHaveBeenCalled()
     expect(navigationMocks.replace).not.toHaveBeenCalled()
     expect(mockedRunSearch).not.toHaveBeenCalled()
   })
@@ -1648,6 +1665,35 @@ describe("FloatingSearchProvider — search pagination", () => {
     } finally {
       mockedRunSearch.mockReset()
     }
+  })
+
+  it("continues search when browser history URL sync fails", async () => {
+    vi.useFakeTimers()
+    const urlSyncError = new DOMException("Throttled", "SecurityError")
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    vi.spyOn(window.history, "replaceState").mockImplementation(() => {
+      throw urlSyncError
+    })
+    mockedRunSearch.mockResolvedValueOnce(
+      makeSearchResponse(
+        [makeSearchResult("bible-project", "Bible Project Result")],
+        false,
+      ),
+    )
+
+    const input = await openSearchOverlay()
+    await submitDebouncedSearch(input, "the bible project")
+    await flushResolvedSearch()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[FloatingSearch] failed to sync search URL",
+      urlSyncError,
+    )
+    expect(mockedRunSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ query: "the bible project" }),
+    )
+    expect(document.body.textContent).toContain("Bible Project Result")
+    expect(document.querySelector(".animate-pulse")).toBeNull()
   })
 
   it("loads the next Watch search page with limit 10, current offset, and appends results", async () => {

--- a/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
+++ b/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
@@ -1,7 +1,7 @@
 ---
 title: "Watch search URL sync can strand the overlay in loading"
 date: "2026-06-15"
-last_updated: "2026-06-15"
+last_updated: "2026-06-23"
 category: "ui-bugs"
 module: "apps/web watch search"
 problem_type: "ui_bug"
@@ -11,6 +11,7 @@ symptoms:
   - "Editing a successful search into a second query can leave the URL behind the input and keep skeleton cards visible."
   - "Production `/watch` server-action POSTs can return 200 while the UI never renders result cards."
   - "The browser can post language metadata for the partial query without ever posting the final `runSearch` payload."
+  - "Edited searches can update the visible `?q=` parameter while the real `runSearch` action never fires."
 root_cause: "async_timing"
 resolution_type: "code_fix"
 severity: "high"
@@ -73,11 +74,17 @@ const browserPathname =
   typeof window !== "undefined" ? window.location.pathname : pathname
 const nextUrl = buildSearchUrl(browserPathname, currentParams, trimmed)
 if (nextUrl !== buildCurrentSearchUrl(browserPathname, currentParams)) {
-  window.history.replaceState(window.history.state, "", nextUrl)
+  try {
+    window.history.replaceState(window.history.state, "", nextUrl)
+  } catch (error) {
+    console.warn("[FloatingSearch] failed to sync search URL", error)
+  }
 }
 ```
 
 Use `window.location.pathname` for the browser-visible path so non-root public routes such as `/watch` stay intact when the query string changes.
+
+The history call is best-effort. If the browser rejects it, the search should still continue to `runSearch`; URL state is less important than returning results.
 
 Then make loading cleanup request-id-scoped and reusable so both normal completion and empty-query resets clear the active spinner without letting stale requests affect newer searches:
 
@@ -108,9 +115,10 @@ try {
 Lock the behavior with provider/controller tests:
 
 - Direct `?q=jesus` hydration calls `runSearch` and does not call `router.replace` for the same URL.
-- Changed queries sync `/watch?utm=campaign` to `/watch?q=jesus&utm=campaign`, preserve unrelated params, preserve a non-null `window.history.state`, and do not call `router.replace`.
+- Changed queries sync `/watch?utm=campaign` to `/watch?q=jesus&utm=campaign`, preserve unrelated params, preserve a non-null `window.history.state`, use `history.replaceState`, do not call `history.pushState`, and do not call `router.replace`.
 - Clearing search removes `q` without calling `runSearch`.
 - Editing from a completed `jesus` search through an intermediate debounced query to `the bible project` still calls `runSearch` for the final query and clears the pulsing skeleton cards.
+- A thrown `history.replaceState` logs a warning but does not prevent `runSearch`.
 - Resetting an in-flight search clears `loading` and `showSkeleton`.
 - A stale search resolving after a newer search starts does not clear the active loading state.
 
@@ -118,7 +126,7 @@ Lock the behavior with provider/controller tests:
 
 In a Next.js App Router page, `router.replace()` is not a harmless assignment. It can start client navigation and RSC work around the same time the search overlay is hydrating, exiting previous result cards, or holding a pending debounce for the user's next keystrokes.
 
-The direct query URL already contains the intended search state, so replacing it with itself gives the router a chance to interrupt the flow without adding any user value. For changed queries, the URL update is still useful, but it does not need a server navigation because the modal's input and results are controlled client-side. Native `replaceState()` keeps the address bar shareable without remounting the overlay or clearing pending debounce timers.
+The direct query URL already contains the intended search state, so replacing it with itself gives the router a chance to interrupt the flow without adding any user value. For changed queries, the URL update is still useful, but it does not need a server navigation because the modal's input and results are controlled client-side. Native `replaceState()` keeps the address bar shareable without remounting the overlay or clearing pending debounce timers. Preserving `window.history.state` keeps framework/browser state attached to the current entry, using `replaceState` avoids creating a new back-button entry for every debounced query, and catching failures prevents a best-effort URL write from aborting the user-visible search.
 
 The loading fix follows the controller's existing request-id model. Every search increments `requestIdRef`; only the currently winning request can clear `loading`, `showSkeleton`, and the skeleton timer. Empty-query reset is also a valid winning request, so it must run the same cleanup instead of invalidating the older request and returning with skeletons still visible.
 
@@ -127,10 +135,12 @@ The loading fix follows the controller's existing request-id model. Every search
 - Reproduce search bugs through the web page, not just one-off server-action probes. For App Router UI bugs, network success can coexist with broken client state.
 - Treat `router.replace()` as a navigation side effect. Before calling it from a hydrated overlay or modal, prove that a server navigation is actually needed.
 - For modal-owned URL state, prefer `window.history.replaceState(window.history.state, "", nextUrl)` so Next history metadata is preserved without dispatching RSC navigation.
+- Keep URL sync best-effort. If history mutation throws, log it and continue the user action.
 - Keep delayed skeleton timers paired with request-id cleanup. A reset path that increments the request id must also clear the active timer and loading flags.
 - Test both sides of URL sync: no-op URLs must not navigate, changed modal query URLs must update browser history without App Router navigation, and edited-query regressions must prove skeletons are gone after final results render.
 - Isolate URL-sync tests from mount hydration by mounting without `q`, then changing `window.history` immediately before the user action being tested.
 - Keep URL helper comments transport-neutral. A helper used by native history updates should describe browser search URL sync, not `router.replace()` calls.
+- Post-deploy smoke should inspect the page-level flow, not only final DOM: typing a broad query should produce a real search action POST, render result cards, and let Load more append without `Failed to load more results.`
 
 ## Related Issues
 


### PR DESCRIPTION
## Summary
Watch search now treats address-bar sync as best-effort, so a failed `history.replaceState` cannot abort the user-visible search flow before `runSearch` or Load more can proceed. This hardens the existing App Router fix for the production symptom where `/watch` can update `?q=` and post language metadata without ever rendering real results.

The regression coverage now proves changed-query sync uses `history.replaceState`, preserves the current history state, avoids `pushState` and `router.replace`, and still renders results when the browser rejects the URL write.

## Verification
- `pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx` (31 tests)
- `pnpm --filter @forge/web typecheck`
- `pnpm --filter @forge/web lint`
- `git diff --check`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md`

## Production Smoke After Deploy
Use `https://watch.jesusfilm.org/watch` and try `jesus`, then `bible`, then `life` if needed to find a query with Load more.

Healthy behavior:
- Typing the query updates the URL and renders result cards.
- The network trace includes a real Watch search server-action POST, not only language-options payloads.
- Clicking Load more sends a second search request, increases the visible result count, and does not show `Failed to load more results.`

Current-prod baseline observed before this PR: typing `jesus` updated the URL to `/watch?q=jesus`, but same-origin Watch POSTs were only language-options payloads and no real search results/Load more path appeared.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
