### PR TITLE
fix: keep Watch search Load More active

### DIFF
--- a/apps/web/src/components/FloatingSearchController.tsx
+++ b/apps/web/src/components/FloatingSearchController.tsx
@@ -39,7 +39,6 @@ type ActiveSearchSignature = {
   query: string
   languageEnglishNames: string[]
   languageSlug: string | null
-  languageKey: string
   routeLanguageSlug: string | null
   resultSource: SearchActionResultSource
   nextOffset: number
@@ -427,10 +426,6 @@ export function FloatingSearchController({
           query: trimmed.slice(0, 200),
           languageEnglishNames: [...activeLanguageEnglishNames],
           languageSlug: signatureLanguageSlug,
-          languageKey: searchLanguageKey(
-            activeLanguageEnglishNames,
-            signatureLanguageSlug,
-          ),
           routeLanguageSlug,
           resultSource: data.resultSource,
           nextOffset: data.nextOffset ?? newResults.length,
@@ -469,22 +464,8 @@ export function FloatingSearchController({
     const expectedSignature = activeSearchSignatureRef.current
     if (!expectedSignature) return
     const currentQuery = queryRef.current.trim().slice(0, 200)
-    const currentLanguageSlug =
-      resultSource === "algolia"
-        ? null
-        : (selectedSearchLanguageOptionRef.current?.publicSlug ??
-          expectedSignature.languageSlug)
-    const currentLanguageEnglishNames =
-      selectedLanguageEnglishNamesRef.current.length > 0
-        ? selectedLanguageEnglishNamesRef.current
-        : expectedSignature.languageEnglishNames
-    const currentLanguageKey = searchLanguageKey(
-      currentLanguageEnglishNames,
-      currentLanguageSlug,
-    )
     if (
       expectedSignature.query !== currentQuery ||
-      expectedSignature.languageKey !== currentLanguageKey ||
       expectedSignature.routeLanguageSlug !== routeLanguageSlug ||
       expectedSignature.resultSource !== resultSource
     ) {
@@ -728,16 +709,6 @@ export function FloatingSearchController({
         : null}
     </FloatingSearchContext.Provider>
   )
-}
-
-function searchLanguageKey(
-  languageEnglishNames: readonly string[],
-  languageSlug: string | null,
-): string {
-  return [
-    languageSlug ?? "",
-    normalizeSearchLanguageEnglishNames(languageEnglishNames).join("\u0001"),
-  ].join("\u0002")
 }
 
 function withSearchLanguageOptionsFallback(

--- a/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
+++ b/apps/web/src/components/__tests__/FloatingSearchProvider.test.tsx
@@ -258,6 +258,14 @@ async function flushResolvedSearch() {
   })
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 function PlaybackStatePublisher({
   detail,
 }: {
@@ -1704,5 +1712,98 @@ describe("FloatingSearchProvider — search pagination", () => {
       "Initial Bible Project Result 1",
     )
     expect(document.body.textContent).toContain("Next Bible Project Result 1")
+  })
+
+  it("continues pagination after delayed language metadata refreshes the default selection", async () => {
+    vi.useFakeTimers()
+    const languageMetadata =
+      deferred<Awaited<ReturnType<typeof getSearchLanguageOptions>>>()
+    mockedGetSearchLanguageOptions.mockReturnValue(languageMetadata.promise)
+    mockedRunSearch
+      .mockResolvedValueOnce(
+        searchResult("semantic", {
+          results: [videoResult("semantic-1")],
+          hasMore: true,
+          nextOffset: 10,
+          resolvedLanguage: {
+            locale: "en",
+            publicSlug: "english",
+            englishName: "English",
+            source: "fallback",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        searchResult("semantic", {
+          results: [videoResult("semantic-2")],
+          hasMore: false,
+          resolvedLanguage: {
+            locale: "en",
+            publicSlug: "english",
+            englishName: "English",
+            source: "fallback",
+          },
+        }),
+      )
+
+    act(() => {
+      root.render(
+        <SearchControllerTestShell>
+          <SearchModeHarness />
+        </SearchControllerTestShell>,
+      )
+    })
+
+    const searchButton = document.querySelector(
+      '[data-testid="search-mode-harness-button"]',
+    ) as HTMLButtonElement
+    const loadMoreButton = document.querySelector(
+      '[data-testid="search-mode-harness-load-more-button"]',
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      searchButton.click()
+      await Promise.resolve()
+    })
+    expect(mockedRunSearch).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1200)
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(mockedRunSearch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      languageMetadata.resolve({
+        ok: true,
+        algoliaEnabled: false,
+        options: [englishSearchLanguage],
+        countrySuggestion: null,
+        recommendedLanguage: null,
+        countryCode: null,
+        countryName: null,
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      loadMoreButton.click()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockedRunSearch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        query: "jesus",
+        offset: 10,
+        languageEnglishNames: [],
+        languageSlug: "english",
+      }),
+    )
   })
 })

--- a/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
+++ b/docs/solutions/ui-bugs/watch-search-url-hydration-perpetual-loading.md
@@ -9,6 +9,7 @@ component: "frontend_stimulus"
 symptoms:
   - "Opening `/watch?q=jesus` can show the search overlay and skeleton cards indefinitely."
   - "Editing a successful search into a second query can leave the URL behind the input and keep skeleton cards visible."
+  - "Clicking Load more can leave the visible result set unchanged when delayed language metadata refreshes after the first search."
   - "Production `/watch` server-action POSTs can return 200 while the UI never renders result cards."
   - "The browser can post language metadata for the partial query without ever posting the final `runSearch` payload."
 root_cause: "async_timing"
@@ -67,6 +68,12 @@ The backend was not simply timing out. Browser-level production tracing showed p
 The first repair kept URL synchronization but moved modal-owned query updates from App Router navigation to native browser history, then tightened request-id-scoped loading cleanup. That reduced App Router remount risk while preserving the shareable `?q=` contract.
 
 The current repair removes the URL-sync contract entirely for Watch search. The durable prevention rule is now simpler: page-level search bugs must be reproduced through the modal, and the modal must not depend on browser query params for active query, loading, results, or pagination state.
+
+## Follow-up: Load More Signature Drift
+
+Production smoke after the local-state merge showed typed search requests were firing with a clean URL, but the `Load more` button could still no-op. The controller had a defensive guard that compared the visible search signature against the mutable current language UI state before paging. When language metadata arrived after the first search and refreshed the default language selection, that guard treated the visible result set as stale and returned before calling `runSearch`.
+
+The follow-up fix keeps the query, route-language, and result-source guards, but stops comparing pagination against mutable post-search language UI defaults. Load More now pages from the active signature that produced the visible results. The regression test delays `getSearchLanguageOptions`, lets the initial search proceed through the fallback path, resolves English metadata afterward, and verifies the next-page request still fires with the original signature offset.
 
 ## Related Issues
 


### PR DESCRIPTION
## Summary
- keep Watch search pagination tied to the active result signature instead of mutable post-search language UI defaults
- add a regression test for delayed language metadata refreshing after the first search
- update the Watch search incident note with the Load More follow-up

## Validation
- pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx
- pnpm --filter @forge/web test -- src/components/__tests__/FloatingSearchProvider.test.tsx src/lib/routes.test.ts src/proxy.test.ts
- pnpm --filter @forge/web typecheck
- pnpm --filter @forge/web lint
- git diff --check