### PR TITLE
docs(solutions): Metro RangeError (missing watchman) + --tunnel manifest trap

### DIFF
--- a/docs/solutions/developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md
+++ b/docs/solutions/developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md
@@ -47,6 +47,18 @@ of time and silently produce a wrong or stale verification:
    formSheet rows) is flaky, so a "the button doesn't do anything" reading is
    often a missed tap, not a bug.
 
+## Prerequisites
+
+Before any of this, **watchman must be installed** (`brew install watchman`).
+Without it, Metro falls back to a node crawler that crashes with `RangeError:
+Invalid string length` on a monorepo this large — intermittently, so a first
+`expo start` may succeed and a later one won't. The crash also masquerades as a
+device-side ngrok/connect error when Metro runs behind a tunnel. See
+`docs/solutions/runtime-errors/metro-node-crawler-rangerror-missing-watchman-20260622.md`,
+which also explains why a `--tunnel` Metro forces even a localhost-connected
+simulator to fetch its bundle through the tunnel (run plain-localhost Metro for
+sim work, as this guide does).
+
 ## Guidance
 
 ### 1. Point the worktree at the running admin, not stale Strapi

--- a/docs/solutions/mobile/expo-env-file-handling.md
+++ b/docs/solutions/mobile/expo-env-file-handling.md
@@ -7,7 +7,7 @@ module: apps/mobile
 symptom: "Network Request Failed or Aborted on real iOS devices; app works on simulators"
 root_cause: "@expo/env loads .env.production over .env when NODE_ENV=production (set by Metro for device builds); real devices cannot reach localhost"
 severity: high
-last_updated: 2026-06-08
+last_updated: 2026-06-22
 ---
 
 ## Problem
@@ -101,14 +101,15 @@ Added to `app.json` infoPlist. Allows HTTP to LAN IPs on real devices. Scoped to
 
 ## Key Gotchas
 
-| Gotcha                                            | Detail                                                                                                           |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `expo export` forces `NODE_ENV=production`        | Regardless of what you set. Don't rely on NODE_ENV for env switching.                                            |
-| Shell `export` doesn't work for `EXPO_PUBLIC_*`   | Metro inlines values from `.env` files via babel, not from `process.env`. Use file-based overrides.              |
-| `--channel` != `--environment` in EAS             | Channel = which builds receive the update. Environment = which env vars are injected. Must pass both explicitly. |
-| SDK 54: `--environment` is optional but critical  | Without it, `eas update` falls back to local `.env` files (which don't exist in CI). In SDK 55+, it's required.  |
-| EAS "secret" visibility                           | NOT available during `eas update`, only during `eas build`. Use "sensitive" for `EXPO_PUBLIC_*` tokens.          |
-| `fromJson` on empty string crashes GitHub Actions | Guard with `services != '' && services != '[]'` before `contains(fromJson(...))`.                                |
+| Gotcha                                                   | Detail                                                                                                                                                                                                                                                        |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `expo export` forces `NODE_ENV=production`               | Regardless of what you set. Don't rely on NODE_ENV for env switching.                                                                                                                                                                                         |
+| Shell `export` doesn't work for `EXPO_PUBLIC_*`          | Metro inlines values from `.env` files via babel, not from `process.env`. Use file-based overrides.                                                                                                                                                           |
+| `--channel` != `--environment` in EAS                    | Channel = which builds receive the update. Environment = which env vars are injected. Must pass both explicitly.                                                                                                                                              |
+| SDK 54: `--environment` is optional but critical         | Without it, `eas update` falls back to local `.env` files (which don't exist in CI). In SDK 55+, it's required.                                                                                                                                               |
+| EAS "secret" visibility                                  | NOT available during `eas update`, only during `eas build`. Use "sensitive" for `EXPO_PUBLIC_*` tokens.                                                                                                                                                       |
+| `fromJson` on empty string crashes GitHub Actions        | Guard with `services != '' && services != '[]'` before `contains(fromJson(...))`.                                                                                                                                                                             |
+| `--tunnel` poisons the bundle host for localhost clients | A `--tunnel` Metro bakes the ngrok URL into the manifest it serves to _every_ client, so a simulator connecting via `localhost` still fetches the bundle through the tunnel. Run plain-localhost Metro for sim work; reserve `--tunnel` for physical devices. |
 
 ## Prevention
 
@@ -123,6 +124,7 @@ Added to `app.json` infoPlist. Allows HTTP to LAN IPs on real devices. Scoped to
 
 - [Mobile admin data-layer cutover](../architecture-patterns/mobile-admin-data-layer-cutover-pattern-20260525.md) — the Strapi → admin migration that replaced platform-split `EXPO_PUBLIC_GRAPHQL_URL_*` (+ `:1337`) with the single `EXPO_PUBLIC_ADMIN_GRAPHQL_URL`
 - [Verifying mobile Expo worktree changes in the simulator](../developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md) — the local admin endpoint trap (`:3003`) and the second-Metro / full-reload verification loop
+- [Metro crashes with RangeError when watchman is missing](../runtime-errors/metro-node-crawler-rangerror-missing-watchman-20260622.md) — the watchman prerequisite, and why a `--tunnel` Metro forces even localhost-connected simulators through the tunnel
 - [EAS Update Stakeholder Preview Setup](../mobile/eas-update-stakeholder-preview-setup.md) — references `.env` which is now `.env.local`
 - [New App CI and Deployment Patterns](../platform/new-app-ci-and-deployment-patterns.md) — `skipValidation` guard and `EAS_BUILD` explanation
 - [Adding New Apps](../platform/adding-new-apps.md) — env validation convention

--- a/docs/solutions/runtime-errors/metro-node-crawler-rangerror-missing-watchman-20260622.md
+++ b/docs/solutions/runtime-errors/metro-node-crawler-rangerror-missing-watchman-20260622.md
@@ -1,0 +1,106 @@
+---
+title: "Metro crashes with `RangeError: Invalid string length` in a large pnpm monorepo when watchman is missing (surfaces as ngrok/connect errors on device)"
+date: 2026-06-22
+problem_type: runtime_error
+category: runtime-errors
+module: apps/mobile
+component: development_workflow
+symptoms:
+  - "Metro crashes: RangeError: Invalid string length at metro-file-map/src/crawlers/node/index.js:140 (Socket.<anonymous>)"
+  - "Physical device shows ERR_NGROK_3004 'The server returned an invalid or incomplete HTTP response' or 'Failed to connect to https://<sub>.exp.direct'"
+  - "iOS simulator: 'Could not connect to development server' pointing at the tunnel URL even when the deep link targeted localhost:8081"
+  - "On-device feature failures (e.g. offline downloads stuck on Retry) that are actually a dead Metro, not app code"
+root_cause: missing_tooling
+resolution_type: environment_setup
+severity: high
+tags:
+  - metro
+  - watchman
+  - expo
+  - pnpm-monorepo
+  - ngrok-tunnel
+  - ios-simulator
+  - react-native
+  - dev-environment
+related:
+  - docs/solutions/developer-experience/metro-watchfolders-monorepo-refresh-storm-20260415.md
+  - docs/solutions/developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md
+  - docs/solutions/mobile/expo-env-file-handling.md
+  - docs/solutions/mobile/metro-pnpm-symlink-react-duplicate-resolution.md
+---
+
+# Metro crashes with `RangeError: Invalid string length` in a large pnpm monorepo when watchman is missing
+
+## Problem
+
+Without watchman installed, Metro falls back to its **node crawler**, which shells out `find` over everything in `watchFolders` (the whole pnpm monorepo) and concatenates the result into a single in-memory string. In a repo this large that string overflows Node's ~512 MB max string length and Metro crashes with `RangeError: Invalid string length`. When Metro is running behind an Expo `--tunnel`, the crash surfaces on the device as an ngrok gateway error — so an `apps/mobile` feature appears broken (e.g. offline downloads stuck on "Retry") when the real failure is a dead bundler.
+
+## Symptoms
+
+- Metro process output: `RangeError: Invalid string length` at `metro-file-map/src/crawlers/node/index.js:140` inside `Socket.<anonymous>`.
+- Physical device dev-client: `ERR_NGROK_3004 "The server returned an invalid or incomplete HTTP response"`, or `"Failed to connect to https://<sub>.exp.direct"` in the launcher.
+- iOS simulator: `"Could not connect to development server"` whose URL points at the **tunnel** host, even when the launch deep link targeted `localhost:8081`.
+- **Intermittent** — the monorepo's file count sits near the string-length boundary, so a fresh `expo start` may succeed and a later one tips over. "It worked the first time" is a trap, not evidence that the environment is fine.
+
+## What Didn't Work
+
+- **Suspecting the app code.** Temporary `console.warn("[dl] ...")` traces showed the download started with `src=fresh valid=true` — the feature logic was correct. The red "Retry" was an environment artifact.
+- **Checking the wifi-only setting.** `wifiOnly` defaults to `false`, so cellular wasn't blocked.
+- **Restarting tunnel Metro repeatedly.** It kept crashing with the same `RangeError` on the same workload — the node crawler is the constant, not a transient.
+- **Cold-relaunching the app / re-scanning the QR.** Downstream symptoms; the bundler was already dead.
+- **Pointing the simulator at `localhost:8081` while Metro was in `--tunnel` mode.** The sim still tried to fetch the bundle from the tunnel and failed (see Why This Works — the manifest, not the connection, carries the bundle host).
+
+## Solution
+
+### 1. Install watchman (the real fix)
+
+```bash
+brew install watchman
+```
+
+Metro prefers watchman when it's present and skips the node crawler entirely. Watchman is event-driven and never materializes the full file list as one string, so the `RangeError` ceiling disappears. After installing, the same workload that crashed before stays up.
+
+Prove Metro is healthy **without a device** by force-building the bundle:
+
+```bash
+curl -s -o /tmp/b.js -w '%{http_code}\n' \
+  'http://localhost:8081/.expo/.virtual-metro-entry.bundle?platform=ios&dev=true'
+# expect: 200, and /tmp/b.js ~11-12 MB of JS
+```
+
+Caveat: watchman's first `watch-project` crawl on a repo this size can take minutes (~197s observed). If it hangs, check whether a path under `watchFolders` is backed by a **stopped Docker Desktop** — watchman stalls on unresponsive mounts and completes once Docker is back.
+
+### 2. Run tunnel mode for the device, plain-localhost for the simulator — don't mix
+
+```bash
+# Physical device (localhost isn't reachable from the phone):
+expo start --tunnel --dev-client
+
+# iOS simulator (runs on the Mac, reaches localhost directly):
+expo start --dev-client          # no --tunnel
+xcrun simctl openurl <UDID> \
+  'forgemobile://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081'
+# then drive it with idb
+```
+
+The simulator is the reliable reproduction surface — fast local bundles, logs that stream, and idb-drivable — versus a flaky device tunnel.
+
+## Why This Works
+
+Metro's file-watching layer has two backends. **watchman** (preferred) tracks changes incrementally and never builds the full path list as a string. The **node-crawler fallback** pipes `find` output through a socket and accumulates it into one JS string per crawl; past ~10M paths that string exceeds V8's limit and throws synchronously inside the socket handler, taking Metro down. Installing watchman removes the fallback path, so the ceiling can't be hit.
+
+The tunnel/localhost split is a Metro design fact, not a bug: with `--tunnel`, Metro bakes the **tunnel URL into the manifest** it serves as the bundle host, so the device (which can't reach `localhost`) gets a reachable bundle. The manifest is identical regardless of who fetched it — so a simulator asking `localhost:8081` still receives a tunnel-URL manifest and tries to load the bundle through the tunnel. Running Metro without `--tunnel` makes the manifest advertise localhost, which the sim can reach directly.
+
+## Prevention
+
+- **Treat watchman as a hard prerequisite for mobile dev, not an optional speedup.** The node-crawler fallback is fragile at this monorepo's scale and fails non-deterministically by file count at launch time. Add it to the `apps/mobile` dev-environment setup (alongside Xcode/idb) so a fresh machine never hits this.
+- **When a device shows `ERR_NGROK_3004` or any tunnel/connect error, check Metro first.** The device error is always downstream — grep the Metro process output for `RangeError: Invalid string length` before suspecting the network, the device, or the feature code.
+- **Use plain-localhost Metro for all simulator work; reserve `--tunnel` for physical devices.** Mixing them sends the sim through the tunnel via the manifest even when the deep link says localhost.
+- **Smoke Metro health with `curl` on `/.expo/.virtual-metro-entry.bundle` before attaching a device** — a `200` proves the bundler is alive independent of tunnel/device state, and isolates "Metro is broken" from "the app is broken" in one step.
+
+## Related Issues
+
+- [Metro watchFolders monorepo refresh storm](../developer-experience/metro-watchfolders-monorepo-refresh-storm-20260415.md) — same "Metro + pnpm monorepo over-broad crawl" family (different mechanism: refresh storm vs. crawl-overflow crash).
+- [Verifying mobile Expo worktree changes in the simulator](../developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md) — the sim dev-loop guide; its plain-localhost-Metro advice is the same conclusion reached here. Predates the watchman prerequisite and the tunnel-manifest note.
+- [Expo env file handling](../mobile/expo-env-file-handling.md) — the device-needs-LAN-IP cousin of the tunnel-vs-localhost split; doesn't yet cover the `--tunnel` manifest behavior.
+- [Metro pnpm symlink react duplicate resolution](../mobile/metro-pnpm-symlink-react-duplicate-resolution.md) — another Metro-in-pnpm-monorepo gotcha on the same `metro.config.js` axis.


### PR DESCRIPTION
## What

Captures a 2026-06-22 mobile debugging session as a compound-engineering learning, split across one new doc and two surgical updates to docs people already read.

### New doc
- `docs/solutions/runtime-errors/metro-node-crawler-rangerror-missing-watchman-20260622.md` — without watchman, Metro falls back to a node crawler that `find`s the whole pnpm monorepo and concatenates it into one JS string, overflowing V8's ~512 MB string ceiling → `RangeError: Invalid string length`, killing Metro. It's **intermittent** (file count sits near the boundary) and **masquerades** as something else: on a `--tunnel` device it surfaces as `ERR_NGROK_3004` / "couldn't connect," so app code looks broken (e.g. offline downloads stuck on "Retry") when the bundler is just dead. Fix is one line (`brew install watchman`) — the doc encodes the dead-ends so nobody re-derives the multi-hour debug.

### Wired in
- `developer-experience/verifying-mobile-expo-worktree-changes-in-simulator-20260608.md` — adds a **Prerequisites** section front-loading the watchman requirement into the guide people read *before* sim work, plus a cross-link.
- `mobile/expo-env-file-handling.md` — documents that `--tunnel` bakes the ngrok host into the manifest served to *every* client, so a `localhost`-connected simulator still fetches its bundle through the tunnel. Plus cross-link and `last_updated` bump.

## Why

Per the repo's Compound Engineering convention, hard-won debugging knowledge lives in `docs/solutions/` so it's agent-discoverable and survives the session. This converts an intermittent, false-trail environment failure into a one-line prerequisite.

## Scope

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)