### PR TITLE
docs(ai-chat): brainstorm + roadmap tickets for exposing Seeker via Mastra route

### DIFF
--- a/docs/brainstorms/2026-06-24-expose-seeker-agent-mastra-route-requirements.md
+++ b/docs/brainstorms/2026-06-24-expose-seeker-agent-mastra-route-requirements.md
@@ -1,0 +1,131 @@
+---
+date: "2026-06-24"
+topic: "expose-seeker-agent-mastra-route"
+---
+
+# Expose the Seeker Agent via a Mastra Service Route
+
+## Summary
+
+Add a new internal Mastra service route (e.g. `/forge-seeker`) that streams the existing `seekerAgent` over Server-Sent Events, behind the existing `MASTRA_SERVICE_API_KEYS` service-bearer auth. It is called server-to-server by another app's backend (the chat app is the first consumer), carries a required `threadId` (and an optional `resourceId`) per request for per-session conversation isolation, and mirrors the existing `/forge-experience-chat` route. This unlocks end-to-end internal dogfooding of Seeker without crossing the documented production safety gate.
+
+## Problem Frame
+
+`seekerAgent` exists and is exercised through Mastra Studio. `apps/mastra/src/mastra/seeker-route-isolation.test.ts` asserts it is absent from the custom route region and referenced exactly twice in `index.ts` — but that guard only proves "no custom `/forge-*` route wires it up." It does **not** prove the agent is unreachable: Mastra's framework auto-exposes every registered agent on a built-in, code-unauthenticated `/api/agents/*` surface (generate/stream), and this app attaches no global auth there. So Seeker is already reachable, without a bearer, to anything that can reach the Mastra endpoint. The real containment today is the network boundary (see Dependencies / Assumptions), not the isolation test. `apps/mastra/CLAUDE.md` documents three release gates (full safety/crisis guardrails, a gateway-access decision, and Postgres-persisted memory) before Seeker is exposed to real users.
+
+The cost today is that no consuming app can exercise Seeker over a _stable, bearer-gated contract_ — only the raw, unauthenticated built-in surface exists, which is not something a consumer should build against. This work adds a guarded `/forge-seeker` route for **internal** dogfooding while keeping the production gates closed. Notably, the new route is _more_ locked down than the surface that already exists, not less.
+
+## Key Decisions
+
+- **Internal dogfooding only; stay behind the safety gate.** The route is for trusted internal callers exercising Seeker end-to-end. The deferred guardrails (crisis routing, anti-fabrication, AI-disclosure) and Postgres-persisted memory remain out of scope. This is not productionizing Seeker.
+
+- **Server-to-server is the chosen access model — not a stepping stone.** The route is an internal service surface authenticated by service bearer, called by a consuming app's backend (matching how admin calls `/forge-experience-chat`). The service bearer never reaches a browser, and the route adds no CORS. Browser-direct access is not a planned future direction; if it were ever needed it would be a separate decision made on its own merits, not something this work anticipates or builds toward.
+
+- **SSE streaming, mirroring `/forge-experience-chat`.** Seeker is conversational, so the route streams `token_delta` frames as the agent generates and a final `result` frame, with `error` frames on failure. The streaming transport (ReadableStream, frame vocabulary, abort/budget composition) is copied from the chat route rather than reinvented. **One caveat:** the chat route passes only `{ maxSteps, abortSignal }` to `agent.stream(...)` and threads no `threadId`/`resourceId` — so per-session memory keying is _not_ inherited from the template and is net-new work for this route (see Outstanding Questions — it is the key technical risk).
+
+- **`resourceId` is an optional, opaque forward-compatibility seam.** `threadId` is required (it drives memory isolation); `resourceId` is **optional** — the route forwards it into the agent call if present and interprets it never. It is not required for v1 because nothing consumes it yet, so callers aren't forced to invent a placeholder. When real user auth lands, the consumer starts passing the authenticated user id as `resourceId` with no change to the route contract.
+
+- **Reversing the isolation guard is explicit, not bypassed.** Wiring the route necessarily changes `seeker-route-isolation.test.ts`. That test is updated as a deliberate, reviewed decision that records the new "Seeker is internally exposed, still gated from public" intent — it is not deleted or silently relaxed.
+
+## Requirements
+
+**Route and contract**
+
+- R1. A new POST service route (working name `/forge-seeker`) is registered in `apps/mastra/src/mastra/index.ts`'s `apiRoutes`, following the existing `registerApiRoute(...)` pattern.
+- R2. The route accepts a JSON body containing a required `prompt` (the seeker's message) and a required `threadId`, plus an optional `resourceId`. Missing or empty `prompt` or `threadId` produces a 400 before the agent is invoked; an absent `resourceId` is accepted.
+- R3. The route responds with an SSE stream emitting `token_delta` frames during generation and a terminal `result` frame that carries both the assistant text and the `sources[]` returned by `retrieveAnswer` (so a dogfooder can see whether the answer is grounded in real cited passages). Failures emit an `error` frame.
+- R4. The route looks up the agent via the Mastra instance by id (`seekerAgent`) rather than importing it directly into the handler, consistent with the `getMastra()` thunk pattern used by the chat route.
+
+**Auth and access**
+
+- R5. The route validates the `Authorization: Bearer <key>` header against `MASTRA_SERVICE_API_KEYS` using the existing `isValidServiceBearer` check; an invalid or missing bearer returns 401 before any agent work.
+- R6. The route adds no CORS headers — it is server-to-server only.
+
+**Conversation state**
+
+- R7. The required `threadId` (and the `resourceId` if present) is threaded into the agent invocation so each conversation has isolated multi-turn memory and no cross-session history bleed through the shared in-memory singleton. The exact `agent.stream(...)` mechanism for passing these (and whether the thread must be created before first recall) is net-new versus the chat-route template and rests on an unverified Mastra API contract — see Outstanding Questions. If `agent.stream(...)` turns out not to honor per-thread memory, the accepted fallback for v1 is stateless / no-memory dogfooding (each turn independent) rather than blocking the route; AE3 is therefore contingent on that contract holding. Even under that fallback the route still earns its build cost — it gives consumers a stable, bearer-gated contract to build against instead of the raw unauthenticated `/api/agents/*` surface (see Problem Frame) — multi-turn memory is the upside, not the whole justification.
+- R8. The route treats `resourceId` as opaque and never branches on its value; `threadId` is the field that drives memory isolation. Isolation holds only if callers send distinct, non-colliding `threadId`s — the route does not namespace or validate ownership of them. This is a **conscious v1 decision**: for the single-trusted-consumer dogfooding phase (Dependencies / Assumptions) the route accepts that any bearer holder supplying another session's `threadId` can read it. The named hardening path, required before a second caller joins the bearer allowlist, is either a dedicated per-route key or route-level `threadId` namespacing (e.g. caller-id prefix) — see Dependencies / Assumptions.
+
+**Generation safety limits**
+
+- R9. The generation is bounded by an abort/time budget and a step cap, consistent with how the chat route bounds `agent.stream(...)` (`TIME_BUDGET_MS` + `STEP_CAPS`). Reusing the existing chat budget or adding a seeker-specific constant is a planning decision.
+- R10. The inbound request's abort signal is honored so a disconnected caller cancels in-flight generation.
+- R11. Before opening the SSE stream, the route checks the model-key **accessor** (`getOpenRouterApiKey()`, which resolves `OPENROUTER_API_PAID_KEY ?? OPENROUTER_API_KEY`) — not the bare `OPENROUTER_API_KEY` var, which would false-trip when only the paid key is set. If no key resolves, the route returns a clean upfront error (e.g. 503 with a fixed reason like `model_key_missing`) and does not start streaming or invoke the agent. The key stays **optional at boot** — other agents fall back to OpenAI, so a blanket boot requirement would needlessly brick deploys that don't use Seeker. This is a route-level, first-use precondition so a misconfigured Seeker fails early and legibly rather than mid-stream.
+
+**Output safety**
+
+- R12. Caller-facing frames carry no internal topology. `error` frames expose a fixed-vocabulary `reason`, not raw exception text (RAG base URL, internal hostnames, upstream provider error bodies) — raw detail goes to server-side logs only. The same constraint applies to `sources[]` in the `result` frame: only the source fields a consumer needs (e.g. title, public URL, snippet, score) are emitted, not internal retrieval-infrastructure detail. The exact emitted-field set and reason vocabulary is a planning detail; that _some_ sanitization happens is a requirement. (The leak surface is already small: `retrieveAnswer` returns a `.strict()` envelope `{ status, sources, message? }` where each source is itself `.strict()` — `{ text, sourceName, title, url, score }` — with internal fields excluded at the tool boundary, so R12 mainly ensures the route doesn't widen it.)
+
+**Isolation guard**
+
+- R13. `apps/mastra/src/mastra/seeker-route-isolation.test.ts` is updated to reflect that `seekerAgent` is now intentionally wired into one service route, with assertions that still pin the intended exposure (e.g. exactly one `/forge-seeker` route, still no other route references) rather than removing the guard.
+
+## Key Flows
+
+- F1. Internal seeker turn (happy path)
+  - **Trigger:** A consuming app's backend receives a user message and POSTs to `/forge-seeker`.
+  - **Actors:** consuming-app backend (caller), Mastra route handler, `seekerAgent`, `retrieveAnswer` RAG tool.
+  - **Steps:** Caller sends `{ prompt, threadId, resourceId? }` with a service bearer → route validates bearer → route validates body → route looks up `seekerAgent` → `agent.stream(...)` runs under the abort/budget signal, calling `retrieveAnswer` → handler relays `token_delta` frames, then a `result` frame carrying text + sanitized `sources[]`.
+  - **Covered by:** R1, R2, R3, R4, R5, R7, R9, R10, R12.
+
+- F2. Rejected/failed calls
+  - **Trigger:** Missing bearer, malformed body, missing model key, a first-turn thread-creation failure, or a generation error/timeout.
+  - **Steps:** Invalid bearer → 401; missing `prompt` or `threadId` → 400; model key absent → 503 upfront (no stream opened, agent not invoked); if the supplied `threadId` has no existing thread and the route/`stream()` does not create it, the first turn surfaces as an `error` frame (this is the common path, not an edge case — see Outstanding Questions); mid-stream failure or budget timeout → terminal `error` frame with a sanitized `reason`.
+  - **Covered by:** R2, R3, R5, R10, R11, R12.
+
+## Acceptance Examples
+
+- AE1. Covers R5. **Given** a request with no `Authorization` header, **when** it hits `/forge-seeker`, **then** the response is 401 and the agent is never invoked.
+- AE2. Covers R2. **Given** a valid bearer but a body missing `threadId`, **when** the route runs, **then** it returns 400 before invoking the agent.
+- AE3. Covers R7. **Given** two requests with different `threadId`s in the same process, **when** both converse, **then** neither sees the other's prior turns. (Contingent on `agent.stream(...)` honoring per-thread memory — see R7; if the contract does not hold, the v1 fallback is stateless dogfooding and this example is waived.)
+- AE3b. Covers R2. **Given** a valid bearer and a valid `prompt` + `threadId` but **no** `resourceId`, **when** the route runs, **then** the request is accepted and the agent is invoked (`resourceId` is optional).
+- AE3c. Covers R7 (the positive case). **Given** two turns sent on the **same** `threadId`, **when** the second turn arrives, **then** the agent can recall context from the first. This is the real proof that multi-turn memory works — AE3's non-bleed check passes vacuously even with no memory, so AE3c is what distinguishes working memory from the stateless fallback. Like AE3, it is contingent on the `agent.stream(...)` memory contract.
+- AE4. Covers R3. **Given** a valid request, **when** the agent generates, **then** the caller receives one or more `token_delta` frames followed by exactly one `result` frame carrying both the assistant text and `sources[]`.
+- AE5. Covers R10. **Given** the caller aborts mid-stream, **when** the abort propagates, **then** in-flight generation is cancelled.
+- AE6. Covers R11. **Given** no OpenRouter key resolves (neither `OPENROUTER_API_PAID_KEY` nor `OPENROUTER_API_KEY` set), **when** a valid request hits `/forge-seeker`, **then** the route returns a 503 with a fixed reason before opening the stream, and the agent is never invoked.
+
+## Scope Boundaries
+
+**Deferred for later (not v1, but plausible next)**
+
+- Postgres-persisted Seeker memory — conversations remain in-memory and are lost on Mastra restart/redeploy. Acceptable for dogfooding; the durable path is a separate release gate.
+- Full safety/crisis guardrails (crisis routing, anti-fabrication, AI-disclosure) — a hard gate on **who may reach Seeker**, not just on "public launch." Required before Seeker is reachable by anyone outside the dev/product dogfooding circle. Enforcing that boundary (e.g. a default-off feature flag gating Seeker vs. the stub agent, scoped to allowlisted users) is consuming-app work, but this route must not be opened wider until the guardrail gate is met. The risk this addresses is accidental exposure — a shared link or a flag defaulting on — reaching a vulnerable user before crisis handling exists.
+- A Mastra-side `SEEKER_ROUTE_ENABLED`-style env flag (default off) as belt-and-suspenders defense-in-depth — possible later hardening, not a v1 requirement. The primary access control for this phase lives on the consuming-app side (it decides whether a human's message reaches Seeker at all). A route-side flag would NOT close the already-open unauthenticated `/api/agents/*` path (that needs separate global-auth work that previously broke Studio), so it is intentionally out of scope here rather than relied upon.
+
+**Outside this work's identity**
+
+- Browser-direct access and CORS — server-to-server is the deliberate model (Key Decisions), not a phase-one limitation.
+- A gateway-access / public-exposure decision — owned by the documented gateway gate, not this route.
+- All chat-app-side wiring (what the consumer sends as `resourceId`, UI, transport) — separate work on the consuming app. **Reminder for that work:** the consumer must mint/scope `threadId`s server-side (e.g. a UUID generated at "new conversation", bound to the user/session, with ownership re-checked on reuse) and must **not** forward browser-supplied `threadId`s verbatim — otherwise a user can supply or enumerate another session's `threadId` and read its conversation (the route treats `threadId` opaquely per R8 and cannot prevent this).
+
+## Dependencies / Assumptions
+
+- **Outer boundary is `apps/mastra`'s private-only Railway networking.** The `@forge/mastra` Railway service has no public domain — it is reachable only from within Railway's private network, not the public internet. This is the load-bearing control that makes "internal" real; the service bearer is a second layer on top. A future reader who enables public networking on this service has changed a foundational assumption and must revisit the whole exposure model. Concretely, before public networking is enabled the built-in unauthenticated `/api/agents/*` surface must be auth-gated (or `seekerAgent` de-registered from auto-exposure) — otherwise Seeker becomes publicly reachable with no bearer regardless of R5. This route's bearer gate does not cover that path.
+- **The shared bearer's blast radius is accepted.** `MASTRA_SERVICE_API_KEYS` is one CSV allowlist shared across all `/forge-*` routes; this work adds Seeker to that radius without a dedicated per-route key. Acceptable for dogfooding behind the private-network boundary; a dedicated bearer is a possible later hardening, not a v1 requirement.
+- Assumes the consuming app has a server-side surface that can hold the service bearer and proxy browser traffic (the chat app's backend is the intended first caller). The route makes no assumption about who that caller is beyond a valid bearer.
+- **Assumes a single trusted consumer (consciously accepted for v1).** `threadId` isolation rests on callers sending distinct ids; with one trusted backend (chat) inside the private network this holds. It is not a guarantee against a second bearer-holder reusing or guessing another thread's id. This is accepted as a v1 decision, not deferred indefinitely: before a second caller is added to `MASTRA_SERVICE_API_KEYS`, the route must adopt a dedicated per-route key or `threadId` namespacing (R8).
+- Assumes the in-memory singleton memory is acceptable for dogfooding: conversations are not durable across restarts, and `resourceId` carries no real identity until auth exists.
+- Assumes `MASTRA_SERVICE_API_KEYS` is provisioned for the environments where the route is exercised (optional in dev, required in production per `assertMastraRuntimeEnv()`).
+- Seeker's model (`openrouter/google/gemma-4-31b-it:free`) needs an OpenRouter key (`OPENROUTER_API_PAID_KEY` or `OPENROUTER_API_KEY`), but it stays optional at boot (other agents fall back to OpenAI). Its absence is caught by the route's first-use preflight (R11) as an upfront 503, not deferred to a mid-stream failure or enforced as a blanket boot requirement.
+
+## Outstanding Questions
+
+**Deferred to Planning**
+
+- **Key technical risk — verify first.** Two facets of `agent.stream(...)` are both net-new versus the chat-route template (which consumes only `output.textStream`) and must be probed against Mastra's API before committing to the implementation shape: (1) **memory keying** — how `stream(...)` accepts `threadId`/`resourceId`, and whether a thread needs explicit creation before first recall (the memory tests show `recall` on a never-created thread _throws_ rather than returning empty, so a fresh-thread first turn could crash unless the route or `stream()` creates it); and (2) **tool-result extraction** — how to surface `retrieveAnswer`'s `sources[]` (R3) from the stream return value, since the mirrored template never reads tool results. Do not assume either falls out of the text-stream relay.
+- Whether the route reuses the existing `TIME_BUDGET_MS.chatTurn` (90s) and `STEP_CAPS.toolCallingTurn` (8) or introduces seeker-specific constants. If a seeker-specific budget is added, the `error`-frame reason classification (`timeout` vs `generation_failed`) must travel with it.
+- Final route name (`/forge-seeker` is the working name) and request body field names.
+- The exact emitted-field set for `sources[]` in the `result` frame and the `error`-frame `reason` vocabulary (R3 fixes that sources are included and R12 fixes that both are sanitized; the precise field layout and reason strings are planning details).
+- Exact reshaping of `seeker-route-isolation.test.ts` assertions to pin the new intended exposure (R4's lookup-by-id implies no new import, so the `seekerAgent` occurrence count moves 2 → 3).
+
+## Sources / Research
+
+- `apps/mastra/src/mastra/index.ts` — Mastra instance, agent registry, `apiRoutes` registration pattern (`registerApiRoute`), `getMastra()` thunk, `serviceKeys` from `MASTRA_SERVICE_API_KEYS`.
+- `apps/mastra/src/mastra/agents/experience-chat-route.ts` — the SSE streaming handler to mirror (frames, abort/budget signals, bearer check).
+- `apps/mastra/src/mastra/agents/seeker-agent.ts` — Seeker definition (`id: "seekerAgent"`, single `retrieveAnswer` tool, attached memory, deferred guardrail attach-point).
+- `apps/mastra/src/mastra/tools/retrieve-answer.ts` — RAG tool I/O schema (`status`, `sources[]`, `message`).
+- `apps/mastra/src/server/service-bearer.ts` — `isValidServiceBearer` timing-safe allowlist check.
+- `apps/mastra/src/mastra/memory.ts` — in-memory Seeker memory singleton (no Postgres; per-session isolation needs distinct `threadId`).
+- `apps/mastra/src/mastra/budgets.ts` — `TIME_BUDGET_MS`, `STEP_CAPS`.
+- `apps/mastra/src/mastra/seeker-route-isolation.test.ts` — the guard this work intentionally updates.
+- `apps/mastra/CLAUDE.md` — service-bearer convention and the three documented release gates (guardrails, gateway, persisted memory).

--- a/docs/roadmap/ai-chat/README.md
+++ b/docs/roadmap/ai-chat/README.md
@@ -11,21 +11,23 @@ from the main DS Year 1 roadmap.
 > index, and nothing regenerates or overwrites it. See `CLAUDE.md` in this
 > folder for the maintenance rules and why the lane is unregistered.
 
-## Status (June 22, 2026)
+## Status (June 24, 2026)
 
-- **Total tickets:** 6
+- **Total tickets:** 8
 - ✅ **Complete:** 4
 - 🟡 **In progress:** 0
-- 🔵 **Not started:** 2
+- 🔵 **Not started:** 4
 - 🔴 **Blocked:** 0
 
 ## Feature Index
 
-| ID                                                        | Feature                                      | Owner    | Priority | Start      | Days | Status         | Code PR |
-| --------------------------------------------------------- | -------------------------------------------- | -------- | -------- | ---------- | ---- | -------------- | ------- |
-| [feat-198](feat-198-seeker-agent-skeleton.md)             | Seeker Agent Skeleton                        | jian wei | P2       | 2026-06-09 | 3    | ✅ complete    | #1279   |
-| [feat-199](feat-199-seeker-rag-retrieval-connection.md)   | Seeker Agent RAG Retrieval Connection        | jian wei | P2       | 2026-06-10 | 3    | ✅ complete    | #1279   |
-| [feat-200](feat-200-chat-app-scaffold.md)                 | Chat app scaffold with stubbed agent         | jian wei | P1       | 2026-06-10 | 3    | ✅ complete    | #1276   |
-| [feat-201](feat-201-chat-app-vigil-reskin.md)             | Chat app Vigil re-skin + conversation shell  | jian wei | P1       | 2026-06-15 | 1    | ✅ complete    | #1276   |
-| [feat-202](feat-202-seeker-rag-runtime-hardening.md)      | Seeker RAG runtime hardening                 | jian wei | P2       | 2026-06-18 | 2    | 🔵 not-started | —       |
-| [feat-203](feat-203-chat-sidebar-component-extraction.md) | Chat sidebar component + behavior extraction | jian wei | P2       | 2026-07-01 | 2    | 🔵 not-started | —       |
+| ID                                                         | Feature                                                   | Owner    | Priority | Start      | Days | Status         | Code PR |
+| ---------------------------------------------------------- | --------------------------------------------------------- | -------- | -------- | ---------- | ---- | -------------- | ------- |
+| [feat-198](feat-198-seeker-agent-skeleton.md)              | Seeker Agent Skeleton                                     | jian wei | P2       | 2026-06-09 | 3    | ✅ complete    | #1279   |
+| [feat-199](feat-199-seeker-rag-retrieval-connection.md)    | Seeker Agent RAG Retrieval Connection                     | jian wei | P2       | 2026-06-10 | 3    | ✅ complete    | #1279   |
+| [feat-200](feat-200-chat-app-scaffold.md)                  | Chat app scaffold with stubbed agent                      | jian wei | P1       | 2026-06-10 | 3    | ✅ complete    | #1276   |
+| [feat-201](feat-201-chat-app-vigil-reskin.md)              | Chat app Vigil re-skin + conversation shell               | jian wei | P1       | 2026-06-15 | 1    | ✅ complete    | #1276   |
+| [feat-202](feat-202-seeker-rag-runtime-hardening.md)       | Seeker RAG runtime hardening                              | jian wei | P2       | 2026-06-18 | 2    | 🔵 not-started | —       |
+| [feat-203](feat-203-chat-sidebar-component-extraction.md)  | Chat sidebar component + behavior extraction              | jian wei | P2       | 2026-07-01 | 2    | 🔵 not-started | —       |
+| [feat-204](feat-204-expose-seeker-mastra-service-route.md) | Expose Seeker agent via internal Mastra SSE service route | jian wei | P2       | 2026-06-24 | 3    | 🔵 not-started | —       |
+| [feat-205](feat-205-chat-wire-seeker-route.md)             | Wire chat app to the Seeker Mastra route                  | jian wei | P1       | 2026-06-27 | 3    | 🔵 not-started | —       |

--- a/docs/roadmap/ai-chat/feat-199-seeker-rag-retrieval-connection.md
+++ b/docs/roadmap/ai-chat/feat-199-seeker-rag-retrieval-connection.md
@@ -8,7 +8,8 @@ start_date: "2026-06-10"
 duration: 3
 depends_on:
   - "feat-198"
-blocks: []
+blocks:
+  - "feat-204"
 tags:
   - "search"
 ---

--- a/docs/roadmap/ai-chat/feat-204-expose-seeker-mastra-service-route.md
+++ b/docs/roadmap/ai-chat/feat-204-expose-seeker-mastra-service-route.md
@@ -1,0 +1,71 @@
+---
+id: "feat-204"
+title: "Expose Seeker agent via internal Mastra SSE service route"
+owner: "jian wei"
+priority: "P2"
+status: "not-started"
+start_date: "2026-06-24"
+duration: 3
+depends_on:
+  - "feat-199"
+blocks:
+  - "feat-205"
+tags:
+  - "ai-pipeline"
+  - "infrastructure"
+---
+
+## Problem
+
+`seekerAgent` (feat-198/feat-199) runs in Mastra Studio but is deliberately kept off every custom `/forge-*` route — `apps/mastra/src/mastra/seeker-route-isolation.test.ts` enforces this. No consuming app can exercise Seeker over a stable, bearer-gated contract; the only thing exposing it today is Mastra's built-in, code-unauthenticated `/api/agents/*` surface, which is not something a consumer should build against.
+
+This adds a guarded `/forge-seeker` SSE service route so the chat app (the first consumer) can dogfood Seeker end-to-end, **internally**, behind the existing private-network + service-bearer boundary and **without** crossing the documented production release gates (full safety/crisis guardrails, gateway-access decision, Postgres-persisted memory). The new route is _more_ locked down than the already-open built-in surface, not less.
+
+Full requirements + decisions: `docs/brainstorms/2026-06-24-expose-seeker-agent-mastra-route-requirements.md`.
+
+## Entry Points — Read These First
+
+1. `docs/brainstorms/2026-06-24-expose-seeker-agent-mastra-route-requirements.md` — the brainstorm; R1–R13, flows, acceptance examples, and the key technical risk all live here.
+2. `apps/mastra/src/mastra/agents/experience-chat-route.ts` — the SSE streaming handler to mirror (frame vocabulary `token_delta`/`result`/`error`, abort/budget composition, bearer check). NOTE: it threads no `threadId`/`resourceId` and reads only `output.textStream` — memory keying AND tool-result (`sources[]`) extraction are net-new here.
+3. `apps/mastra/src/mastra/index.ts` — `apiRoutes` + `registerApiRoute`, the `getMastra()` thunk lookup pattern, `serviceKeys` from `MASTRA_SERVICE_API_KEYS`.
+4. `apps/mastra/src/mastra/agents/seeker-agent.ts` — `id: "seekerAgent"`, single `retrieveAnswer` tool, attached in-memory `Memory`, lazy OpenRouter key read at generate time.
+5. `apps/mastra/src/mastra/memory.ts` + `memory.test.ts` — `getSeekerMemory()` singleton; `recall` on a never-created thread **throws**, so first-turn thread creation must be handled.
+6. `apps/mastra/src/mastra/tools/retrieve-answer.ts` — RAG tool output `{ status, sources, message? }`, each source `.strict()` `{ text, sourceName, title, url, score }`.
+7. `apps/mastra/src/server/service-bearer.ts` — `isValidServiceBearer`.
+8. `apps/mastra/src/config/env.ts` — `getOpenRouterApiKey()` (`OPENROUTER_API_PAID_KEY ?? OPENROUTER_API_KEY`); both optional at boot.
+9. `apps/mastra/src/mastra/budgets.ts` — `TIME_BUDGET_MS.chatTurn` (90s), `STEP_CAPS.toolCallingTurn` (8).
+
+## Grep These
+
+- `registerApiRoute` / `apiRoutes` in `index.ts` — where the route registers.
+- `seekerAgent` in `index.ts` — currently 2 occurrences; the isolation test asserts exactly that and must move to allow the new route.
+- `handleExperienceChatRouteRequest` / `text/event-stream` — the streaming template.
+- `getOpenRouterApiKey` — the accessor the preflight (R11) must call, NOT the bare `OPENROUTER_API_KEY`.
+- `recall` / `saveThread` in `memory.test.ts` — the throw-on-missing-thread behavior.
+
+## What To Build
+
+A `POST /forge-seeker` service route in `apps/mastra/src/mastra/index.ts`'s `apiRoutes`, mirroring `/forge-experience-chat`:
+
+- Body: required `prompt` + `threadId`, optional `resourceId` (forwarded opaquely, never interpreted). Missing `prompt`/`threadId` → 400; absent `resourceId` accepted. (R2, R7, R8)
+- Service-bearer auth via `isValidServiceBearer` against `MASTRA_SERVICE_API_KEYS`; no CORS (server-to-server only). (R5, R6)
+- First-use preflight: if `getOpenRouterApiKey()` resolves nothing → 503 `model_key_missing` before opening the stream. (R11)
+- SSE stream: `token_delta` frames + terminal `result { text, sources }` (sanitized) + `error` frames; bounded by abort/time budget + step cap; honor inbound abort signal. (R3, R9, R10, R12)
+- Thread the `threadId` (and `resourceId` if present) into `agent.stream(...)` for per-session memory; handle first-turn thread creation. **Key risk:** the `agent.stream(...)` memory-keying + tool-result-extraction contract is unverified against this Mastra version — probe it first. If memory keying can't be made to work, the accepted v1 fallback is stateless dogfooding (AE3/AE3c waived). (R7)
+- Output sanitization: `error` frames carry a fixed-vocabulary `reason` only; `sources[]` emits consumer-facing fields only — no raw exception text / internal hostnames. (R12)
+- Update `seeker-route-isolation.test.ts` deliberately to pin the new intended exposure (exactly one `/forge-seeker` route, still no other route references; `seekerAgent` occurrences move 2 → 3 via lookup-by-id, no new import). (R13)
+
+## Constraints
+
+- **Internal dogfooding only — do NOT cross the release gates.** Safety/crisis guardrails and Postgres-persisted memory stay deferred; this is gated behind private networking + the consuming-app feature flag, not productionized.
+- **Server-to-server is the chosen model**, not a stepping stone — no CORS, no browser-direct path.
+- **No new required-at-boot env var.** `OPENROUTER_API_KEY` stays optional; the route-level preflight handles its absence.
+- **Do not weaken the isolation guard** — update it as a reviewed decision, don't delete it.
+- Chat-app wiring is out of scope (separate work). That work must mint/scope `threadId`s server-side and not forward browser-supplied ones — see the brainstorm's Scope Boundaries.
+
+## Verification
+
+- `pnpm --filter @forge/mastra test` — add route cases mirroring the brainstorm's acceptance examples: 401 on missing bearer (AE1); 400 on missing `threadId` (AE2); request accepted with no `resourceId` (AE3b); same-`threadId` recall works (AE3c, contingent); `token_delta`→`result{text,sources}` shape (AE4); abort cancels mid-stream (AE5); 503 before stream when no OpenRouter key resolves (AE6); updated isolation-guard assertions (R13).
+- `pnpm --filter @forge/mastra typecheck && pnpm --filter @forge/mastra lint`.
+- Confirm `assertMastraRuntimeEnv` gains no new required env var.
+- Manually probe the `agent.stream(...)` memory + `sources[]` contract before locking the implementation shape.

--- a/docs/roadmap/ai-chat/feat-205-chat-wire-seeker-route.md
+++ b/docs/roadmap/ai-chat/feat-205-chat-wire-seeker-route.md
@@ -1,0 +1,61 @@
+---
+id: "feat-205"
+title: "Wire chat app to the Seeker Mastra route"
+owner: "jian wei"
+priority: "P1"
+status: "not-started"
+start_date: "2026-06-27"
+duration: 3
+depends_on:
+  - "feat-204"
+blocks: []
+tags:
+  - "web"
+  - "ai-pipeline"
+---
+
+> **Thin stub — not yet investigated.** This ticket needs its own brainstorm/plan
+> before implementation. It exists to capture the follow-on to feat-204 and the
+> consuming-app responsibilities surfaced during that brainstorm so they aren't
+> lost. Read
+> `docs/brainstorms/2026-06-24-expose-seeker-agent-mastra-route-requirements.md`
+> (especially its Scope Boundaries) first.
+
+## Problem
+
+feat-204 exposes `seekerAgent` over an internal, bearer-gated SSE route
+(`POST /forge-seeker`). The chat app (`apps/chat`) still talks only to its stub
+agent. This wires `apps/chat` to call the Seeker route so devs/product can
+dogfood Seeker end-to-end — internally, behind a feature flag, without crossing
+the production release gates.
+
+## What this work must get right (carried over from the feat-204 brainstorm)
+
+These are load-bearing, not optional polish:
+
+1. **Server-side bearer / proxy.** The chat backend holds `MASTRA_SERVICE_API_KEYS`
+   and proxies browser requests to `/forge-seeker`. The service bearer must never
+   reach the browser. (Mirrors how admin proxies `/forge-experience-chat`.)
+2. **Server-minted, ownership-checked `threadId`.** Generate the `threadId`
+   server-side (e.g. a UUID at "new conversation", bound to the user/session,
+   ownership re-checked on reuse). Do **not** forward browser-supplied
+   `threadId`s — otherwise a user can supply or enumerate another session's
+   `threadId` and read its conversation (the route treats `threadId` opaquely and
+   cannot prevent this).
+3. **Default-off feature flag gating Seeker vs. the stub agent.** This is the
+   enforcement point for the crisis-gate boundary — Seeker must be reachable only
+   by allowlisted dev/product users until the safety/crisis guardrails ship. Not
+   cosmetic: it is what keeps vulnerable users away from an unguarded agent.
+4. **Optional `resourceId`.** May be omitted pre-auth; pass the authenticated
+   user id here once chat auth lands (no route-side change needed).
+
+## Constraints
+
+- Internal dogfooding only — do not widen Seeker's audience beyond the gated
+  allowlist until the guardrail release gate is met.
+- Do not relocate any Mastra-side responsibility here; this ticket is purely the
+  chat-side consumer.
+
+## Verification
+
+- To be defined in this ticket's own brainstorm/plan.


### PR DESCRIPTION
## What

Docs-only PR. Adds the requirements brainstorm and roadmap tickets for exposing the existing `seekerAgent` over a new internal, bearer-gated SSE service route (`/forge-seeker`) so the chat app can dogfood Seeker end-to-end — **internally**, behind the existing private-network + service-bearer boundary, and **without** crossing the documented production release gates.

No code or config changes; nothing ships behavior here.

## Files

- **`docs/brainstorms/2026-06-24-expose-seeker-agent-mastra-route-requirements.md`** — the requirements brainstorm (R1–R13, flows, acceptance examples, scope boundaries, the key technical risk).
- **`docs/roadmap/ai-chat/feat-204-…md`** — full ticket: expose Seeker via the Mastra SSE route.
- **`docs/roadmap/ai-chat/feat-205-…md`** — thin stub: wire the chat app to that route (`depends_on: feat-204`), carrying the consuming-app responsibilities (server-side bearer/proxy, server-minted `threadId`, default-off feature flag).
- **`docs/roadmap/ai-chat/feat-199-…md`** — `blocks: [feat-204]` back-reference.
- **`docs/roadmap/ai-chat/README.md`** — index rows + status counts (6 → 8 tickets).

## Key decisions captured

- Internal dogfooding only; stays behind the safety/crisis-guardrail, gateway, and persisted-memory release gates.
- Server-to-server is the chosen access model (no CORS, no browser-direct), not a stepping stone.
- The new bearer-gated route is *more* locked down than Mastra's already-open unauthenticated `/api/agents/*` surface.
- `threadId` required, `resourceId` optional/opaque; per-session memory keying flagged as the key technical risk to verify before implementation.

## Notes

- The `ai-chat` lane is intentionally unrendered by the roadmap viewer; `README.md` is hand-maintained per that lane's conventions.
- Dependency chain: feat-199 → feat-204 → feat-205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jyBvJt1XnFD2H8RJQ4vP4