### PR TITLE
feat(search): add admin search stage timing logs

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -146,6 +146,12 @@ Semantic-Only Search is for measuring whether Content Embeddings can find releva
 
 The response-side state that says whether semantic retrieval actually contributed to a search response. It reflects runtime embedding availability, not the requested Search Pipeline Mode.
 
+### Search Stage Timing
+
+Per-query observability that breaks Admin search latency into route, retrieval,
+fusion, mapping, hydration, trace-write, and total service time. It is an
+operator diagnostic contract, not a public search response contract.
+
 ### Content Embedding
 
 A vector representation of localized content used for semantic retrieval across videos, scenes, transcripts, and experiences. Content Embeddings are only comparable when the query vector and stored document vectors come from the same provider contract and transform behavior.

--- a/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const routeMocks = vi.hoisted(() => ({
   rateLimitAuthRoute: vi.fn(),
   isValidSearchTraceSamplingBearer: vi.fn(),
-  search: vi.fn(),
+  searchWithTrace: vi.fn(),
   recordSearchTraceSafely: vi.fn(),
   languageFindFirst: vi.fn(),
 }))
@@ -11,7 +11,7 @@ const routeMocks = vi.hoisted(() => ({
 const {
   rateLimitAuthRoute,
   isValidSearchTraceSamplingBearer,
-  search,
+  searchWithTrace,
   recordSearchTraceSafely,
   languageFindFirst,
 } = routeMocks
@@ -32,10 +32,16 @@ vi.mock("@/db/client", () => ({
 vi.mock("@/services/search-trace.service", () => ({
   recordSearchTraceSafely: routeMocks.recordSearchTraceSafely,
 }))
-vi.mock("@/services/hybrid-search.service", () => {
+vi.mock("@/services/hybrid-search.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/services/hybrid-search.service")
+  >("@/services/hybrid-search.service")
   const contentTypes = new Set(["video", "experience"])
   return {
-    HybridSearchService: vi.fn(() => ({ search: routeMocks.search })),
+    ...actual,
+    HybridSearchService: vi.fn(() => ({
+      searchWithTrace: routeMocks.searchWithTrace,
+    })),
     isContentType: (value: string) => contentTypes.has(value),
   }
 })
@@ -60,26 +66,53 @@ describe("POST /api/internal/search-eval/search", () => {
     rateLimitAuthRoute.mockResolvedValue({ allowed: true, source: "local" })
     isValidSearchTraceSamplingBearer.mockReturnValue(true)
     languageFindFirst.mockResolvedValue(null)
-    search.mockResolvedValue({
-      results: [
-        {
-          type: "video",
-          id: "video-1",
-          slug: "jesus",
-          title: "JESUS",
-          imageUrl: null,
-          snippet: "The story of Jesus.",
-          startSeconds: null,
-          playbackId: null,
-          score: 1,
-          label: "FEATURE_FILM",
-          durationSeconds: 120,
-          childCount: null,
-        },
-      ],
-      hasMore: false,
-      query: "Jesus",
-      searchMode: "hybrid",
+    searchWithTrace.mockResolvedValue({
+      response: {
+        results: [
+          {
+            type: "video",
+            id: "video-1",
+            slug: "jesus",
+            title: "JESUS",
+            imageUrl: null,
+            snippet: "The story of Jesus.",
+            startSeconds: null,
+            playbackId: null,
+            score: 1,
+            label: "FEATURE_FILM",
+            durationSeconds: 120,
+            childCount: null,
+          },
+        ],
+        hasMore: false,
+        query: "Jesus",
+        searchMode: "hybrid",
+      },
+      trace: {
+        searchMode: "hybrid",
+        resultCount: 1,
+        outcome: "success",
+        traceClass: "none",
+        failedRetrievers: [],
+        contributingRetrievers: ["semantic-video"],
+      },
+      timings: {
+        totalMs: 321,
+        retrievalsMs: 300,
+        fusionMs: 1,
+        dilutionCapMs: 0,
+        dedupeMs: 2,
+        mappingMs: 3,
+        hydrationMs: 4,
+        retrievers: [
+          {
+            label: "semantic-video",
+            status: "fulfilled",
+            elapsedMs: 295,
+            resultCount: 1,
+          },
+        ],
+      },
     })
   })
 
@@ -99,6 +132,16 @@ describe("POST /api/internal/search-eval/search", () => {
       results: [{ id: "video-1" }],
       query: "Jesus",
       searchMode: "hybrid",
+      timings: {
+        totalMs: 321,
+        retrievalsMs: 300,
+        fusionMs: 1,
+        dilutionCapMs: 0,
+        dedupeMs: 2,
+        mappingMs: 3,
+        hydrationMs: 4,
+        retrievers: [{ label: "semantic-video" }],
+      },
     })
     expect(rateLimitAuthRoute).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -107,7 +150,7 @@ describe("POST /api/internal/search-eval/search", () => {
         windowMs: 60_000,
       }),
     )
-    expect(search).toHaveBeenCalledWith({
+    expect(searchWithTrace).toHaveBeenCalledWith({
       query: "Jesus",
       locale: "en",
       limit: 10,
@@ -136,7 +179,7 @@ describe("POST /api/internal/search-eval/search", () => {
       where: { slug: "spanish-castilian", deletedAt: null },
       select: { bcp47: true },
     })
-    expect(search).toHaveBeenCalledWith(
+    expect(searchWithTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         query: "Jesus",
         locale: "es",
@@ -144,6 +187,32 @@ describe("POST /api/internal/search-eval/search", () => {
         allowInternalEvalModes: true,
       }),
     )
+  })
+
+  it("emits a search_timing log for internal eval without query text", async () => {
+    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const response = await POST(
+        request({
+          query: "Jesus secret query",
+          locale: "en",
+          mode: "semantic-only",
+        }),
+      )
+      expect(response.status).toBe(200)
+      const timingLine = logSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .find((line) => line.includes("event=search_timing"))
+      expect(timingLine).toContain("route=internal")
+      expect(timingLine).toContain("locale=en")
+      expect(timingLine).toContain("requested_mode=semantic-only")
+      expect(timingLine).toContain("total_ms=321")
+      expect(timingLine).toContain("db_retriever_semantic_video_ms=295")
+      expect(timingLine).not.toContain("Jesus secret query")
+      expect(timingLine).not.toMatch(/embedding/i)
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 
   it("rejects unsafe or unknown language slugs before search", async () => {
@@ -164,7 +233,7 @@ describe("POST /api/internal/search-eval/search", () => {
       }),
     )
     expect(response.status).toBe(400)
-    expect(search).not.toHaveBeenCalled()
+    expect(searchWithTrace).not.toHaveBeenCalled()
   })
 
   it("rejects missing bearer before parsing the body", async () => {
@@ -180,7 +249,7 @@ describe("POST /api/internal/search-eval/search", () => {
 
     expect(response.status).toBe(401)
     expect(text).not.toHaveBeenCalled()
-    expect(search).not.toHaveBeenCalled()
+    expect(searchWithTrace).not.toHaveBeenCalled()
   })
 
   it("returns 429 before auth or body parsing when rate-limited", async () => {
@@ -232,7 +301,7 @@ describe("POST /api/internal/search-eval/search", () => {
       const response = await POST(request(body))
       expect(response.status).toBe(400)
     }
-    expect(search).not.toHaveBeenCalled()
+    expect(searchWithTrace).not.toHaveBeenCalled()
   })
 
   it("rejects chunked bodies after the byte cap without fully parsing", async () => {
@@ -250,7 +319,7 @@ describe("POST /api/internal/search-eval/search", () => {
     } as unknown as Request)
 
     expect(response.status).toBe(413)
-    expect(search).not.toHaveBeenCalled()
+    expect(searchWithTrace).not.toHaveBeenCalled()
   })
 
   it("rejects declared oversized bodies before search", async () => {
@@ -264,11 +333,11 @@ describe("POST /api/internal/search-eval/search", () => {
     } as unknown as Request)
 
     expect(response.status).toBe(413)
-    expect(search).not.toHaveBeenCalled()
+    expect(searchWithTrace).not.toHaveBeenCalled()
   })
 
   it("maps search failures to a 503 without leaking details", async () => {
-    search.mockRejectedValueOnce(new Error("provider secret leaked?"))
+    searchWithTrace.mockRejectedValueOnce(new Error("provider secret leaked?"))
 
     const response = await POST(request({ query: "Jesus", locale: "en" }))
 

--- a/apps/admin/src/app/api/internal/search-eval/search/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.ts
@@ -2,6 +2,7 @@ import { rateLimitAuthRoute } from "@/auth/rate-limit"
 import { isValidSearchTraceSamplingBearer } from "@/auth/search-trace-bearer"
 import { prisma } from "@/db/client"
 import {
+  formatSearchTimingLogLine,
   HybridSearchService,
   isContentType,
   type ContentType,
@@ -231,7 +232,7 @@ export async function POST(request: Request): Promise<Response> {
     const locale = await searchLocaleForParams(params)
     if (locale instanceof Response) return locale
     const service = new HybridSearchService({ prisma })
-    const response = await service.search({
+    const { response, trace, timings } = await service.searchWithTrace({
       query: params.query,
       locale,
       limit: params.limit,
@@ -243,7 +244,18 @@ export async function POST(request: Request): Promise<Response> {
     console.info(
       `[search] event=eval_search auth=bearer route=internal rl=${limit.source} locale=${logValue(locale)} mode=${logValue(params.mode)} result_count=${response.results.length}`,
     )
-    return Response.json(response, { status: 200 })
+    console.error(
+      formatSearchTimingLogLine({
+        route: "internal",
+        locale,
+        requestedMode: params.mode ?? null,
+        searchMode: trace.searchMode,
+        outcome: trace.outcome,
+        resultCount: trace.resultCount,
+        timings,
+      }),
+    )
+    return Response.json({ ...response, timings }, { status: 200 })
   } catch (error) {
     console.error(
       `[search] event=eval_search_failed route=internal error_class=${logValue(error instanceof Error ? error.name : typeof error)}`,

--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -15,6 +15,23 @@ vi.mock("@/config/env", () => ({
 // The route constructs a HybridSearchService with the shared `prisma`
 // import; we mock the class so tests don't touch the DB.
 const searchMock = vi.fn()
+const mockTimings = {
+  totalMs: 123,
+  retrievalsMs: 80,
+  fusionMs: 1,
+  dilutionCapMs: 0,
+  dedupeMs: 2,
+  mappingMs: 3,
+  hydrationMs: 4,
+  retrievers: [
+    {
+      label: "semantic-video",
+      status: "fulfilled" as const,
+      elapsedMs: 77,
+      resultCount: 1,
+    },
+  ],
+}
 const searchWithTraceMock = vi.fn(async (params) => {
   const response = await searchMock(params)
   return {
@@ -30,6 +47,7 @@ const searchWithTraceMock = vi.fn(async (params) => {
       failedRetrievers: [],
       contributingRetrievers: [],
     },
+    timings: mockTimings,
   }
 })
 vi.mock("@/services/hybrid-search.service", async () => {
@@ -360,6 +378,35 @@ describe("GET /api/search", () => {
       query: "jesus",
       searchMode: "hybrid",
     })
+  })
+
+  it("emits a search_timing log without query text or secret-bearing fields", async () => {
+    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const res = await GET(
+        req("/api/search?q=jesus-secret-query&locale=en&mode=keyword-first"),
+      )
+      expect(res.status).toBe(200)
+
+      const timingLine = logSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .find((line) => line.includes("event=search_timing"))
+      expect(timingLine).toContain("route=rest")
+      expect(timingLine).toContain("locale=en")
+      expect(timingLine).toContain("requested_mode=keyword-first")
+      expect(timingLine).toContain("search_mode=hybrid")
+      expect(timingLine).toContain("result_count=0")
+      expect(timingLine).toContain("total_ms=123")
+      expect(timingLine).toContain("db_retrievals_ms=80")
+      expect(timingLine).toContain("trace_write_ms=")
+      expect(timingLine).toContain("db_retriever_semantic_video_ms=77")
+      expect(timingLine).not.toContain("jesus-secret-query")
+      expect(timingLine).not.toContain("Bearer")
+      expect(timingLine).not.toContain("keyId=")
+      expect(timingLine).not.toMatch(/embedding/i)
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 
   it("does not trace invalid requests rejected before live search", async () => {

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -11,6 +11,7 @@ import { rateLimitAuthRoute } from "@/auth/rate-limit"
 import { isAnyKnownBearer } from "@/auth/search-bearer"
 import { env } from "@/config/env"
 import {
+  formatSearchTimingLogLine,
   HybridSearchService,
   isContentType,
   type ContentType,
@@ -200,7 +201,7 @@ export async function GET(request: Request): Promise<Response> {
 
   try {
     const service = new HybridSearchService({ prisma })
-    const { response, trace } = await service.searchWithTrace({
+    const { response, trace, timings } = await service.searchWithTrace({
       query: q,
       locale,
       limit: limitParam,
@@ -209,6 +210,7 @@ export async function GET(request: Request): Promise<Response> {
       mode,
       debug,
     })
+    const traceWriteStartedAt = performance.now()
     await recordSearchTraceSafely({
       query: q,
       locale,
@@ -221,6 +223,22 @@ export async function GET(request: Request): Promise<Response> {
       startedAt,
       completedAt: new Date(),
     }).catch(() => {})
+    const traceWriteMs = Math.max(
+      0,
+      Math.round(performance.now() - traceWriteStartedAt),
+    )
+    console.error(
+      formatSearchTimingLogLine({
+        route: "rest",
+        locale,
+        requestedMode: mode ?? null,
+        searchMode: trace.searchMode,
+        outcome: trace.outcome,
+        resultCount: trace.resultCount,
+        timings,
+        traceWriteMs,
+      }),
+    )
     return Response.json(response, { status: 200 })
   } catch (error) {
     await recordSearchTraceSafely({

--- a/apps/admin/src/graphql/queries/hybrid-search.test.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.test.ts
@@ -11,6 +11,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const searchMock = vi.fn()
+const mockTimings = {
+  totalMs: 234,
+  retrievalsMs: 190,
+  fusionMs: 2,
+  dilutionCapMs: 0,
+  dedupeMs: 3,
+  mappingMs: 4,
+  hydrationMs: 5,
+  retrievers: [
+    {
+      label: "semantic-video",
+      status: "fulfilled" as const,
+      elapsedMs: 180,
+      resultCount: 2,
+    },
+  ],
+}
 const searchWithTraceMock = vi.fn(async (params) => {
   const response = await searchMock(params)
   return {
@@ -26,6 +43,7 @@ const searchWithTraceMock = vi.fn(async (params) => {
       failedRetrievers: [],
       contributingRetrievers: [],
     },
+    timings: mockTimings,
   }
 })
 vi.mock("@/services/hybrid-search.service", async () => {
@@ -288,6 +306,37 @@ describe("Query.search resolver", () => {
       query: "jesus",
       searchMode: "hybrid",
     })
+  })
+
+  it("emits a search_timing log without query text or secret-bearing fields", async () => {
+    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      await expect(
+        invoke({
+          q: "jesus-secret-query",
+          locale: "en",
+          mode: "keyword-first",
+        }),
+      ).resolves.toBeDefined()
+
+      const timingLine = logSpy.mock.calls
+        .map((args) => String(args[0] ?? ""))
+        .find((line) => line.includes("event=search_timing"))
+      expect(timingLine).toContain("route=graphql")
+      expect(timingLine).toContain("locale=en")
+      expect(timingLine).toContain("requested_mode=keyword-first")
+      expect(timingLine).toContain("search_mode=hybrid")
+      expect(timingLine).toContain("total_ms=234")
+      expect(timingLine).toContain("db_retrievals_ms=190")
+      expect(timingLine).toContain("trace_write_ms=")
+      expect(timingLine).toContain("db_retriever_semantic_video_ms=180")
+      expect(timingLine).not.toContain("jesus-secret-query")
+      expect(timingLine).not.toContain("Bearer")
+      expect(timingLine).not.toContain("keyId=")
+      expect(timingLine).not.toMatch(/embedding/i)
+    } finally {
+      logSpy.mockRestore()
+    }
   })
 })
 

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -15,6 +15,7 @@ import { prisma } from "@/db/client"
 import { isAnyKnownBearer } from "@/auth/search-bearer"
 import { env } from "@/config/env"
 import {
+  formatSearchTimingLogLine,
   HybridSearchService,
   isContentType,
   type ContentType,
@@ -254,7 +255,7 @@ builder.queryFields((t) => ({
       const service = new HybridSearchService({ prisma })
       const startedAt = new Date()
       try {
-        const { response, trace } = await service.searchWithTrace({
+        const { response, trace, timings } = await service.searchWithTrace({
           query,
           locale: args.locale,
           limit: args.limit ?? undefined,
@@ -263,6 +264,7 @@ builder.queryFields((t) => ({
           mode,
           debug,
         })
+        const traceWriteStartedAt = performance.now()
         await recordSearchTraceSafely({
           query,
           locale: args.locale,
@@ -275,6 +277,22 @@ builder.queryFields((t) => ({
           startedAt,
           completedAt: new Date(),
         }).catch(() => {})
+        const traceWriteMs = Math.max(
+          0,
+          Math.round(performance.now() - traceWriteStartedAt),
+        )
+        console.error(
+          formatSearchTimingLogLine({
+            route: "graphql",
+            locale: args.locale,
+            requestedMode: mode ?? null,
+            searchMode: trace.searchMode,
+            outcome: trace.outcome,
+            resultCount: trace.resultCount,
+            timings,
+            traceWriteMs,
+          }),
+        )
         return response
       } catch (error) {
         await recordSearchTraceSafely({

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -87,7 +87,7 @@ describe("HybridSearchService keyword-first branch", () => {
       logger: { warn: vi.fn(), error: vi.fn() },
     })
 
-    await service.search({
+    const traced = await service.searchWithTrace({
       query: "the bible project",
       locale: "en",
       mode: "keyword-first",
@@ -108,6 +108,15 @@ describe("HybridSearchService keyword-first branch", () => {
       locale: "en",
       limit: 60,
     })
+    expect(traced.timings.retrievers.map((r) => r.label)).toEqual([
+      "semantic-video",
+      "keyword-weighted-video",
+      "trigram-video",
+      "exact-title-video",
+      "semantic-experience",
+      "keyword-experience",
+    ])
+    expect(JSON.stringify(traced.timings)).not.toMatch(/embedding/i)
   })
 
   it("does NOT dispatch the legacy R4 video keyword retriever in keyword-first mode", async () => {
@@ -185,16 +194,27 @@ describe("HybridSearchService keyword-first branch", () => {
       logger: { warn: vi.fn(), error: loggerError },
     })
 
-    const result = await service.search({
+    const traced = await service.searchWithTrace({
       query: "jesus",
       locale: "en",
       mode: "keyword-first",
     })
+    const result = traced.response
 
     expect(result.results).toHaveLength(1)
     expect(result.results[0]!.id).toBe("vid-1")
     expect(loggerError).toHaveBeenCalledWith(
       expect.stringContaining("trigram-video retrieval failed"),
+    )
+    expect(traced.timings.retrievers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "trigram-video",
+          status: "rejected",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+      ]),
     )
   })
 
@@ -252,7 +272,7 @@ describe("HybridSearchService keyword-first branch", () => {
       logger: { warn: vi.fn(), error: vi.fn() },
     })
 
-    await service.search({
+    const traced = await service.searchWithTrace({
       query: "jesus",
       locale: "en",
       mode: "semantic-only",
@@ -274,6 +294,10 @@ describe("HybridSearchService keyword-first branch", () => {
     expect(searchByKeywordWeighted).not.toHaveBeenCalled()
     expect(searchByTrigram).not.toHaveBeenCalled()
     expect(searchByExactTitle).not.toHaveBeenCalled()
+    expect(traced.timings.retrievers.map((r) => r.label)).toEqual([
+      "semantic-video",
+      "semantic-experience",
+    ])
   })
 
   it("keeps semantic-only internal and falls back to hybrid without the eval flag", async () => {

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -219,6 +219,32 @@ describe("HybridSearchService", () => {
       failedRetrievers: [],
       contributingRetrievers: ["semantic-video"],
     })
+    expect(traced.timings).toMatchObject({
+      totalMs: expect.any(Number),
+      retrievalsMs: expect.any(Number),
+      fusionMs: expect.any(Number),
+      dilutionCapMs: 0,
+      dedupeMs: expect.any(Number),
+      mappingMs: expect.any(Number),
+      hydrationMs: expect.any(Number),
+    })
+    expect(traced.timings.retrievers.map((r) => r.label)).toEqual([
+      "semantic-video",
+      "keyword-video",
+      "semantic-experience",
+      "keyword-experience",
+    ])
+    expect(traced.timings.retrievers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "semantic-video",
+          status: "fulfilled",
+          resultCount: 1,
+          elapsedMs: expect.any(Number),
+        }),
+      ]),
+    )
+    expect(JSON.stringify(traced.timings)).not.toMatch(/embedding/i)
     expect(await service.search({ query: "jesus", locale: "en" })).toEqual(
       expect.objectContaining({
         query: "jesus",
@@ -282,6 +308,16 @@ describe("HybridSearchService", () => {
     expect(traced.trace.traceClass).toBe("retrieval_failure")
     expect(traced.trace.failedRetrievers).toEqual(["keyword-video"])
     expect(traced.trace.contributingRetrievers).toEqual(["semantic-video"])
+    expect(traced.timings.retrievers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "keyword-video",
+          status: "rejected",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+      ]),
+    )
   })
 
   describe("query embedding", () => {

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -256,9 +256,107 @@ export type SearchExecutionSummary = {
   contributingRetrievers: string[]
 }
 
+export type SearchRetrieverTiming = {
+  label: string
+  status: "fulfilled" | "rejected"
+  elapsedMs: number
+  resultCount: number
+}
+
+export type SearchTimingSummary = {
+  totalMs: number
+  retrievalsMs: number
+  fusionMs: number
+  dilutionCapMs: number
+  dedupeMs: number
+  mappingMs: number
+  hydrationMs: number
+  retrievers: SearchRetrieverTiming[]
+}
+
 export type SearchWithTraceResult = {
   response: SearchResponse
   trace: SearchExecutionSummary
+  timings: SearchTimingSummary
+}
+
+export type SearchTimingRouteSource = "rest" | "graphql" | "internal"
+
+export function searchTimingLogValue(raw: unknown): string {
+  const normalized = String(raw ?? "none")
+    .replace(/[\r\n\t\s=]/g, "_")
+    .slice(0, 64)
+  return normalized.length > 0 ? normalized : "none"
+}
+
+function nowMs(): number {
+  return performance.now()
+}
+
+function boundedMs(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0
+  return Math.round(value)
+}
+
+function elapsedMs(startedAt: number): number {
+  return boundedMs(nowMs() - startedAt)
+}
+
+function retrieverLogKey(label: string): string {
+  return searchTimingLogValue(label).replace(/-/g, "_")
+}
+
+export function formatSearchTimingLogFields(
+  timings: SearchTimingSummary,
+  extra: { traceWriteMs?: number } = {},
+): string {
+  const fields = [
+    `total_ms=${timings.totalMs}`,
+    `db_retrievals_ms=${timings.retrievalsMs}`,
+    `fusion_ms=${timings.fusionMs}`,
+    `dilution_cap_ms=${timings.dilutionCapMs}`,
+    `dedupe_ms=${timings.dedupeMs}`,
+    `mapping_ms=${timings.mappingMs}`,
+    `hydration_ms=${timings.hydrationMs}`,
+  ]
+
+  if (extra.traceWriteMs != null) {
+    fields.push(`trace_write_ms=${boundedMs(extra.traceWriteMs)}`)
+  }
+
+  for (const retriever of timings.retrievers) {
+    const key = retrieverLogKey(retriever.label)
+    fields.push(`db_retriever_${key}_ms=${retriever.elapsedMs}`)
+    fields.push(`db_retriever_${key}_status=${retriever.status}`)
+    fields.push(`db_retriever_${key}_count=${retriever.resultCount}`)
+  }
+
+  return fields.join(" ")
+}
+
+export function formatSearchTimingLogLine(input: {
+  route: SearchTimingRouteSource
+  locale: string
+  requestedMode?: string | null
+  searchMode: string
+  outcome: string
+  resultCount: number
+  timings: SearchTimingSummary
+  traceWriteMs?: number
+}): string {
+  return [
+    "[search]",
+    "event=search_timing",
+    `route=${input.route}`,
+    `locale=${searchTimingLogValue(input.locale)}`,
+    `requested_mode=${searchTimingLogValue(input.requestedMode ?? "none")}`,
+    `search_mode=${searchTimingLogValue(input.searchMode)}`,
+    `outcome=${searchTimingLogValue(input.outcome)}`,
+    `result_count=${Math.max(0, Math.round(input.resultCount))}`,
+    formatSearchTimingLogFields(input.timings, {
+      traceWriteMs: input.traceWriteMs,
+    }),
+  ].join(" ")
 }
 
 /**
@@ -616,6 +714,7 @@ export class HybridSearchService {
   }
 
   async searchWithTrace(params: SearchParams): Promise<SearchWithTraceResult> {
+    const totalStartedAt = nowMs()
     const { query, locale } = params
 
     // Decode the opt-in pipeline mode. Unknown values warn-and-fall-back
@@ -673,6 +772,35 @@ export class HybridSearchService {
       promise: Promise<RankedItem[]>
     }
     const retrievals: Retrieval[] = []
+    const retrieverTimings = new Map<string, SearchRetrieverTiming>()
+    const timedRetrieval = (
+      label: string,
+      run: () => Promise<RankedItem[]>,
+    ): Promise<RankedItem[]> => {
+      const startedAt = nowMs()
+      return Promise.resolve()
+        .then(run)
+        .then(
+          (value) => {
+            retrieverTimings.set(label, {
+              label,
+              status: "fulfilled",
+              elapsedMs: elapsedMs(startedAt),
+              resultCount: value.length,
+            })
+            return value
+          },
+          (error) => {
+            retrieverTimings.set(label, {
+              label,
+              status: "rejected",
+              elapsedMs: elapsedMs(startedAt),
+              resultCount: 0,
+            })
+            throw error
+          },
+        )
+    }
 
     if (wantsVideos) {
       // Semantic-video is shared by every embedding-backed pipeline.
@@ -680,11 +808,15 @@ export class HybridSearchService {
         label: "semantic-video",
         promise:
           queryEmbeddingText != null
-            ? (searchVideoSemantic(this.prisma, {
-                queryEmbedding: queryEmbeddingText,
-                locale,
-                limit: overfetchLimit,
-              }) as Promise<RankedItem[]>)
+            ? timedRetrieval(
+                "semantic-video",
+                () =>
+                  searchVideoSemantic(this.prisma, {
+                    queryEmbedding: queryEmbeddingText,
+                    locale,
+                    limit: overfetchLimit,
+                  }) as Promise<RankedItem[]>,
+              )
             : Promise.resolve([]),
       })
 
@@ -696,38 +828,54 @@ export class HybridSearchService {
         // strictly weaker than the weighted one for this workload.
         retrievals.push({
           label: "keyword-weighted-video",
-          promise: searchByKeywordWeighted(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "keyword-weighted-video",
+            () =>
+              searchByKeywordWeighted(this.prisma, {
+                query,
+                locale,
+                limit: overfetchLimit,
+              }) as Promise<RankedItem[]>,
+          ),
         })
         retrievals.push({
           label: "trigram-video",
-          promise: searchByTrigram(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "trigram-video",
+            () =>
+              searchByTrigram(this.prisma, {
+                query,
+                locale,
+                limit: overfetchLimit,
+              }) as Promise<RankedItem[]>,
+          ),
         })
         retrievals.push({
           label: "exact-title-video",
-          promise: searchByExactTitle(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "exact-title-video",
+            () =>
+              searchByExactTitle(this.prisma, {
+                query,
+                locale,
+                limit: overfetchLimit,
+              }) as Promise<RankedItem[]>,
+          ),
         })
       } else if (!semanticOnly) {
         // Hybrid path — UNCHANGED from R4. Byte-identity locked in by
         // hybrid-search.regression.test.ts.
         retrievals.push({
           label: "keyword-video",
-          promise: searchVideoKeyword(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "keyword-video",
+            () =>
+              searchVideoKeyword(this.prisma, {
+                query,
+                locale,
+                limit: overfetchLimit,
+              }) as Promise<RankedItem[]>,
+          ),
         })
       }
     }
@@ -737,26 +885,36 @@ export class HybridSearchService {
         label: "semantic-experience",
         promise:
           queryEmbeddingText != null
-            ? (searchExperienceSemantic(this.prisma, {
-                queryEmbedding: queryEmbeddingText,
-                locale,
-                limit: overfetchLimit,
-              }) as Promise<RankedItem[]>)
+            ? timedRetrieval(
+                "semantic-experience",
+                () =>
+                  searchExperienceSemantic(this.prisma, {
+                    queryEmbedding: queryEmbeddingText,
+                    locale,
+                    limit: overfetchLimit,
+                  }) as Promise<RankedItem[]>,
+              )
             : Promise.resolve([]),
       })
       if (!semanticOnly) {
         retrievals.push({
           label: "keyword-experience",
-          promise: searchExperienceKeyword(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "keyword-experience",
+            () =>
+              searchExperienceKeyword(this.prisma, {
+                query,
+                locale,
+                limit: overfetchLimit,
+              }) as Promise<RankedItem[]>,
+          ),
         })
       }
     }
 
+    const retrievalsStartedAt = nowMs()
     const outcomes = await Promise.allSettled(retrievals.map((r) => r.promise))
+    const retrievalsMs = elapsedMs(retrievalsStartedAt)
     const failedRetrievers: string[] = []
     const lists = outcomes.map((outcome, i) =>
       this.unwrapOutcome(outcome, retrievals[i]!.label, failedRetrievers),
@@ -794,7 +952,9 @@ export class HybridSearchService {
     // normalizes by dividing by the number of input lists, so empty
     // ones dilute scores from lists that did contribute.
     const nonEmptyLists = lists.filter((list) => list.length > 0)
+    const fusionStartedAt = nowMs()
     const fused = fuseRankedLists(nonEmptyLists, RRF_K)
+    const fusionMs = elapsedMs(fusionStartedAt)
 
     // Snapshot pre-cap fused scores so the debug payload can surface
     // both numbers (the cap mutates `result.score` in place).
@@ -809,18 +969,24 @@ export class HybridSearchService {
     // fused result whose ONLY contributing list was semantic AND whose
     // video core_id is not represented in the top-N keyword-side
     // core_ids. Hybrid mode never reaches this step.
+    let dilutionCapMs = 0
     if (pipelineMode === "keyword-first" && isDilutionCapEnabled()) {
+      const dilutionCapStartedAt = nowMs()
       applyDilutionCap(fused, labeledLists, query, debugByKey)
+      dilutionCapMs = elapsedMs(dilutionCapStartedAt)
     }
 
     // Step 4: Dedup one extra result beyond the page window so we know
     // whether more results exist (drives hasMore without a full count
     // pass).
+    const dedupeStartedAt = nowMs()
     const deduped = deduplicateResults(fused, offset + limit + 1)
 
     // Step 5: Paginate and map to API contract.
     const page = deduped.slice(offset, offset + limit)
     const hasMore = deduped.length > offset + limit
+    const dedupeMs = elapsedMs(dedupeStartedAt)
+    const mappingStartedAt = nowMs()
     const mapped = page.map((result) => {
       const base = mapToSearchResult(result)
       if (params.debug !== true) return base
@@ -829,15 +995,18 @@ export class HybridSearchService {
       if (trace == null) return base
       return { ...base, debug: trace }
     })
+    const mappingMs = elapsedMs(mappingStartedAt)
 
     // Hydrate card display fields for video results in one batched query.
     // Experience rows pass through untouched.
+    const hydrationStartedAt = nowMs()
     const results = await hydrateCardDisplayFields(
       this.prisma,
       mapped,
       locale,
       this.logger,
     )
+    const hydrationMs = elapsedMs(hydrationStartedAt)
 
     const searchMode = queryEmbeddingText != null ? "hybrid" : "keyword-only"
     const contributingRetrievers = labeledLists
@@ -867,6 +1036,19 @@ export class HybridSearchService {
         traceClass,
         failedRetrievers,
         contributingRetrievers,
+      },
+      timings: {
+        totalMs: elapsedMs(totalStartedAt),
+        retrievalsMs,
+        fusionMs,
+        dilutionCapMs,
+        dedupeMs,
+        mappingMs,
+        hydrationMs,
+        retrievers: retrievals.flatMap((retrieval) => {
+          const timing = retrieverTimings.get(retrieval.label)
+          return timing == null ? [] : [timing]
+        }),
       },
     }
   }

--- a/apps/mastra/src/services/admin-search-eval-client.test.ts
+++ b/apps/mastra/src/services/admin-search-eval-client.test.ts
@@ -92,6 +92,23 @@ const searchResponse = {
   hasMore: false,
   query: "Jesus",
   searchMode: "hybrid",
+  timings: {
+    totalMs: 321,
+    retrievalsMs: 300,
+    fusionMs: 1,
+    dilutionCapMs: 0,
+    dedupeMs: 2,
+    mappingMs: 3,
+    hydrationMs: 4,
+    retrievers: [
+      {
+        label: "semantic-video",
+        status: "fulfilled",
+        elapsedMs: 295,
+        resultCount: 1,
+      },
+    ],
+  },
 }
 
 const candidateListResponse = {
@@ -225,6 +242,16 @@ describe("Admin search eval client", () => {
       ok: true,
       result: {
         results: [expect.objectContaining({ snippet: expect.any(String) })],
+        timings: {
+          totalMs: 321,
+          retrievalsMs: 300,
+          retrievers: [
+            expect.objectContaining({
+              label: "semantic-video",
+              elapsedMs: 295,
+            }),
+          ],
+        },
       },
     })
     if (result.ok) {
@@ -347,6 +374,35 @@ describe("Admin search eval client", () => {
         bearer: "eval-key",
         payload,
         fetchImpl: vi.fn(async () => Response.json({ bad: true })),
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "parse_error",
+      retryable: true,
+      status: 200,
+    })
+
+    await expect(
+      callAdminEvalSearch({
+        url,
+        bearer: "eval-key",
+        payload,
+        fetchImpl: vi.fn(async () =>
+          Response.json({
+            ...searchResponse,
+            timings: {
+              ...searchResponse.timings,
+              retrievers: [
+                {
+                  label: "semantic-video",
+                  status: "fulfilled",
+                  elapsedMs: -1,
+                  resultCount: 1,
+                },
+              ],
+            },
+          }),
+        ),
       }),
     ).resolves.toMatchObject({
       ok: false,

--- a/apps/mastra/src/services/admin-search-eval-client.ts
+++ b/apps/mastra/src/services/admin-search-eval-client.ts
@@ -158,12 +158,42 @@ const SearchResultSchema = z
     childCount: result.childCount ?? null,
   }))
 
+const NonNegativeTimingMsSchema = z
+  .number()
+  .nonnegative()
+  .refine((value) => Number.isFinite(value), "must be finite")
+
+export const AdminSearchRetrieverTimingSchema = z
+  .object({
+    label: z.string(),
+    status: z.enum(["fulfilled", "rejected"]),
+    elapsedMs: NonNegativeTimingMsSchema,
+    resultCount: z.number().int().nonnegative(),
+  })
+  .strict()
+
+export const AdminSearchTimingsSchema = z
+  .object({
+    totalMs: NonNegativeTimingMsSchema,
+    retrievalsMs: NonNegativeTimingMsSchema,
+    fusionMs: NonNegativeTimingMsSchema,
+    dilutionCapMs: NonNegativeTimingMsSchema,
+    dedupeMs: NonNegativeTimingMsSchema,
+    mappingMs: NonNegativeTimingMsSchema,
+    hydrationMs: NonNegativeTimingMsSchema,
+    retrievers: z.array(AdminSearchRetrieverTimingSchema),
+  })
+  .strict()
+
+export type AdminSearchTimings = z.infer<typeof AdminSearchTimingsSchema>
+
 export const AdminSearchResponseSchema = z
   .object({
     results: z.array(SearchResultSchema),
     hasMore: z.boolean(),
     query: z.string(),
     searchMode: z.enum(["hybrid", "keyword-only"]),
+    timings: AdminSearchTimingsSchema.optional(),
   })
   .strict()
 

--- a/apps/mastra/src/services/offline-search-eval/artifacts.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/artifacts.test.ts
@@ -14,6 +14,24 @@ import type { BaselineArtifact, SearchEvalReport } from "./types"
 
 let rootDir: string
 
+const searchTimings = {
+  totalMs: 120,
+  retrievalsMs: 90,
+  fusionMs: 3,
+  dilutionCapMs: 0,
+  dedupeMs: 4,
+  mappingMs: 5,
+  hydrationMs: 6,
+  retrievers: [
+    {
+      label: "semantic-video",
+      status: "fulfilled" as const,
+      elapsedMs: 88,
+      resultCount: 1,
+    },
+  ],
+}
+
 beforeEach(async () => {
   rootDir = await mkdtemp(join(tmpdir(), "forge-mastra-search-eval-"))
 })
@@ -86,6 +104,40 @@ describe("search eval artifact store", () => {
       path: expect.stringContaining("reports/run-1.json"),
     })
     await expect(store.readReport("run-1")).resolves.toEqual(report())
+  })
+
+  it("round-trips Admin search timings on baselines and reports", async () => {
+    const store = createSearchEvalArtifactStore(rootDir)
+    const timedBaseline = baseline()
+    timedBaseline.cases[0]!.searchTimings = searchTimings
+    const timedReport = finalizeReport({
+      ...report(),
+      outcomes: [
+        {
+          kind: "tie",
+          caseId: "seed-jesus",
+          locale: "en",
+          queryText: "Jesus",
+          source: "seed",
+          callerTrack: "public-watch",
+          baselineResults: [],
+          currentResults: [],
+          baselineSearchTimings: searchTimings,
+          currentSearchTimings: searchTimings,
+          verdicts: ["tie", "tie"],
+          rationale: "same",
+        },
+      ],
+    })
+
+    await expect(store.writeBaseline(timedBaseline)).resolves.toMatchObject({
+      path: expect.stringContaining("baselines/default.json"),
+    })
+    await expect(store.readBaseline("default")).resolves.toEqual(timedBaseline)
+    await expect(store.writeReport(timedReport)).resolves.toMatchObject({
+      path: expect.stringContaining("reports/run-1.json"),
+    })
+    await expect(store.readReport("run-1")).resolves.toEqual(timedReport)
   })
 
   it("accepts reports after real native Evaluation records are synced", async () => {

--- a/apps/mastra/src/services/offline-search-eval/artifacts.ts
+++ b/apps/mastra/src/services/offline-search-eval/artifacts.ts
@@ -38,6 +38,33 @@ const SearchEvalResultSchema = z
   })
   .strict()
 
+const NonNegativeTimingMsSchema = z
+  .number()
+  .nonnegative()
+  .refine((value) => Number.isFinite(value), "must be finite")
+
+const AdminSearchRetrieverTimingSchema = z
+  .object({
+    label: z.string().max(128),
+    status: z.enum(["fulfilled", "rejected"]),
+    elapsedMs: NonNegativeTimingMsSchema,
+    resultCount: z.number().int().nonnegative().max(MAX_RESULT_COUNT),
+  })
+  .strict()
+
+const AdminSearchTimingSummarySchema = z
+  .object({
+    totalMs: NonNegativeTimingMsSchema,
+    retrievalsMs: NonNegativeTimingMsSchema,
+    fusionMs: NonNegativeTimingMsSchema,
+    dilutionCapMs: NonNegativeTimingMsSchema,
+    dedupeMs: NonNegativeTimingMsSchema,
+    mappingMs: NonNegativeTimingMsSchema,
+    hydrationMs: NonNegativeTimingMsSchema,
+    retrievers: z.array(AdminSearchRetrieverTimingSchema).max(10),
+  })
+  .strict()
+
 const SearchFailureSchema = z
   .object({
     code: z.enum([
@@ -111,6 +138,7 @@ const BaselineCaseSchema = z
     tags: z.array(z.string().max(64)).max(MAX_TAGS),
     operatorNotes: z.string().max(MAX_SAFE_TEXT).optional(),
     results: z.array(SearchEvalResultSchema).max(MAX_RESULT_COUNT),
+    searchTimings: AdminSearchTimingSummarySchema.optional(),
     searchFailure: SearchFailureSchema.optional(),
   })
   .strict()
@@ -233,6 +261,8 @@ const ComparisonOutcomeSchema = z
     ),
     baselineResults: z.array(SearchEvalResultSchema).max(MAX_RESULT_COUNT),
     currentResults: z.array(SearchEvalResultSchema).max(MAX_RESULT_COUNT),
+    baselineSearchTimings: AdminSearchTimingSummarySchema.optional(),
+    currentSearchTimings: AdminSearchTimingSummarySchema.optional(),
     verdicts: z.tuple([JudgeVerdictSchema, JudgeVerdictSchema]).optional(),
     rationale: z.string().max(MAX_SAFE_TEXT).optional(),
     searchFailure: SearchFailureSchema.optional(),
@@ -254,6 +284,7 @@ const ExploratoryGeneratedOutcomeSchema = z
     retentionExpiresAt: z.string().nullable(),
     skippedReason: z.literal("trace_derived_not_judged_or_searched").optional(),
     results: z.array(SearchEvalResultSchema).max(MAX_RESULT_COUNT),
+    searchTimings: AdminSearchTimingSummarySchema.optional(),
     searchFailure: SearchFailureSchema.optional(),
   })
   .strict()

--- a/apps/mastra/src/services/offline-search-eval/runner.test.ts
+++ b/apps/mastra/src/services/offline-search-eval/runner.test.ts
@@ -33,6 +33,42 @@ const resultB: SearchEvalResult = {
   snippet: "current",
 }
 
+const baselineSearchTimings = {
+  totalMs: 120,
+  retrievalsMs: 90,
+  fusionMs: 3,
+  dilutionCapMs: 0,
+  dedupeMs: 4,
+  mappingMs: 5,
+  hydrationMs: 6,
+  retrievers: [
+    {
+      label: "semantic-video",
+      status: "fulfilled" as const,
+      elapsedMs: 88,
+      resultCount: 1,
+    },
+  ],
+}
+
+const currentSearchTimings = {
+  totalMs: 150,
+  retrievalsMs: 111,
+  fusionMs: 4,
+  dilutionCapMs: 0,
+  dedupeMs: 5,
+  mappingMs: 6,
+  hydrationMs: 7,
+  retrievers: [
+    {
+      label: "semantic-video",
+      status: "fulfilled" as const,
+      elapsedMs: 109,
+      resultCount: 1,
+    },
+  ],
+}
+
 function baselineArtifact(): BaselineArtifact {
   return {
     schemaVersion: "1",
@@ -453,6 +489,52 @@ describe("runOfflineSearchEval", () => {
     expect(judgePair).not.toHaveBeenCalledWith(
       expect.objectContaining({ query: "raw trace query" }),
     )
+  })
+
+  it("preserves baseline and current Admin search timings in comparison outcomes", async () => {
+    const baseline = baselineArtifact()
+    baseline.cases[0]!.searchTimings = baselineSearchTimings
+    const store = memoryStore(baseline)
+    const judgePair = vi.fn(async () => ({
+      verdict: "tie" as const,
+      rationale: "same",
+      tokens: { input: 1, output: 1 },
+      model: "judge",
+    }))
+
+    const result = await runOfflineSearchEval(
+      { mode: "compare", baselineName: "default" },
+      {
+        runId: "run-timing-propagation",
+        artifactStore: store,
+        adminBearer: "eval-key",
+        searchUrl: "https://admin.internal/api/internal/search-eval/search",
+        searchClient: vi.fn(async () => ({
+          ok: true as const,
+          result: {
+            results: [resultB],
+            hasMore: false,
+            query: "Jesus",
+            searchMode: "hybrid" as const,
+            timings: currentSearchTimings,
+          },
+        })),
+        judge: { model: "judge", judgePair },
+        now: () => new Date("2026-05-27T00:00:00.000Z"),
+      },
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      report: {
+        outcomes: [
+          {
+            baselineSearchTimings,
+            currentSearchTimings,
+          },
+        ],
+      },
+    })
   })
 
   it("keeps seed baseline capture running when exploratory candidate reads fail", async () => {

--- a/apps/mastra/src/services/offline-search-eval/runner.ts
+++ b/apps/mastra/src/services/offline-search-eval/runner.ts
@@ -382,6 +382,9 @@ async function searchSeedCases(
       tags: prompt.tags,
       operatorNotes: prompt.operatorNotes,
       results: result.ok ? result.result.results : [],
+      ...(result.ok && result.result.timings
+        ? { searchTimings: result.result.timings }
+        : {}),
       ...(result.ok ? {} : { searchFailure: searchFailure(result) }),
     })
   }
@@ -402,6 +405,12 @@ function baselineReportOutcomes(
     callerTrack: normalizeSearchEvalCallerTrack(entry.callerTrack),
     baselineResults: entry.results,
     currentResults: entry.results,
+    ...(entry.searchTimings
+      ? {
+          baselineSearchTimings: entry.searchTimings,
+          currentSearchTimings: entry.searchTimings,
+        }
+      : {}),
     ...(entry.searchFailure ? { searchFailure: entry.searchFailure } : {}),
   }))
 }
@@ -497,6 +506,9 @@ async function exploratoryGeneratedOutcomes(
       queryHash: entry.queryHash,
       retentionExpiresAt: entry.retentionExpiresAt,
       results: result.ok ? result.result.results : [],
+      ...(result.ok && result.result.timings
+        ? { searchTimings: result.result.timings }
+        : {}),
       ...(result.ok ? {} : { searchFailure: searchFailure(result) }),
     })
   }
@@ -587,6 +599,12 @@ async function compareBaselineCases({
         callerTrack: input.callerTrack,
         baselineResults: entry.results,
         currentResults: current.ok ? current.result.results : [],
+        ...(entry.searchTimings
+          ? { baselineSearchTimings: entry.searchTimings }
+          : {}),
+        ...(current.ok && current.result.timings
+          ? { currentSearchTimings: current.result.timings }
+          : {}),
         searchFailure: current.ok
           ? entry.searchFailure
           : searchFailure(current),
@@ -624,6 +642,12 @@ async function compareBaselineCases({
         callerTrack: input.callerTrack,
         baselineResults: entry.results,
         currentResults: current.result.results,
+        ...(entry.searchTimings
+          ? { baselineSearchTimings: entry.searchTimings }
+          : {}),
+        ...(current.result.timings
+          ? { currentSearchTimings: current.result.timings }
+          : {}),
         verdicts: [forward.verdict, swapped.verdict],
         rationale: forward.rationale,
       })
@@ -648,6 +672,12 @@ async function compareBaselineCases({
         callerTrack: input.callerTrack,
         baselineResults: entry.results,
         currentResults: current.result.results,
+        ...(entry.searchTimings
+          ? { baselineSearchTimings: entry.searchTimings }
+          : {}),
+        ...(current.result.timings
+          ? { currentSearchTimings: current.result.timings }
+          : {}),
         rationale: "judge_failed",
         searchFailure: judgeFailure,
       })

--- a/apps/mastra/src/services/offline-search-eval/types.ts
+++ b/apps/mastra/src/services/offline-search-eval/types.ts
@@ -142,6 +142,24 @@ export type SearchEvalResult = {
   childCount: number | null
 }
 
+export type AdminSearchRetrieverTiming = {
+  label: string
+  status: "fulfilled" | "rejected"
+  elapsedMs: number
+  resultCount: number
+}
+
+export type AdminSearchTimingSummary = {
+  totalMs: number
+  retrievalsMs: number
+  fusionMs: number
+  dilutionCapMs: number
+  dedupeMs: number
+  mappingMs: number
+  hydrationMs: number
+  retrievers: AdminSearchRetrieverTiming[]
+}
+
 export type SeedPromptCase = {
   id: string
   locale: string
@@ -178,6 +196,7 @@ export type BaselineCase = {
   tags: string[]
   operatorNotes?: string
   results: SearchEvalResult[]
+  searchTimings?: AdminSearchTimingSummary
   searchFailure?: SearchFailure
 }
 
@@ -249,6 +268,8 @@ export type ComparisonOutcome = {
   callerTrack: SearchEvalCallerTrack
   baselineResults: SearchEvalResult[]
   currentResults: SearchEvalResult[]
+  baselineSearchTimings?: AdminSearchTimingSummary
+  currentSearchTimings?: AdminSearchTimingSummary
   verdicts?: [JudgeVerdict, JudgeVerdict]
   rationale?: string
   searchFailure?: SearchFailure
@@ -264,6 +285,7 @@ export type ExploratoryGeneratedOutcome = {
   retentionExpiresAt: string | null
   skippedReason?: "trace_derived_not_judged_or_searched"
   results: SearchEvalResult[]
+  searchTimings?: AdminSearchTimingSummary
   searchFailure?: SearchFailure
 }
 

--- a/docs/plans/2026-06-24-001-feat-search-path-latency-logging-plan.md
+++ b/docs/plans/2026-06-24-001-feat-search-path-latency-logging-plan.md
@@ -1,0 +1,250 @@
+---
+title: "feat: Add search path latency logging"
+type: "feat"
+date: 2026-06-24
+---
+
+# feat: Add Search Path Latency Logging
+
+## Summary
+
+Add production-safe timing visibility to Admin search so keyword-first, hybrid,
+and internal semantic-only searches report where latency is spent. The first
+slice measures route/service work, DB-backed retriever calls, fusion, dilution,
+dedupe, mapping, hydration, and trace writes; it intentionally does not measure
+embedding latency.
+
+---
+
+## Problem Frame
+
+`feat-175` needs production evidence before the next optimization move. Current
+prod-backed eval artifacts show whole-query latency around 4.2-4.6 seconds on
+average, but the Admin search path does not expose the stage timings needed to
+separate DB retrieval cost from RRF, hydration, trace persistence, or transport.
+
+The requested implementation should add the missing measurement layer without
+changing public search response shape, leaking search query text, or timing the
+embedding provider call.
+
+---
+
+## Requirements
+
+- R1. Emit a production-visible search timing log for successful and degraded
+  Admin search requests across REST, GraphQL, and the internal eval route.
+- R2. Include DB-backed retrieval elapsed time per retriever label, including
+  semantic video, keyword video, weighted keyword video, trigram video, exact
+  title video, semantic experience, and keyword experience when they run.
+- R3. Do not emit or return embedding latency, even though the embedding call
+  remains part of total service time.
+- R4. Include non-retriever timings for retrieval fan-out total, RRF fusion,
+  dilution cap, dedupe, mapping, card hydration, trace write, and total search
+  service time where the boundary can observe them.
+- R5. Keep public REST and GraphQL response shapes unchanged.
+- R6. Extend the internal search-eval contract and Mastra client/report types so
+  per-query timing details survive strict schema parsing and later eval reports.
+- R7. Logs and artifacts must not include raw query text, raw vectors, bearer
+  tokens, user ids, IPs, or per-result debug payloads.
+- R8. Timing values must be bounded non-negative millisecond numbers and use the
+  existing `[search] event=name key=value` log format that Railway surfaces.
+
+---
+
+## Key Technical Decisions
+
+- **Measure retriever promises as DB retrieval timing:** Each retriever function
+  is the service-level DB retrieval boundary. Wrapping the promises where the
+  orchestrator dispatches them gives per-label timing without rewriting raw SQL
+  or leaking parameters.
+- **Return timings only from internal trace/eval surfaces:** Public search
+  responses stay stable. `searchWithTrace` can return a timing summary beside
+  the existing internal trace metadata, while REST and GraphQL use it only for
+  logs and trace-write measurement.
+- **Do not split out embedding latency:** Total search time still includes
+  embedding because users wait for it, but no `embeddingMs` field is produced.
+  That matches the requested measurement boundary.
+- **Teach Mastra the new internal eval shape in the same PR:** The eval client
+  currently uses a strict Admin search response schema. Adding timing fields to
+  the internal route requires matching parser, runner, artifact, and report
+  updates so the data is not discarded or rejected.
+- **Keep log fields parser-friendly:** Emit only controlled labels, modes,
+  route names, counts, and numeric timings. Use the plain-string `event=...`
+  format documented for Railway logsV2.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["REST / GraphQL / internal eval route"] --> B["HybridSearchService.searchWithTrace"]
+  B --> C["Embedding call runs but is not separately timed"]
+  C --> D["Timed retriever fan-out"]
+  D --> E["Per-label DB retriever ms"]
+  D --> F["RRF fusion ms"]
+  F --> G["Dilution / dedupe / mapping ms"]
+  G --> H["Card hydration ms"]
+  H --> I["Timing summary"]
+  I --> J["Search timing log"]
+  I --> K["Internal eval response + Mastra report"]
+  I --> L["Trace write timing at public boundaries"]
+```
+
+---
+
+## Scope Boundaries
+
+In scope:
+
+- Admin search service timing summary and structured logs.
+- Internal eval route timing response shape.
+- Mastra strict parser/report updates needed to preserve internal eval timings.
+- Unit tests proving timing presence, privacy boundaries, and parser
+  compatibility.
+
+Deferred to follow-up work:
+
+- Running production canaries and comparing all three modes after the PR is
+  deployed.
+- Changing ranking, SQL query plans, HNSW indexes, retriever timeouts, or
+  hydration strategy.
+- Browser RUM or frontend input-to-results timing.
+- Persisting detailed per-stage timing in Admin trace tables.
+
+---
+
+## Implementation Units
+
+### U1. Add Admin Search Timing Summary
+
+- **Goal:** Produce an internal timing summary from the Admin search
+  orchestrator without exposing it on public API responses.
+- **Requirements:** R1, R2, R3, R4, R5, R7, R8
+- **Dependencies:** None
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+- **Approach:** Add a timing helper based on a monotonic clock. Wrap each
+  retriever promise at construction time so fulfilled, rejected, and empty-list
+  paths record per-label elapsed time. Measure retrieval fan-out total, fusion,
+  dilution cap, dedupe, mapping, hydration, and total service time. Add the
+  summary to `SearchWithTraceResult`, not `SearchResponse`.
+- **Patterns to follow:** Existing retriever labels and `Promise.allSettled`
+  orchestration in `hybrid-search.service.ts`; existing log sanitizer and
+  privacy posture around `sanitizeForLog`.
+- **Test scenarios:**
+  - A successful hybrid search returns a timing summary with per-label retriever
+    timings for dispatched retrievers.
+  - A rejected retriever still records that label's elapsed time and appears in
+    `failedRetrievers`.
+  - Keyword-first records the weighted, trigram, and exact-title labels when
+    videos are requested.
+  - Internal semantic-only skips lexical retrievers and records only dispatched
+    semantic labels.
+  - No timing field named `embeddingMs` or equivalent is present.
+- **Verification:** Admin search service tests pass and public `search()`
+  response shape remains unchanged.
+
+### U2. Log Boundary Timings For REST And GraphQL
+
+- **Goal:** Emit parseable production logs for public Admin search boundaries
+  and include trace-write elapsed time where those boundaries perform trace
+  writes.
+- **Requirements:** R1, R3, R4, R5, R7, R8
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/app/api/search/route.ts`
+  - `apps/admin/src/app/api/search/route.test.ts`
+  - `apps/admin/src/graphql/queries/hybrid-search.ts`
+  - Relevant GraphQL query tests if existing mocks assert trace shape
+- **Approach:** After `searchWithTrace`, time `recordSearchTraceSafely` and log
+  one `[search] event=search_timing ...` line with route, mode, locale, result
+  count, total ms, retriever total, per-label retriever ms, fusion, dilution,
+  dedupe, mapping, hydration, and trace-write ms. Emit controlled values only.
+- **Patterns to follow:** Existing `event=search.request` plain-string logs and
+  Railway logsV2 guidance in
+  `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`.
+- **Test scenarios:**
+  - REST happy path logs `event=search_timing` with route `rest` and numeric
+    timing fields.
+  - REST logging does not include the raw query, bearer, key id, vector, or
+    debug payload.
+  - GraphQL route uses the same field names with route `graphql`.
+  - Trace write timeout or failure still produces a timing log without rejecting
+    the successful search response.
+- **Verification:** Route tests prove logs are parseable and response contracts
+  remain unchanged.
+
+### U3. Extend Internal Eval Timing Contract
+
+- **Goal:** Return and preserve per-query Admin timing from the internal eval
+  route so later prod query sweeps can report all three modes with DB retrieval
+  timing.
+- **Requirements:** R1, R2, R3, R4, R6, R7, R8
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/app/api/internal/search-eval/search/route.ts`
+  - `apps/admin/src/app/api/internal/search-eval/search/route.test.ts`
+  - `apps/mastra/src/services/admin-search-eval-client.ts`
+  - `apps/mastra/src/services/admin-search-eval-client.test.ts`
+  - `apps/mastra/src/services/offline-search-eval/runner.ts`
+  - `apps/mastra/src/services/offline-search-eval/runner.test.ts`
+  - `apps/mastra/src/services/offline-search-eval/types.ts`
+  - `apps/mastra/src/services/offline-search-eval/artifacts.ts`
+  - Relevant report/artifact tests that assert strict report schema
+- **Approach:** Change the internal eval route to call `searchWithTrace` and
+  return an envelope that carries the normal search fields plus a `timings`
+  object. Update Mastra's strict schema to accept that internal shape, normalize
+  timings into the runner result, and aggregate or expose per-case stage
+  timings in eval artifacts without breaking old artifacts.
+- **Patterns to follow:** Strict zod response parsing in
+  `admin-search-eval-client.ts`; report timing metadata in
+  `offline-search-eval/types.ts`; internal Admin HTTP boundary guidance in
+  `docs/solutions/architecture-patterns/mastra-offline-search-eval-orchestration-boundary-pattern.md`.
+- **Test scenarios:**
+  - Internal eval response includes timings for a successful query.
+  - Mastra client accepts the new response shape and rejects malformed negative
+    timing values.
+  - Existing search result normalization still truncates snippets and defaults
+    optional card fields.
+  - Runner/report output includes Admin stage timing data without raw query text
+    beyond existing eval prompt artifacts.
+  - Old artifacts without stage timings remain readable if the report schema is
+    expanded.
+- **Verification:** Admin internal eval route tests and Mastra offline search
+  eval parser/report tests pass.
+
+---
+
+## Risks & Dependencies
+
+- Mastra's strict schemas can reject the internal response if Admin changes land
+  without matching client updates. Keep Admin and Mastra changes in the same PR.
+- Total search time will still include the unreported embedding call. Reports
+  must label this clearly so readers do not mistake the sum of visible stages
+  for the total.
+- Logging per retriever label creates a new production signal. Keep field names
+  stable enough for the immediate query sweep, but treat them as internal
+  observability rather than public contract.
+- The timing layer may show that optimization belongs in SQL or hydration. This
+  PR should stop at measurement and leave those changes for the evidence-backed
+  follow-up.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-12-001-fix-semantic-search-performance-proof-plan.md`
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/services/hybrid-search-retrievers.ts`
+- `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts`
+- `apps/admin/src/app/api/search/route.ts`
+- `apps/admin/src/graphql/queries/hybrid-search.ts`
+- `apps/admin/src/app/api/internal/search-eval/search/route.ts`
+- `apps/mastra/src/services/admin-search-eval-client.ts`
+- `apps/mastra/src/services/offline-search-eval/runner.ts`
+- `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`
+- `docs/solutions/security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md`
+- `docs/solutions/architecture-patterns/internal-diagnostic-search-modes-need-mode-aware-eval-identity.md`

--- a/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
+++ b/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
@@ -9,7 +9,8 @@ duration: 1
 depends_on:
   - "feat-131"
   - "feat-172"
-blocks: []
+blocks:
+  - "feat-203"
 tags:
   - "admin"
   - "search"

--- a/docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md
+++ b/docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md
@@ -11,6 +11,7 @@ depends_on:
 blocks:
   - "feat-194"
   - "feat-196"
+  - "feat-203"
 tags:
   - "admin"
   - "mastra"

--- a/docs/roadmap/content-discovery/feat-203-hybrid-semantic-only-search-performance.md
+++ b/docs/roadmap/content-discovery/feat-203-hybrid-semantic-only-search-performance.md
@@ -1,0 +1,132 @@
+---
+id: "feat-203"
+title: "Hybrid and semantic-only search performance investigation"
+owner: "nisal"
+priority: "P1"
+status: "not-started"
+start_date: "2026-06-24"
+duration: 3
+depends_on:
+  - "feat-175"
+  - "feat-193"
+blocks: []
+tags:
+  - "admin"
+  - "watch"
+  - "search"
+  - "hybrid"
+  - "semantic-search"
+  - "performance"
+  - "evals"
+---
+
+## Problem
+
+`feat-175` focuses on the production Watch path that opts into Admin
+`mode="keyword-first"`. The same Admin search service also serves default
+`hybrid` callers and internal `semantic-only` diagnostics through the Mastra
+search eval suite. Those modes can still inherit the expensive semantic-video
+retrieval path, retriever fan-out costs, trace persistence costs, and Admin
+transport latency.
+
+The team needs a separate performance pass for `hybrid` and `semantic-only`
+searches so AI experience generation, diagnostics, and future callers do not
+ship with hidden latency problems after the public keyword-first path is fixed.
+
+## Entry Points - Read These First
+
+1. `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+   - current keyword-first latency recovery and pgvector/HNSW guardrails.
+2. `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
+   - existing eval tracks for `public-watch`, `ai-experience-generation`, and
+   `semantic-diagnostic`.
+3. `apps/admin/src/services/hybrid-search.service.ts`
+   - mode selection, retriever fan-out, RRF orchestration, trace metadata, and
+   result mapping.
+4. `apps/admin/src/services/hybrid-search-retrievers.ts`
+   - semantic-video, keyword, trigram, exact-title, and experience retriever SQL.
+5. `apps/admin/src/app/api/internal/search-eval/search/route.ts`
+   - internal eval route that accepts mode-specific eval calls.
+6. `apps/admin/src/graphql/queries/hybrid-search.ts`
+   - public GraphQL search boundary for `hybrid` and `keyword-first` callers.
+7. `apps/mastra/src/services/offline-search-eval/runner.ts`
+   - mode/caller-track eval runner behavior.
+8. `apps/mastra/src/services/offline-search-eval/types.ts`
+   - caller-track defaults and suitable modes.
+9. `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+   - pgvector planner and index-selection failure modes.
+
+## Grep These
+
+- `rg -n "mode.*hybrid|semantic-only|keyword-first" apps/admin/src apps/mastra/src`
+- `rg -n "semantic-video|searchVideoSemantic|searchExperienceSemantic" apps/admin/src/services`
+- `rg -n "retriever|elapsed|timing|trace|recordSearchTrace" apps/admin/src/services apps/admin/src/app/api`
+- `rg -n "callerTrack|ai-experience-generation|semantic-diagnostic" apps/mastra/src/services/offline-search-eval apps/mastra/src/mastra/workflows`
+- `rg -n "EXPLAIN|ANALYZE|BUFFERS|hnsw|embedding <=>" docs apps/admin`
+
+## What To Build
+
+1. Capture baseline latency for default `hybrid` and internal `semantic-only`
+   searches using representative canary queries and the existing Mastra eval
+   caller tracks:
+   - `ai-experience-generation` with `mode="hybrid"`;
+   - `semantic-diagnostic` with `mode="semantic-only"`.
+2. Compare total latency and per-stage timings for retriever fan-out,
+   semantic-video SQL, semantic-experience SQL, RRF/fusion, hydration, mapping,
+   trace persistence, and Admin transport. Do not measure or report embedding
+   latency as a separate field.
+3. Identify which slow paths are shared with `feat-175` and which are unique to
+   broad `hybrid` or `semantic-only` execution.
+4. Fix scoped bottlenecks that can be changed without degrading relevance or
+   changing public response contracts. Likely candidates include mode-specific
+   retriever dispatch, bounded semantic windows, post-collapse hydration,
+   corpus-health skips, trace write overhead, and redundant query work.
+5. For any SQL/index change, collect production-shaped
+   `EXPLAIN (ANALYZE, BUFFERS)` evidence before and after the change.
+6. Keep `semantic-only` internal-only unless a separate product/API ticket
+   explicitly promotes it. Public REST and GraphQL mode behavior should stay
+   stable.
+7. Save a concise performance proof that names the search mode, caller track,
+   query set, p50/p95 or per-canary timings, and any remaining bottleneck.
+
+## Constraints
+
+- Do not broaden `feat-175`; this is a follow-up for non-keyword-first modes.
+- Do not solve speed primarily by timing out retrievers and returning degraded
+  results.
+- Do not change public REST, GraphQL, or Web result shape.
+- Do not let `semantic-only` become a public mode as part of this work.
+- Do not add a separate embedding latency measurement.
+- Do not delete old vectors or scene tables as the first performance lever.
+- Do not ship HNSW-first rewrites without a distinct-video guarantee or
+  duplicate-heavy Mastra no-regression proof.
+- Keep provider-bound semantic correctness: query and stored vectors must share
+  provider, model, dimensions, native dimensions, and transform-version
+  semantics.
+
+## Acceptance Criteria
+
+- Baseline timings exist for `hybrid` and `semantic-only` canaries before any
+  fix is claimed.
+- The investigation identifies whether latency is dominated by embedding,
+  semantic-video SQL, semantic-experience SQL, retriever fan-out, fusion,
+  hydration, trace persistence, or Admin transport.
+- Any implemented fix preserves relevance and response-shape contracts.
+- Mastra evals for `ai-experience-generation` and `semantic-diagnostic` show no
+  relevance regression.
+- Post-fix timings improve or a clear documented blocker explains why no safe
+  optimization landed.
+- Remaining follow-up work is captured as narrower tickets if this pass finds
+  larger indexing, data cleanup, or API-design changes.
+
+## Verification
+
+- `pnpm --filter @forge/admin test -- src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search.service.test.ts src/services/hybrid-search.regression.test.ts`
+- `pnpm --filter @forge/admin test -- src/app/api/internal/search-eval/search/route.test.ts`
+- `pnpm --filter @forge/admin typecheck`
+- `pnpm --filter @forge/admin lint -- src/services/hybrid-search.service.ts src/services/hybrid-search-retrievers.ts src/app/api/internal/search-eval/search/route.ts`
+- Run Mastra search evals for:
+  - caller track `ai-experience-generation`, mode `hybrid`;
+  - caller track `semantic-diagnostic`, mode `semantic-only`.
+- Capture production-shaped canary timings and, for SQL changes,
+  `EXPLAIN (ANALYZE, BUFFERS)` before/after evidence.

--- a/docs/roadmap/content-discovery/feat-203-hybrid-semantic-only-search-performance.md
+++ b/docs/roadmap/content-discovery/feat-203-hybrid-semantic-only-search-performance.md
@@ -39,10 +39,10 @@ ship with hidden latency problems after the public keyword-first path is fixed.
    - current keyword-first latency recovery and pgvector/HNSW guardrails.
 2. `docs/roadmap/content-discovery/feat-193-watch-search-readiness-eval-suite.md`
    - existing eval tracks for `public-watch`, `ai-experience-generation`, and
-   `semantic-diagnostic`.
+     `semantic-diagnostic`.
 3. `apps/admin/src/services/hybrid-search.service.ts`
    - mode selection, retriever fan-out, RRF orchestration, trace metadata, and
-   result mapping.
+     result mapping.
 4. `apps/admin/src/services/hybrid-search-retrievers.ts`
    - semantic-video, keyword, trigram, exact-title, and experience retriever SQL.
 5. `apps/admin/src/app/api/internal/search-eval/search/route.ts`

--- a/docs/solutions/architecture-patterns/admin-search-stage-timing-without-contract-drift.md
+++ b/docs/solutions/architecture-patterns/admin-search-stage-timing-without-contract-drift.md
@@ -1,0 +1,208 @@
+---
+title: "Admin search stage timing without public contract drift"
+date: 2026-06-24
+category: architecture-patterns
+module: apps/admin
+problem_type: architecture_pattern
+component: service_object
+severity: medium
+applies_when:
+  - "Admin search needs production latency evidence across REST, GraphQL, and internal eval callers"
+  - "Per-query timing must survive strict eval artifacts without changing public response shapes"
+tags:
+  - admin
+  - search
+  - observability
+  - latency
+  - mastra
+  - railway
+---
+
+# Admin Search Stage Timing Without Public Contract Drift
+
+## Context
+
+Admin search needed production evidence for `feat-175`: total request latency was
+known to be high, but the system could not separate DB-backed retrieval,
+fusion, hydration, trace persistence, and route overhead. The risky part was not
+the timer itself. The risky part was adding useful per-query timing without
+changing the public REST or GraphQL search payload, leaking query text, or
+teaching Mastra's strict eval parser to reject old artifacts.
+
+The successful shape keeps the timing summary internal to the service and eval
+tooling:
+
+- `searchWithTrace()` returns `{ response, trace, timings }`.
+- Public REST and GraphQL routes log `timings` but still return only
+  `response`.
+- The internal eval route returns `{ ...response, timings }` because Mastra is
+  the intended machine consumer.
+- Mastra schemas accept optional timings so older artifacts remain readable.
+
+## Guidance
+
+### Put Timing Beside The Public Response, Not Inside It
+
+Keep the public response type stable and attach observability to the internal
+trace surface:
+
+```ts
+export type SearchWithTraceResult = {
+  response: SearchResponse
+  trace: SearchExecutionSummary
+  timings: SearchTimingSummary
+}
+
+async search(params: SearchParams): Promise<SearchResponse> {
+  const { response } = await this.searchWithTrace(params)
+  return response
+}
+```
+
+This lets existing public callers keep their exact JSON contract while routes
+and internal eval tools still get the timing detail they need.
+
+### Measure DB Retrieval At The Retriever Boundary
+
+Wrap each retriever promise where the search orchestrator dispatches it. That
+is the service-level DB retrieval boundary: it includes the SQL query and
+Prisma/raw-query work for that retriever label, without forcing timing into
+each SQL helper.
+
+```ts
+const timedRetrieval = (
+  label: string,
+  run: () => Promise<RankedItem[]>,
+): Promise<RankedItem[]> => {
+  const startedAt = nowMs()
+  return Promise.resolve()
+    .then(run)
+    .then(
+      (value) => {
+        retrieverTimings.set(label, {
+          label,
+          status: "fulfilled",
+          elapsedMs: elapsedMs(startedAt),
+          resultCount: value.length,
+        })
+        return value
+      },
+      (error) => {
+        retrieverTimings.set(label, {
+          label,
+          status: "rejected",
+          elapsedMs: elapsedMs(startedAt),
+          resultCount: 0,
+        })
+        throw error
+      },
+    )
+}
+```
+
+Do not create fake timing records for retrievers that did not run. For example,
+if query embedding fails, semantic DB retrievers are not dispatched, so they
+should be absent from `timings.retrievers` rather than reported as `0ms`.
+
+### Keep Embedding Latency Out Of The Timing Contract
+
+Total search time still includes the embedding call because the user waits for
+it. The explicit timing fields should not include `embeddingMs`,
+`embedding_ms`, or a synonym when the requested measurement excludes embedding
+latency. That means visible stage timings will not necessarily sum to total
+time, and reports should label that clearly.
+
+### Log In Railway-Friendly Key-Value Lines
+
+Railway logsV2 has previously dropped JSON-shaped runtime logs from Next.js
+route handlers. Emit parseable plain-string logs instead:
+
+```text
+[search] event=search_timing route=rest locale=en requested_mode=keyword-first search_mode=hybrid outcome=success result_count=10 total_ms=123 db_retrievals_ms=80 fusion_ms=1 hydration_ms=4 trace_write_ms=2 db_retriever_semantic_video_ms=77
+```
+
+Use a small formatter that owns all field names and sanitizes user-adjacent
+values:
+
+```ts
+export function searchTimingLogValue(raw: unknown): string {
+  const normalized = String(raw ?? "none")
+    .replace(/[\r\n\t\s=]/g, "_")
+    .slice(0, 64)
+  return normalized.length > 0 ? normalized : "none"
+}
+```
+
+Route inputs such as `mode` and `locale` should never be interpolated raw into
+the timing line. Do not log the query text, raw vectors, bearer tokens, key ids,
+user ids, IPs, or debug payloads.
+
+### Extend Strict Eval Consumers In The Same Slice
+
+If an internal Admin route returns a new optional object, update the Mastra
+client and artifact schemas in the same PR:
+
+```ts
+export const AdminSearchResponseSchema = z
+  .object({
+    results: z.array(SearchResultSchema),
+    hasMore: z.boolean(),
+    query: z.string(),
+    searchMode: z.enum(["hybrid", "keyword-only"]),
+    timings: AdminSearchTimingsSchema.optional(),
+  })
+  .strict()
+```
+
+Then propagate timings through baseline cases, comparison outcomes, and
+exploratory generated outcomes only when present. Optional fields keep old
+artifacts compatible.
+
+## Why This Matters
+
+This pattern gives operators stage-level latency evidence without making public
+search callers pay for an API change. It also keeps privacy and operational
+logging concerns in one place: the service owns timing collection, the route
+owns trace-write timing and log emission, and Mastra owns strict preservation
+for later analysis.
+
+The separation is important because the next performance move should be based
+on production data. If DB retrieval dominates, SQL/index/window work is likely.
+If trace persistence or hydration dominates, changing pgvector plans would be
+noise. Without stable per-stage fields, those paths are hard to compare across
+`keyword-first`, `hybrid`, and internal `semantic-only` searches.
+
+## When To Apply
+
+- A shared service feeds public routes and internal diagnostics.
+- Operators need per-stage latency from production logs before optimizing.
+- Public response contracts must remain byte-stable.
+- A strict offline/eval client needs to preserve new diagnostic metadata.
+- Some requested stage, such as embedding latency, must intentionally remain
+  unreported even though it affects total time.
+
+## Examples
+
+Good boundaries:
+
+- Service timing: total search service time, retrieval fan-out, individual
+  retrievers, fusion, dilution cap, dedupe, mapping, hydration.
+- Route timing: trace-write time for routes that write traces.
+- Internal eval response: optional `timings` object for Mastra only.
+- Public REST/GraphQL response: unchanged `SearchResponse`.
+
+Avoid these shortcuts:
+
+- Adding `timings` to the public REST or GraphQL search payload.
+- Logging raw query text in a hot-path timing line.
+- Returning `embeddingMs` when embedding latency is explicitly out of scope.
+- Reporting skipped semantic retrievers as `0ms` DB calls.
+- Updating Admin's internal route without updating Mastra's strict parser.
+
+## Related
+
+- [Railway logsV2 silences JSON-stringified payloads from Next.js App Router runtime route handlers](../runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md)
+- [Log-injection: sanitize user input before interpolating into structured warn lines](../security-issues/log-injection-sanitizer-user-input-structured-logs-20260429.md)
+- [Admin hybrid search (R4) - port pattern](../platform/admin-hybrid-search-r4-pattern.md)
+- [Admin hybrid search keyword-first mode - R4 extension pattern](../platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md)
+- `docs/plans/2026-06-24-001-feat-search-path-latency-logging-plan.md`


### PR DESCRIPTION
## Summary
Admin search now emits production-visible stage timing lines for successful and degraded REST, GraphQL, and internal eval searches, so the follow-up query sweep can separate DB retriever time, RRF/fusion, mapping, hydration, trace writes, and total service time without changing public search responses. The timing contract intentionally does not expose embedding latency; total time still includes the user's wait, but there is no `embeddingMs` or `embedding_ms` field.

## What changed
- `HybridSearchService.searchWithTrace()` now returns an internal `timings` summary beside `response` and `trace`, with per-label DB retriever timings, status, and counts.
- REST and GraphQL keep their response bodies unchanged and emit `[search] event=search_timing ...` lines with sanitized key-value fields and trace-write timing.
- Internal eval returns `{ ...response, timings }`, and Mastra parses, preserves, and writes those optional timings into baseline/comparison artifacts.
- Added the follow-up ticket for hybrid/semantic-only performance investigation, explicitly excluding separate embedding-latency measurement.

## Validation
- `pnpm --filter @forge/admin test -- src/services/hybrid-search.service.test.ts src/services/hybrid-search.keyword-first.test.ts src/app/api/search/route.test.ts src/graphql/queries/hybrid-search.test.ts src/app/api/internal/search-eval/search/route.test.ts`
- `pnpm --filter @forge/mastra test -- src/services/admin-search-eval-client.test.ts src/services/offline-search-eval/runner.test.ts src/services/offline-search-eval/artifacts.test.ts src/services/offline-search-eval/report.test.ts`
- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/mastra lint`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/mastra typecheck`
- `git diff --check`

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
