### PR TITLE
fix(search): restore admin search timing logs

### DIFF
--- a/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
@@ -34,8 +34,43 @@ vi.mock("@/services/search-trace.service", () => ({
 }))
 vi.mock("@/services/hybrid-search.service", () => {
   const contentTypes = new Set(["video", "experience"])
+  const makeTimings = () => ({
+    pipelineMode: "hybrid" as const,
+    totalMs: 1,
+    embeddingMs: 1,
+    retrievalsMs: 0,
+    fusionMs: 0,
+    dilutionCapMs: 0,
+    dedupeMs: 0,
+    mappingMs: 0,
+    hydrationMs: 0,
+    retrievers: [],
+    db: [],
+  })
   return {
-    HybridSearchService: vi.fn(() => ({ search: routeMocks.search })),
+    HybridSearchService: vi.fn(() => ({
+      search: routeMocks.search,
+      searchWithTrace: async (params: unknown) => {
+        const response = await routeMocks.search(params)
+        return {
+          response,
+          trace: {
+            searchMode: response.searchMode,
+            resultCount: response.results.length,
+            outcome:
+              response.searchMode === "keyword-only" ? "degraded" : "success",
+            traceClass:
+              response.searchMode === "keyword-only"
+                ? "query_embedding_failure"
+                : "none",
+            failedRetrievers: [],
+            contributingRetrievers: [],
+          },
+          timings: makeTimings(),
+        }
+      },
+    })),
+    formatSearchTimingLogLine: vi.fn(() => "[search] event=search_timing"),
     isContentType: (value: string) => contentTypes.has(value),
   }
 })

--- a/apps/admin/src/app/api/internal/search-eval/search/route.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.ts
@@ -2,6 +2,7 @@ import { rateLimitAuthRoute } from "@/auth/rate-limit"
 import { isValidSearchTraceSamplingBearer } from "@/auth/search-trace-bearer"
 import { prisma } from "@/db/client"
 import {
+  formatSearchTimingLogLine,
   HybridSearchService,
   isContentType,
   type ContentType,
@@ -231,7 +232,7 @@ export async function POST(request: Request): Promise<Response> {
     const locale = await searchLocaleForParams(params)
     if (locale instanceof Response) return locale
     const service = new HybridSearchService({ prisma })
-    const response = await service.search({
+    const { response, trace, timings } = await service.searchWithTrace({
       query: params.query,
       locale,
       limit: params.limit,
@@ -242,6 +243,17 @@ export async function POST(request: Request): Promise<Response> {
     })
     console.info(
       `[search] event=eval_search auth=bearer route=internal rl=${limit.source} locale=${logValue(locale)} mode=${logValue(params.mode)} result_count=${response.results.length}`,
+    )
+    console.error(
+      formatSearchTimingLogLine({
+        route: "internal",
+        locale,
+        requestedMode: params.mode ?? null,
+        searchMode: trace.searchMode,
+        outcome: trace.outcome,
+        resultCount: trace.resultCount,
+        timings,
+      }),
     )
     return Response.json(response, { status: 200 })
   } catch (error) {

--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -15,6 +15,19 @@ vi.mock("@/config/env", () => ({
 // The route constructs a HybridSearchService with the shared `prisma`
 // import; we mock the class so tests don't touch the DB.
 const searchMock = vi.fn()
+const makeTimings = () => ({
+  pipelineMode: "hybrid" as const,
+  totalMs: 1,
+  embeddingMs: 1,
+  retrievalsMs: 0,
+  fusionMs: 0,
+  dilutionCapMs: 0,
+  dedupeMs: 0,
+  mappingMs: 0,
+  hydrationMs: 0,
+  retrievers: [],
+  db: [],
+})
 const searchWithTraceMock = vi.fn(async (params) => {
   const response = await searchMock(params)
   return {
@@ -30,6 +43,7 @@ const searchWithTraceMock = vi.fn(async (params) => {
       failedRetrievers: [],
       contributingRetrievers: [],
     },
+    timings: makeTimings(),
   }
 })
 vi.mock("@/services/hybrid-search.service", async () => {

--- a/apps/admin/src/app/api/search/route.ts
+++ b/apps/admin/src/app/api/search/route.ts
@@ -11,6 +11,7 @@ import { rateLimitAuthRoute } from "@/auth/rate-limit"
 import { isAnyKnownBearer } from "@/auth/search-bearer"
 import { env } from "@/config/env"
 import {
+  formatSearchTimingLogLine,
   HybridSearchService,
   isContentType,
   type ContentType,
@@ -200,7 +201,7 @@ export async function GET(request: Request): Promise<Response> {
 
   try {
     const service = new HybridSearchService({ prisma })
-    const { response, trace } = await service.searchWithTrace({
+    const { response, trace, timings } = await service.searchWithTrace({
       query: q,
       locale,
       limit: limitParam,
@@ -209,6 +210,7 @@ export async function GET(request: Request): Promise<Response> {
       mode,
       debug,
     })
+    const traceWriteStartedAt = performance.now()
     await recordSearchTraceSafely({
       query: q,
       locale,
@@ -221,6 +223,22 @@ export async function GET(request: Request): Promise<Response> {
       startedAt,
       completedAt: new Date(),
     }).catch(() => {})
+    const traceWriteMs = Math.max(
+      0,
+      Math.round((performance.now() - traceWriteStartedAt) * 10) / 10,
+    )
+    console.error(
+      formatSearchTimingLogLine({
+        route: "rest",
+        locale,
+        requestedMode: mode ?? null,
+        searchMode: trace.searchMode,
+        outcome: trace.outcome,
+        resultCount: trace.resultCount,
+        timings,
+        traceWriteMs,
+      }),
+    )
     return Response.json(response, { status: 200 })
   } catch (error) {
     await recordSearchTraceSafely({

--- a/apps/admin/src/graphql/queries/hybrid-search.test.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.test.ts
@@ -11,6 +11,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const searchMock = vi.fn()
+const makeTimings = () => ({
+  pipelineMode: "hybrid" as const,
+  totalMs: 1,
+  embeddingMs: 1,
+  retrievalsMs: 0,
+  fusionMs: 0,
+  dilutionCapMs: 0,
+  dedupeMs: 0,
+  mappingMs: 0,
+  hydrationMs: 0,
+  retrievers: [],
+  db: [],
+})
 const searchWithTraceMock = vi.fn(async (params) => {
   const response = await searchMock(params)
   return {
@@ -26,6 +39,7 @@ const searchWithTraceMock = vi.fn(async (params) => {
       failedRetrievers: [],
       contributingRetrievers: [],
     },
+    timings: makeTimings(),
   }
 })
 vi.mock("@/services/hybrid-search.service", async () => {

--- a/apps/admin/src/graphql/queries/hybrid-search.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.ts
@@ -15,6 +15,7 @@ import { prisma } from "@/db/client"
 import { isAnyKnownBearer } from "@/auth/search-bearer"
 import { env } from "@/config/env"
 import {
+  formatSearchTimingLogLine,
   HybridSearchService,
   isContentType,
   type ContentType,
@@ -254,7 +255,7 @@ builder.queryFields((t) => ({
       const service = new HybridSearchService({ prisma })
       const startedAt = new Date()
       try {
-        const { response, trace } = await service.searchWithTrace({
+        const { response, trace, timings } = await service.searchWithTrace({
           query,
           locale: args.locale,
           limit: args.limit ?? undefined,
@@ -263,6 +264,7 @@ builder.queryFields((t) => ({
           mode,
           debug,
         })
+        const traceWriteStartedAt = performance.now()
         await recordSearchTraceSafely({
           query,
           locale: args.locale,
@@ -275,6 +277,22 @@ builder.queryFields((t) => ({
           startedAt,
           completedAt: new Date(),
         }).catch(() => {})
+        const traceWriteMs = Math.max(
+          0,
+          Math.round((performance.now() - traceWriteStartedAt) * 10) / 10,
+        )
+        console.error(
+          formatSearchTimingLogLine({
+            route: "graphql",
+            locale: args.locale,
+            requestedMode: mode ?? null,
+            searchMode: trace.searchMode,
+            outcome: trace.outcome,
+            resultCount: trace.resultCount,
+            timings,
+            traceWriteMs,
+          }),
+        )
         return response
       } catch (error) {
         await recordSearchTraceSafely({

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
@@ -16,6 +16,7 @@ import {
   searchByTrigram,
   tokenizeForExactTitle,
 } from "./hybrid-search-keyword-first-retrievers"
+import { SearchTimingRecorder } from "./hybrid-search-timing"
 
 function mockPrisma() {
   const $queryRaw = vi.fn()
@@ -131,6 +132,30 @@ describe("searchByKeywordWeighted", () => {
       description: "Animated bible overview",
       rank: 0.42,
     })
+  })
+
+  it("records the weighted keyword DB timing when a recorder is passed", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const timing = new SearchTimingRecorder()
+
+    await searchByKeywordWeighted(
+      prisma,
+      {
+        query: "bible project",
+        locale: "en",
+        limit: 10,
+      },
+      timing,
+    )
+
+    expect(timing.snapshotDbTimings()).toEqual([
+      expect.objectContaining({
+        label: "keyword-weighted-video.query",
+        status: "fulfilled",
+        resultCount: 0,
+        elapsedMs: expect.any(Number),
+      }),
+    ])
   })
 
   it("short-circuits to [] on empty / whitespace input without a DB call", async () => {

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
@@ -22,6 +22,10 @@
 import { Prisma, type PrismaClient } from "@prisma/client"
 import { WEIGHTED_TSV_QUERY_EXPR } from "./hybrid-search-sql"
 import type { RankedItem } from "./hybrid-search-fusion"
+import {
+  recordSearchDbTiming,
+  type SearchTimingRecorder,
+} from "./hybrid-search-timing"
 
 // -----------------------------------------------------------------------------
 // Shared parameter shapes
@@ -170,6 +174,7 @@ export function tokenizeForExactTitle(query: string): string[] {
 export async function searchByKeywordWeighted(
   prisma: PrismaClient,
   params: KeywordWeightedSearchParams,
+  timing?: SearchTimingRecorder,
 ): Promise<KeywordWeightedResult[]> {
   const trimmed = params.query.trim()
   if (trimmed.length === 0) return []
@@ -177,30 +182,34 @@ export async function searchByKeywordWeighted(
   const { locale, limit } = params
   const tsvector = Prisma.raw(WEIGHTED_TSV_QUERY_EXPR)
 
-  const rows = await prisma.$queryRaw<KeywordWeightedRow[]>`
-    SELECT * FROM (
-      SELECT DISTINCT ON (v.id)
-        v.id           AS video_id,
-        v.core_id      AS video_core_id,
-        v.slug         AS video_slug,
-        vl.title       AS video_title,
-        vl.description AS description,
-        ts_rank_cd(
-          ${tsvector},
-          websearch_to_tsquery('simple', ${trimmed})
-        ) AS rank
-      FROM video_locale vl
-      JOIN video v ON v.id = vl.video_id
-        AND v.deleted_at IS NULL
-      WHERE ${tsvector} @@ websearch_to_tsquery('simple', ${trimmed})
-        AND vl.locale = ${locale}
-        AND vl.status = 'published'
-        AND vl.deleted_at IS NULL
-      ORDER BY v.id, rank DESC
-    ) sub
-    ORDER BY sub.rank DESC
-    LIMIT ${limit}
-  `
+  const rows = await recordSearchDbTiming(
+    timing,
+    "keyword-weighted-video.query",
+    () => prisma.$queryRaw<KeywordWeightedRow[]>`
+      SELECT * FROM (
+        SELECT DISTINCT ON (v.id)
+          v.id           AS video_id,
+          v.core_id      AS video_core_id,
+          v.slug         AS video_slug,
+          vl.title       AS video_title,
+          vl.description AS description,
+          ts_rank_cd(
+            ${tsvector},
+            websearch_to_tsquery('simple', ${trimmed})
+          ) AS rank
+        FROM video_locale vl
+        JOIN video v ON v.id = vl.video_id
+          AND v.deleted_at IS NULL
+        WHERE ${tsvector} @@ websearch_to_tsquery('simple', ${trimmed})
+          AND vl.locale = ${locale}
+          AND vl.status = 'published'
+          AND vl.deleted_at IS NULL
+        ORDER BY v.id, rank DESC
+      ) sub
+      ORDER BY sub.rank DESC
+      LIMIT ${limit}
+    `,
+  )
 
   return rows.map((row) => ({
     resultType: "video" as const,
@@ -253,36 +262,41 @@ export async function searchByKeywordWeighted(
 export async function searchByTrigram(
   prisma: PrismaClient,
   params: TrigramSearchParams,
+  timing?: SearchTimingRecorder,
 ): Promise<TrigramResult[]> {
   const trimmed = params.query.trim()
   if (trimmed.length === 0) return []
 
   const { locale, limit } = params
 
-  const rows = await prisma.$queryRaw<TrigramRow[]>`
-    SELECT * FROM (
-      SELECT DISTINCT ON (v.id)
-        v.id           AS video_id,
-        v.core_id      AS video_core_id,
-        v.slug         AS video_slug,
-        vl.title       AS video_title,
-        vl.description AS description,
-        GREATEST(
-          similarity(vl.title, ${trimmed}),
-          similarity(coalesce(vl.description, ''), ${trimmed})
-        ) AS similarity
-      FROM video_locale vl
-      JOIN video v ON v.id = vl.video_id
-        AND v.deleted_at IS NULL
-      WHERE (vl.title %> ${trimmed} OR vl.description %> ${trimmed})
-        AND vl.locale = ${locale}
-        AND vl.status = 'published'
-        AND vl.deleted_at IS NULL
-      ORDER BY v.id, similarity DESC
-    ) sub
-    ORDER BY sub.similarity DESC
-    LIMIT ${limit}
-  `
+  const rows = await recordSearchDbTiming(
+    timing,
+    "trigram-video.query",
+    () => prisma.$queryRaw<TrigramRow[]>`
+      SELECT * FROM (
+        SELECT DISTINCT ON (v.id)
+          v.id           AS video_id,
+          v.core_id      AS video_core_id,
+          v.slug         AS video_slug,
+          vl.title       AS video_title,
+          vl.description AS description,
+          GREATEST(
+            similarity(vl.title, ${trimmed}),
+            similarity(coalesce(vl.description, ''), ${trimmed})
+          ) AS similarity
+        FROM video_locale vl
+        JOIN video v ON v.id = vl.video_id
+          AND v.deleted_at IS NULL
+        WHERE (vl.title %> ${trimmed} OR vl.description %> ${trimmed})
+          AND vl.locale = ${locale}
+          AND vl.status = 'published'
+          AND vl.deleted_at IS NULL
+        ORDER BY v.id, similarity DESC
+      ) sub
+      ORDER BY sub.similarity DESC
+      LIMIT ${limit}
+    `,
+  )
 
   return rows.map((row) => ({
     resultType: "video" as const,
@@ -321,6 +335,7 @@ export async function searchByTrigram(
 export async function searchByExactTitle(
   prisma: PrismaClient,
   params: ExactTitleSearchParams,
+  timing?: SearchTimingRecorder,
 ): Promise<ExactTitleResult[]> {
   const tokens = tokenizeForExactTitle(params.query)
   if (tokens.length === 0) return []
@@ -334,27 +349,31 @@ export async function searchByExactTitle(
     " AND ",
   )
 
-  const rows = await prisma.$queryRaw<ExactTitleRow[]>`
-    SELECT * FROM (
-      SELECT DISTINCT ON (v.id)
-        v.id            AS video_id,
-        v.core_id       AS video_core_id,
-        v.slug          AS video_slug,
-        vl.title        AS video_title,
-        vl.description  AS description,
-        LENGTH(vl.title) AS title_length
-      FROM video_locale vl
-      JOIN video v ON v.id = vl.video_id
-        AND v.deleted_at IS NULL
-      WHERE ${ilikeChain}
-        AND vl.locale = ${locale}
-        AND vl.status = 'published'
-        AND vl.deleted_at IS NULL
-      ORDER BY v.id, title_length ASC
-    ) sub
-    ORDER BY sub.title_length ASC
-    LIMIT ${limit}
-  `
+  const rows = await recordSearchDbTiming(
+    timing,
+    "exact-title-video.query",
+    () => prisma.$queryRaw<ExactTitleRow[]>`
+      SELECT * FROM (
+        SELECT DISTINCT ON (v.id)
+          v.id            AS video_id,
+          v.core_id       AS video_core_id,
+          v.slug          AS video_slug,
+          vl.title        AS video_title,
+          vl.description  AS description,
+          LENGTH(vl.title) AS title_length
+        FROM video_locale vl
+        JOIN video v ON v.id = vl.video_id
+          AND v.deleted_at IS NULL
+        WHERE ${ilikeChain}
+          AND vl.locale = ${locale}
+          AND vl.status = 'published'
+          AND vl.deleted_at IS NULL
+        ORDER BY v.id, title_length ASC
+      ) sub
+      ORDER BY sub.title_length ASC
+      LIMIT ${limit}
+    `,
+  )
 
   return rows.map((row) => ({
     resultType: "video" as const,

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -16,6 +16,7 @@ import {
   searchExperienceSemantic,
   searchExperienceKeyword,
 } from "./hybrid-search-retrievers"
+import { SearchTimingRecorder } from "./hybrid-search-timing"
 
 function mockPrisma() {
   const $queryRaw = vi.fn()
@@ -124,6 +125,30 @@ describe("searchVideoSemantic", () => {
       similarity: 0.87,
       embeddingText: "[0.1,0.2]",
     })
+  })
+
+  it("records the semantic-video DB timing when a recorder is passed", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const timing = new SearchTimingRecorder()
+
+    await searchVideoSemantic(
+      prisma,
+      {
+        queryEmbedding: "[0.1,0.2]",
+        locale: "en",
+        limit: 10,
+      },
+      timing,
+    )
+
+    expect(timing.snapshotDbTimings()).toEqual([
+      expect.objectContaining({
+        label: "semantic-video.query",
+        status: "fulfilled",
+        resultCount: 0,
+        elapsedMs: expect.any(Number),
+      }),
+    ])
   })
 
   it("maps transcript evidence rows through the same semantic-video result shape", async () => {

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -30,6 +30,10 @@ import {
   EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR,
 } from "./hybrid-search-sql"
 import type { RankedItem } from "./hybrid-search-fusion"
+import {
+  recordSearchDbTiming,
+  type SearchTimingRecorder,
+} from "./hybrid-search-timing"
 
 const QWEN_CONTENT_EMBEDDING_PROVIDER = "jesus-film-ai-gateway"
 const QWEN_CONTENT_EMBEDDING_MODEL = "embeddings"
@@ -308,6 +312,7 @@ type ExperienceKeywordRow = {
 export async function searchVideoSemantic(
   prisma: PrismaClient,
   params: SemanticSearchParams,
+  timing?: SearchTimingRecorder,
 ): Promise<VideoSemanticResult[]> {
   const { queryEmbedding, locale, limit } = params
   const candidateLimit = Math.max(limit * 2, limit)
@@ -322,86 +327,90 @@ export async function searchVideoSemantic(
           AND vtc.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
         `
 
-  const evidenceRows = await prisma.$queryRaw<VideoSemanticEvidenceRow[]>`
-    WITH transcript_source AS (
-      SELECT * FROM (
-        SELECT DISTINCT ON (vt.video_id)
-          vt.video_id                       AS video_id,
-          v.core_id                         AS video_core_id,
-          v.slug                            AS video_slug,
-          vl.title                          AS video_title,
-          vt.video_edition_id               AS video_edition_id,
-          vtc.id                            AS evidence_id,
-          'transcript'                      AS evidence_source,
-          COALESCE(
-            NULLIF(vtc.content_summary, ''),
-            NULLIF(vtc.raw_source_text, ''),
-            vtc.text
-          )                                 AS scene_description,
-          vtc.start_seconds                 AS start_seconds,
-          1 - (vtc.embedding <=> ${queryEmbedding}::vector) AS source_score
-        FROM video_transcript_chunk vtc
-        JOIN video_transcript vt ON vt.id = vtc.transcript_id
-          AND vt.language = ${locale}
-        JOIN video v ON v.id = vt.video_id
-          AND v.deleted_at IS NULL
-        JOIN video_locale vl
-          ON vl.video_id = v.id
-          AND vl.locale = ${locale}
-          AND vl.status = 'published'
-          AND vl.deleted_at IS NULL
-        WHERE vtc.embedding IS NOT NULL
-          ${transcriptProvenanceFilter}
-          AND vtc.language = ${locale}
-        ORDER BY
-          vt.video_id,
-          vtc.embedding <=> ${queryEmbedding}::vector,
-          vtc.start_seconds ASC NULLS LAST,
-          vtc.id ASC
-      ) best_transcript_per_video
-      ORDER BY source_score DESC, start_seconds ASC NULLS LAST, evidence_id ASC
-      LIMIT ${candidateLimit}
-    ),
-    requested_language AS MATERIALIZED (
-      SELECT id
-      FROM language
-      WHERE bcp47 = ${locale}
-    )
-    SELECT
-      ts.video_id                      AS video_id,
-      ts.video_core_id                 AS video_core_id,
-      ts.video_slug                    AS video_slug,
-      ts.video_title                   AS video_title,
-      COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
-      ts.evidence_id                   AS evidence_id,
-      ts.evidence_source               AS evidence_source,
-      ts.scene_description             AS scene_description,
-      ts.start_seconds                 AS start_seconds,
-      dub_mux.playback_id              AS playback_id,
-      ts.source_score                  AS source_score,
-      vtc_final.embedding::text        AS embedding_text
-    FROM transcript_source ts
-    LEFT JOIN video_transcript_chunk vtc_final
-      ON vtc_final.id = ts.evidence_id
-    LEFT JOIN LATERAL (
-      SELECT mv.playback_id
-      FROM video_dub vd
-      LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
-      WHERE vd.video_edition_id = ts.video_edition_id
-        AND vd.deleted_at IS NULL
-        AND vd.language_id IN (SELECT id FROM requested_language)
-      ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
-      LIMIT 1
-    ) dub_mux ON true
-    LEFT JOIN LATERAL (
-      SELECT vi2.mobile_cinematic_high, vi2.url
-      FROM video_image vi2
-      WHERE vi2.video_id = ts.video_id
-        AND vi2.deleted_at IS NULL
-      ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
-      LIMIT 1
-    ) vi ON true
-  `
+  const evidenceRows = await recordSearchDbTiming(
+    timing,
+    "semantic-video.query",
+    () => prisma.$queryRaw<VideoSemanticEvidenceRow[]>`
+      WITH transcript_source AS (
+        SELECT * FROM (
+          SELECT DISTINCT ON (vt.video_id)
+            vt.video_id                       AS video_id,
+            v.core_id                         AS video_core_id,
+            v.slug                            AS video_slug,
+            vl.title                          AS video_title,
+            vt.video_edition_id               AS video_edition_id,
+            vtc.id                            AS evidence_id,
+            'transcript'                      AS evidence_source,
+            COALESCE(
+              NULLIF(vtc.content_summary, ''),
+              NULLIF(vtc.raw_source_text, ''),
+              vtc.text
+            )                                 AS scene_description,
+            vtc.start_seconds                 AS start_seconds,
+            1 - (vtc.embedding <=> ${queryEmbedding}::vector) AS source_score
+          FROM video_transcript_chunk vtc
+          JOIN video_transcript vt ON vt.id = vtc.transcript_id
+            AND vt.language = ${locale}
+          JOIN video v ON v.id = vt.video_id
+            AND v.deleted_at IS NULL
+          JOIN video_locale vl
+            ON vl.video_id = v.id
+            AND vl.locale = ${locale}
+            AND vl.status = 'published'
+            AND vl.deleted_at IS NULL
+          WHERE vtc.embedding IS NOT NULL
+            ${transcriptProvenanceFilter}
+            AND vtc.language = ${locale}
+          ORDER BY
+            vt.video_id,
+            vtc.embedding <=> ${queryEmbedding}::vector,
+            vtc.start_seconds ASC NULLS LAST,
+            vtc.id ASC
+        ) best_transcript_per_video
+        ORDER BY source_score DESC, start_seconds ASC NULLS LAST, evidence_id ASC
+        LIMIT ${candidateLimit}
+      ),
+      requested_language AS MATERIALIZED (
+        SELECT id
+        FROM language
+        WHERE bcp47 = ${locale}
+      )
+      SELECT
+        ts.video_id                      AS video_id,
+        ts.video_core_id                 AS video_core_id,
+        ts.video_slug                    AS video_slug,
+        ts.video_title                   AS video_title,
+        COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
+        ts.evidence_id                   AS evidence_id,
+        ts.evidence_source               AS evidence_source,
+        ts.scene_description             AS scene_description,
+        ts.start_seconds                 AS start_seconds,
+        dub_mux.playback_id              AS playback_id,
+        ts.source_score                  AS source_score,
+        vtc_final.embedding::text        AS embedding_text
+      FROM transcript_source ts
+      LEFT JOIN video_transcript_chunk vtc_final
+        ON vtc_final.id = ts.evidence_id
+      LEFT JOIN LATERAL (
+        SELECT mv.playback_id
+        FROM video_dub vd
+        LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+        WHERE vd.video_edition_id = ts.video_edition_id
+          AND vd.deleted_at IS NULL
+          AND vd.language_id IN (SELECT id FROM requested_language)
+        ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
+        LIMIT 1
+      ) dub_mux ON true
+      LEFT JOIN LATERAL (
+        SELECT vi2.mobile_cinematic_high, vi2.url
+        FROM video_image vi2
+        WHERE vi2.video_id = ts.video_id
+          AND vi2.deleted_at IS NULL
+        ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
+        LIMIT 1
+      ) vi ON true
+    `,
+  )
 
   return mixVideoSemanticEvidenceRows(evidenceRows)
     .slice(0, limit)
@@ -434,6 +443,7 @@ export async function searchVideoSemantic(
 export async function searchVideoKeyword(
   prisma: PrismaClient,
   params: KeywordSearchParams,
+  timing?: SearchTimingRecorder,
 ): Promise<VideoKeywordResult[]> {
   const trimmed = params.query.trim()
   if (trimmed.length === 0) return []
@@ -441,58 +451,62 @@ export async function searchVideoKeyword(
   const { locale, limit } = params
   const tsvector = Prisma.raw(VIDEO_LOCALE_TSVECTOR_QUERY_EXPR)
 
-  const rows = await prisma.$queryRaw<VideoKeywordRow[]>`
-    SELECT * FROM (
-      SELECT DISTINCT ON (v.id)
-        v.id           AS video_id,
-        v.core_id      AS video_core_id,
-        v.slug         AS video_slug,
-        vl.title       AS video_title,
-        COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
-        vl.description AS description,
-        dub_mux.playback_id AS playback_id,
-        ts_rank(
-          ${tsvector},
-          plainto_tsquery('simple', ${trimmed})
-        ) AS rank
-      FROM video_locale vl
-      JOIN video v ON v.id = vl.video_id
-        AND v.deleted_at IS NULL
-      LEFT JOIN LATERAL (
-        SELECT vi2.mobile_cinematic_high, vi2.url
-        FROM video_image vi2
-        WHERE vi2.video_id = v.id
-          AND vi2.deleted_at IS NULL
-        ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
-        LIMIT 1
-      ) vi ON true
-      LEFT JOIN LATERAL (
-        -- Only published dubs reach the public search response. An
-        -- unpublished dub's playback_id is still a public Mux ID
-        -- (HLS URL component, not a secret), but consumers expect
-        -- search results to point at content they can actually play.
-        -- Returning a draft dub's playback_id surfaces unfinished
-        -- editorial work on the watch page.
-        SELECT mv.playback_id
-        FROM video_dub vd
-        JOIN language lg ON lg.id = vd.language_id
-          AND lg.bcp47 = ${locale}
-        LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
-        WHERE vd.video_id = v.id
-          AND vd.published = true
-          AND vd.deleted_at IS NULL
-        ORDER BY vd.updated_at DESC
-        LIMIT 1
-      ) dub_mux ON true
-      WHERE ${tsvector} @@ plainto_tsquery('simple', ${trimmed})
-        AND vl.locale = ${locale}
-        AND vl.status = 'published'
-        AND vl.deleted_at IS NULL
-      ORDER BY v.id, rank DESC
-    ) sub
-    ORDER BY sub.rank DESC
-    LIMIT ${limit}
-  `
+  const rows = await recordSearchDbTiming(
+    timing,
+    "keyword-video.query",
+    () => prisma.$queryRaw<VideoKeywordRow[]>`
+      SELECT * FROM (
+        SELECT DISTINCT ON (v.id)
+          v.id           AS video_id,
+          v.core_id      AS video_core_id,
+          v.slug         AS video_slug,
+          vl.title       AS video_title,
+          COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
+          vl.description AS description,
+          dub_mux.playback_id AS playback_id,
+          ts_rank(
+            ${tsvector},
+            plainto_tsquery('simple', ${trimmed})
+          ) AS rank
+        FROM video_locale vl
+        JOIN video v ON v.id = vl.video_id
+          AND v.deleted_at IS NULL
+        LEFT JOIN LATERAL (
+          SELECT vi2.mobile_cinematic_high, vi2.url
+          FROM video_image vi2
+          WHERE vi2.video_id = v.id
+            AND vi2.deleted_at IS NULL
+          ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
+          LIMIT 1
+        ) vi ON true
+        LEFT JOIN LATERAL (
+          -- Only published dubs reach the public search response. An
+          -- unpublished dub's playback_id is still a public Mux ID
+          -- (HLS URL component, not a secret), but consumers expect
+          -- search results to point at content they can actually play.
+          -- Returning a draft dub's playback_id surfaces unfinished
+          -- editorial work on the watch page.
+          SELECT mv.playback_id
+          FROM video_dub vd
+          JOIN language lg ON lg.id = vd.language_id
+            AND lg.bcp47 = ${locale}
+          LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+          WHERE vd.video_id = v.id
+            AND vd.published = true
+            AND vd.deleted_at IS NULL
+          ORDER BY vd.updated_at DESC
+          LIMIT 1
+        ) dub_mux ON true
+        WHERE ${tsvector} @@ plainto_tsquery('simple', ${trimmed})
+          AND vl.locale = ${locale}
+          AND vl.status = 'published'
+          AND vl.deleted_at IS NULL
+        ORDER BY v.id, rank DESC
+      ) sub
+      ORDER BY sub.rank DESC
+      LIMIT ${limit}
+    `,
+  )
 
   return rows.map((row) => ({
     resultType: "video" as const,
@@ -525,30 +539,35 @@ export async function searchVideoKeyword(
 export async function searchExperienceSemantic(
   prisma: PrismaClient,
   params: SemanticSearchParams,
+  timing?: SearchTimingRecorder,
 ): Promise<ExperienceSemanticResult[]> {
   const { queryEmbedding, locale, limit } = params
 
-  const rows = await prisma.$queryRaw<ExperienceSemanticRow[]>`
-    SELECT
-      el.id               AS experience_locale_id,
-      el.slug             AS slug,
-      el.title            AS title,
-      el.meta_description AS meta_description,
-      1 - (el.embedding <=> ${queryEmbedding}::vector) AS similarity
-    FROM experience_locale el
-    JOIN experience e ON e.id = el.experience_id
-      AND e.archived_at IS NULL
-    WHERE el.embedding IS NOT NULL
-      AND el.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
-      AND el.embedding_model = ${QWEN_CONTENT_EMBEDDING_MODEL}
-      AND el.embedding_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
-      AND el.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
-      AND el.embedding_transform_version IS NULL
-      AND el.locale = ${locale}
-      AND el.status = 'published'
-    ORDER BY el.embedding <=> ${queryEmbedding}::vector
-    LIMIT ${limit}
-  `
+  const rows = await recordSearchDbTiming(
+    timing,
+    "semantic-experience.query",
+    () => prisma.$queryRaw<ExperienceSemanticRow[]>`
+      SELECT
+        el.id               AS experience_locale_id,
+        el.slug             AS slug,
+        el.title            AS title,
+        el.meta_description AS meta_description,
+        1 - (el.embedding <=> ${queryEmbedding}::vector) AS similarity
+      FROM experience_locale el
+      JOIN experience e ON e.id = el.experience_id
+        AND e.archived_at IS NULL
+      WHERE el.embedding IS NOT NULL
+        AND el.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+        AND el.embedding_model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+        AND el.embedding_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        AND el.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        AND el.embedding_transform_version IS NULL
+        AND el.locale = ${locale}
+        AND el.status = 'published'
+      ORDER BY el.embedding <=> ${queryEmbedding}::vector
+      LIMIT ${limit}
+    `,
+  )
 
   return rows.map((row) => ({
     resultType: "experience" as const,
@@ -572,6 +591,7 @@ export async function searchExperienceSemantic(
 export async function searchExperienceKeyword(
   prisma: PrismaClient,
   params: KeywordSearchParams,
+  timing?: SearchTimingRecorder,
 ): Promise<ExperienceKeywordResult[]> {
   const trimmed = params.query.trim()
   if (trimmed.length === 0) return []
@@ -579,25 +599,29 @@ export async function searchExperienceKeyword(
   const { locale, limit } = params
   const tsvector = Prisma.raw(EXPERIENCE_LOCALE_TSVECTOR_QUERY_EXPR)
 
-  const rows = await prisma.$queryRaw<ExperienceKeywordRow[]>`
-    SELECT
-      el.id               AS experience_locale_id,
-      el.slug             AS slug,
-      el.title            AS title,
-      el.meta_description AS meta_description,
-      ts_rank(
-        ${tsvector},
-        plainto_tsquery('simple', ${trimmed})
-      ) AS rank
-    FROM experience_locale el
-    JOIN experience e ON e.id = el.experience_id
-      AND e.archived_at IS NULL
-    WHERE ${tsvector} @@ plainto_tsquery('simple', ${trimmed})
-      AND el.locale = ${locale}
-      AND el.status = 'published'
-    ORDER BY rank DESC
-    LIMIT ${limit}
-  `
+  const rows = await recordSearchDbTiming(
+    timing,
+    "keyword-experience.query",
+    () => prisma.$queryRaw<ExperienceKeywordRow[]>`
+      SELECT
+        el.id               AS experience_locale_id,
+        el.slug             AS slug,
+        el.title            AS title,
+        el.meta_description AS meta_description,
+        ts_rank(
+          ${tsvector},
+          plainto_tsquery('simple', ${trimmed})
+        ) AS rank
+      FROM experience_locale el
+      JOIN experience e ON e.id = el.experience_id
+        AND e.archived_at IS NULL
+      WHERE ${tsvector} @@ plainto_tsquery('simple', ${trimmed})
+        AND el.locale = ${locale}
+        AND el.status = 'published'
+      ORDER BY rank DESC
+      LIMIT ${limit}
+    `,
+  )
 
   return rows.map((row) => ({
     resultType: "experience" as const,

--- a/apps/admin/src/services/hybrid-search-timing.ts
+++ b/apps/admin/src/services/hybrid-search-timing.ts
@@ -1,0 +1,177 @@
+import { performance } from "node:perf_hooks"
+
+export type SearchTimingPipelineMode =
+  | "hybrid"
+  | "keyword-first"
+  | "semantic-only"
+
+export type SearchTimingStatus = "fulfilled" | "rejected" | "skipped"
+
+export type SearchRetrieverTiming = {
+  label: string
+  status: SearchTimingStatus
+  elapsedMs: number
+  resultCount: number
+}
+
+export type SearchDbTiming = {
+  label: string
+  status: Exclude<SearchTimingStatus, "skipped">
+  elapsedMs: number
+  resultCount: number
+}
+
+export type SearchTimingSummary = {
+  pipelineMode: SearchTimingPipelineMode
+  totalMs: number
+  embeddingMs: number
+  retrievalsMs: number
+  fusionMs: number
+  dilutionCapMs: number
+  dedupeMs: number
+  mappingMs: number
+  hydrationMs: number
+  retrievers: SearchRetrieverTiming[]
+  db: SearchDbTiming[]
+}
+
+export type SearchTimingRouteSource = "rest" | "graphql" | "internal"
+
+export class SearchTimingRecorder {
+  private readonly dbTimings: SearchDbTiming[] = []
+
+  recordDb(timing: SearchDbTiming): void {
+    this.dbTimings.push(timing)
+  }
+
+  snapshotDbTimings(): SearchDbTiming[] {
+    return this.dbTimings.map((timing) => ({ ...timing }))
+  }
+}
+
+export function nowMs(): number {
+  return performance.now()
+}
+
+export function boundedMs(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0
+  return Math.round(value * 10) / 10
+}
+
+export function elapsedMs(startedAt: number): number {
+  return boundedMs(nowMs() - startedAt)
+}
+
+function defaultResultCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0
+}
+
+export async function recordSearchDbTiming<T>(
+  recorder: SearchTimingRecorder | undefined,
+  label: string,
+  run: () => Promise<T>,
+  resultCount: (value: T) => number = defaultResultCount,
+): Promise<T> {
+  if (recorder == null) return run()
+
+  const startedAt = nowMs()
+  try {
+    const value = await run()
+    recorder.recordDb({
+      label,
+      status: "fulfilled",
+      elapsedMs: elapsedMs(startedAt),
+      resultCount: Math.max(0, Math.round(resultCount(value))),
+    })
+    return value
+  } catch (error) {
+    recorder.recordDb({
+      label,
+      status: "rejected",
+      elapsedMs: elapsedMs(startedAt),
+      resultCount: 0,
+    })
+    throw error
+  }
+}
+
+export function searchTimingLogValue(raw: unknown): string {
+  const normalized = String(raw ?? "none")
+    .replace(/[\r\n\t\s=]/g, "_")
+    .slice(0, 64)
+  return normalized.length > 0 ? normalized : "none"
+}
+
+function searchTimingLogKey(raw: string): string {
+  const key = searchTimingLogValue(raw)
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase()
+  return key.length > 0 ? key : "unknown"
+}
+
+export function formatSearchTimingLogFields(
+  timings: SearchTimingSummary,
+  extra: { traceWriteMs?: number } = {},
+): string {
+  const dbTotalMs = boundedMs(
+    timings.db.reduce((total, timing) => total + timing.elapsedMs, 0),
+  )
+  const fields = [
+    `total_ms=${timings.totalMs}`,
+    `embedding_ms=${timings.embeddingMs}`,
+    `db_retrievals_ms=${timings.retrievalsMs}`,
+    `db_total_ms=${dbTotalMs}`,
+    `fusion_ms=${timings.fusionMs}`,
+    `dilution_cap_ms=${timings.dilutionCapMs}`,
+    `dedupe_ms=${timings.dedupeMs}`,
+    `mapping_ms=${timings.mappingMs}`,
+    `hydration_ms=${timings.hydrationMs}`,
+  ]
+
+  if (extra.traceWriteMs != null) {
+    fields.push(`trace_write_ms=${boundedMs(extra.traceWriteMs)}`)
+  }
+
+  for (const retriever of timings.retrievers) {
+    const key = searchTimingLogKey(retriever.label)
+    fields.push(`retriever_${key}_ms=${retriever.elapsedMs}`)
+    fields.push(`retriever_${key}_status=${retriever.status}`)
+    fields.push(`retriever_${key}_count=${retriever.resultCount}`)
+  }
+
+  for (const dbTiming of timings.db) {
+    const key = searchTimingLogKey(dbTiming.label)
+    fields.push(`db_${key}_ms=${dbTiming.elapsedMs}`)
+    fields.push(`db_${key}_status=${dbTiming.status}`)
+    fields.push(`db_${key}_count=${dbTiming.resultCount}`)
+  }
+
+  return fields.join(" ")
+}
+
+export function formatSearchTimingLogLine(input: {
+  route: SearchTimingRouteSource
+  locale: string
+  requestedMode?: string | null
+  searchMode: string
+  outcome: string
+  resultCount: number
+  timings: SearchTimingSummary
+  traceWriteMs?: number
+}): string {
+  return [
+    "[search]",
+    "event=search_timing",
+    `route=${input.route}`,
+    `locale=${searchTimingLogValue(input.locale)}`,
+    `requested_mode=${searchTimingLogValue(input.requestedMode ?? "none")}`,
+    `pipeline_mode=${searchTimingLogValue(input.timings.pipelineMode)}`,
+    `search_mode=${searchTimingLogValue(input.searchMode)}`,
+    `outcome=${searchTimingLogValue(input.outcome)}`,
+    `result_count=${Math.max(0, Math.round(input.resultCount))}`,
+    formatSearchTimingLogFields(input.timings, {
+      traceWriteMs: input.traceWriteMs,
+    }),
+  ].join(" ")
+}

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -93,21 +93,33 @@ describe("HybridSearchService keyword-first branch", () => {
       mode: "keyword-first",
     })
 
-    expect(searchByKeywordWeighted).toHaveBeenCalledWith(mockPrisma, {
-      query: "the bible project",
-      locale: "en",
-      limit: 60,
-    })
-    expect(searchByTrigram).toHaveBeenCalledWith(mockPrisma, {
-      query: "the bible project",
-      locale: "en",
-      limit: 60,
-    })
-    expect(searchByExactTitle).toHaveBeenCalledWith(mockPrisma, {
-      query: "the bible project",
-      locale: "en",
-      limit: 60,
-    })
+    expect(searchByKeywordWeighted).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        query: "the bible project",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
+    expect(searchByTrigram).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        query: "the bible project",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
+    expect(searchByExactTitle).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        query: "the bible project",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
   })
 
   it("does NOT dispatch the legacy R4 video keyword retriever in keyword-first mode", async () => {
@@ -259,16 +271,24 @@ describe("HybridSearchService keyword-first branch", () => {
       allowInternalEvalModes: true,
     })
 
-    expect(searchVideoSemantic).toHaveBeenCalledWith(mockPrisma, {
-      queryEmbedding: "[0.1,0.2,0.3]",
-      locale: "en",
-      limit: 60,
-    })
-    expect(searchExperienceSemantic).toHaveBeenCalledWith(mockPrisma, {
-      queryEmbedding: "[0.1,0.2,0.3]",
-      locale: "en",
-      limit: 60,
-    })
+    expect(searchVideoSemantic).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        queryEmbedding: "[0.1,0.2,0.3]",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
+    expect(searchExperienceSemantic).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        queryEmbedding: "[0.1,0.2,0.3]",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
     expect(searchVideoKeyword).not.toHaveBeenCalled()
     expect(searchExperienceKeyword).not.toHaveBeenCalled()
     expect(searchByKeywordWeighted).not.toHaveBeenCalled()

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./hybrid-search-retrievers"
 import { __resetSearchHealthForTest, getStats } from "./hybrid-search-health"
 import {
+  formatSearchTimingLogLine,
   HybridSearchService,
   normalizeMode,
   sanitizeForLog,
@@ -106,16 +107,24 @@ describe("HybridSearchService", () => {
     })
 
     // All 4 retrievers were invoked with overfetch = DEFAULT_LIMIT * 3 = 60.
-    expect(searchVideoSemantic).toHaveBeenCalledWith(mockPrisma, {
-      queryEmbedding: "[0.1,0.2,0.3]",
-      locale: "en",
-      limit: 60,
-    })
-    expect(searchVideoKeyword).toHaveBeenCalledWith(mockPrisma, {
-      query: "forgiveness",
-      locale: "en",
-      limit: 60,
-    })
+    expect(searchVideoSemantic).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        queryEmbedding: "[0.1,0.2,0.3]",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
+    expect(searchVideoKeyword).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        query: "forgiveness",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
     expect(searchExperienceSemantic).toHaveBeenCalled()
     expect(searchExperienceKeyword).toHaveBeenCalled()
 
@@ -219,6 +228,43 @@ describe("HybridSearchService", () => {
       failedRetrievers: [],
       contributingRetrievers: ["semantic-video"],
     })
+    expect(traced.timings).toMatchObject({
+      pipelineMode: "hybrid",
+      totalMs: expect.any(Number),
+      embeddingMs: expect.any(Number),
+      retrievalsMs: expect.any(Number),
+      fusionMs: expect.any(Number),
+      dilutionCapMs: 0,
+      dedupeMs: expect.any(Number),
+      mappingMs: expect.any(Number),
+      hydrationMs: expect.any(Number),
+    })
+    expect(traced.timings.retrievers.map((r) => r.label)).toEqual([
+      "semantic-video",
+      "keyword-video",
+      "semantic-experience",
+      "keyword-experience",
+    ])
+    expect(traced.timings.retrievers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "semantic-video",
+          status: "fulfilled",
+          resultCount: 1,
+          elapsedMs: expect.any(Number),
+        }),
+      ]),
+    )
+    expect(traced.timings.db).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "hydration.video.findMany",
+          status: "fulfilled",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+      ]),
+    )
     expect(await service.search({ query: "jesus", locale: "en" })).toEqual(
       expect.objectContaining({
         query: "jesus",
@@ -245,6 +291,22 @@ describe("HybridSearchService", () => {
       outcome: "degraded",
       traceClass: "query_embedding_failure",
     })
+    expect(traced.timings.retrievers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "semantic-video",
+          status: "skipped",
+          resultCount: 0,
+          elapsedMs: 0,
+        }),
+        expect.objectContaining({
+          label: "semantic-experience",
+          status: "skipped",
+          resultCount: 0,
+          elapsedMs: 0,
+        }),
+      ]),
+    )
   })
 
   it("classifies partial retriever failure separately from zero results", async () => {
@@ -282,6 +344,66 @@ describe("HybridSearchService", () => {
     expect(traced.trace.traceClass).toBe("retrieval_failure")
     expect(traced.trace.failedRetrievers).toEqual(["keyword-video"])
     expect(traced.trace.contributingRetrievers).toEqual(["semantic-video"])
+    expect(traced.timings.retrievers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "keyword-video",
+          status: "rejected",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+      ]),
+    )
+  })
+
+  it("formats structured timing logs without query text", () => {
+    const line = formatSearchTimingLogLine({
+      route: "graphql",
+      locale: "en\nx=1",
+      requestedMode: "keyword first",
+      searchMode: "hybrid",
+      outcome: "success",
+      resultCount: 2,
+      traceWriteMs: 1.2,
+      timings: {
+        pipelineMode: "keyword-first",
+        totalMs: 123.4,
+        embeddingMs: 15.2,
+        retrievalsMs: 100,
+        fusionMs: 1,
+        dilutionCapMs: 0,
+        dedupeMs: 0.4,
+        mappingMs: 0.3,
+        hydrationMs: 6,
+        retrievers: [
+          {
+            label: "semantic-video",
+            status: "fulfilled",
+            elapsedMs: 99,
+            resultCount: 60,
+          },
+        ],
+        db: [
+          {
+            label: "semantic-video.query",
+            status: "fulfilled",
+            elapsedMs: 98,
+            resultCount: 60,
+          },
+        ],
+      },
+    })
+
+    expect(line).toContain("event=search_timing")
+    expect(line).toContain("route=graphql")
+    expect(line).toContain("locale=en_x_1")
+    expect(line).toContain("requested_mode=keyword_first")
+    expect(line).toContain("pipeline_mode=keyword-first")
+    expect(line).toContain("embedding_ms=15.2")
+    expect(line).toContain("retriever_semantic_video_ms=99")
+    expect(line).toContain("db_semantic_video_query_ms=98")
+    expect(line).toContain("trace_write_ms=1.2")
+    expect(line).not.toContain("Jesus")
   })
 
   describe("query embedding", () => {
@@ -368,6 +490,7 @@ describe("HybridSearchService", () => {
     expect(searchVideoSemantic).toHaveBeenCalledWith(
       mockPrisma,
       expect.objectContaining({ limit: 150 }), // 50 * 3
+      expect.any(Object),
     )
   })
 
@@ -383,6 +506,7 @@ describe("HybridSearchService", () => {
     expect(searchVideoSemantic).toHaveBeenCalledWith(
       mockPrisma,
       expect.objectContaining({ limit: 3 }), // 1 * 3
+      expect.any(Object),
     )
   })
 

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -38,6 +38,26 @@ import {
   searchByExactTitle,
   tokenizeForExactTitle,
 } from "./hybrid-search-keyword-first-retrievers"
+import {
+  elapsedMs,
+  nowMs,
+  recordSearchDbTiming,
+  SearchTimingRecorder,
+  type SearchRetrieverTiming,
+  type SearchTimingSummary,
+} from "./hybrid-search-timing"
+
+export {
+  formatSearchTimingLogLine,
+  formatSearchTimingLogFields,
+  searchTimingLogValue,
+} from "./hybrid-search-timing"
+export type {
+  SearchDbTiming,
+  SearchRetrieverTiming,
+  SearchTimingRouteSource,
+  SearchTimingSummary,
+} from "./hybrid-search-timing"
 
 export const RRF_K = 60
 export const DEFAULT_LIMIT = 20
@@ -259,6 +279,7 @@ export type SearchExecutionSummary = {
 export type SearchWithTraceResult = {
   response: SearchResponse
   trace: SearchExecutionSummary
+  timings: SearchTimingSummary
 }
 
 /**
@@ -381,6 +402,7 @@ async function hydrateCardDisplayFields(
   results: SearchResult[],
   locale: string,
   logger?: { error: (msg: string) => void },
+  timing?: SearchTimingRecorder,
 ): Promise<SearchResult[]> {
   const videoIds = results.filter((r) => r.type === "video").map((r) => r.id)
   if (videoIds.length === 0) return results
@@ -391,88 +413,92 @@ async function hydrateCardDisplayFields(
   // sparse card metadata rather than HTTP 503 for the whole request.
   let rows
   try {
-    rows = await prisma.video.findMany({
-      where: { id: { in: videoIds }, deletedAt: null },
-      select: {
-        id: true,
-        label: true,
-        primaryLanguageId: true,
-        locales: {
-          where: {
-            locale,
-            status: "PUBLISHED",
-            deletedAt: null,
+    rows = await recordSearchDbTiming(timing, "hydration.video.findMany", () =>
+      prisma.video.findMany({
+        where: { id: { in: videoIds }, deletedAt: null },
+        select: {
+          id: true,
+          label: true,
+          primaryLanguageId: true,
+          locales: {
+            where: {
+              locale,
+              status: "PUBLISHED",
+              deletedAt: null,
+            },
+            take: 1,
+            select: {
+              description: true,
+              snippet: true,
+            },
           },
-          take: 1,
-          select: {
-            description: true,
-            snippet: true,
+          images: {
+            where: { deletedAt: null },
+            orderBy: [{ createdAt: "asc" }],
+            take: HYDRATION_IMAGES_PER_VIDEO,
+            select: {
+              mobileCinematicHigh: true,
+              mobileCinematicLow: true,
+              videoStill: true,
+              thumbnail: true,
+              url: true,
+            },
           },
-        },
-        images: {
-          where: { deletedAt: null },
-          orderBy: [{ createdAt: "asc" }],
-          take: HYDRATION_IMAGES_PER_VIDEO,
-          select: {
-            mobileCinematicHigh: true,
-            mobileCinematicLow: true,
-            videoStill: true,
-            thumbnail: true,
-            url: true,
+          dubs: {
+            // `duration: { gt: 0 }` excludes sync-glitch rows (Core
+            // occasionally returns a published dub with duration=0; the
+            // pill picker then renders nothing for those rows, leaving an
+            // unexplained gap on the card).
+            where: {
+              published: true,
+              hls: { not: null },
+              deletedAt: null,
+              duration: { gt: 0 },
+            },
+            // `take` bounds the per-video dubs scan. Order by duration
+            // descending so the longest published in-locale dub anchors
+            // the top of the page; the post-query `find` below prefers the
+            // primary-language dub among these top-N rows, falling back to
+            // `dubs[0]` (longest) when the primary dub isn't in the top-N
+            // by duration. On heavily-dubbed videos (200+ dubs) the primary
+            // may rank below position N — accept the fallback rather than
+            // widen `take` (cost is bounded at 50 × N rows per request).
+            orderBy: [{ duration: "desc" }],
+            take: HYDRATION_DUBS_PER_VIDEO,
+            select: {
+              languageId: true,
+              duration: true,
+              muxVideo: { select: { playbackId: true } },
+            },
           },
-        },
-        dubs: {
-          // `duration: { gt: 0 }` excludes sync-glitch rows (Core
-          // occasionally returns a published dub with duration=0; the
-          // pill picker then renders nothing for those rows, leaving an
-          // unexplained gap on the card).
-          where: {
-            published: true,
-            hls: { not: null },
-            deletedAt: null,
-            duration: { gt: 0 },
-          },
-          // `take` bounds the per-video dubs scan. Order by duration
-          // descending so the longest published in-locale dub anchors
-          // the top of the page; the post-query `find` below prefers the
-          // primary-language dub among these top-N rows, falling back to
-          // `dubs[0]` (longest) when the primary dub isn't in the top-N
-          // by duration. On heavily-dubbed videos (200+ dubs) the primary
-          // may rank below position N — accept the fallback rather than
-          // widen `take` (cost is bounded at 50 × N rows per request).
-          orderBy: [{ duration: "desc" }],
-          take: HYDRATION_DUBS_PER_VIDEO,
-          select: {
-            languageId: true,
-            duration: true,
-            muxVideo: { select: { playbackId: true } },
-          },
-        },
-        // `_count.children` mirrors the consumer-facing ABAC at
-        // videoChildrenFilter (apps/admin/src/graphql/types/video.ts):
-        // only count children that have a PUBLISHED locale and aren't
-        // soft-deleted. Without this filter the search-card "{n} episodes"
-        // pill drifts from what the watch page actually renders. Self-
-        // referential rows (parent_id = child_id) — a data-quality issue
-        // seen for `1-jesus-our-loving-pursuer` — can still inflate the
-        // count; web's normalizeAdminVideo filters those client-side, but
-        // the count is computed before that pass. Acceptable today; if
-        // self-ref inflation becomes a UX issue, switch to a raw SQL
-        // count that adds `WHERE child_id <> parent_id`.
-        _count: {
-          select: {
-            children: {
-              where: {
-                child: {
-                  deletedAt: null,
-                  locales: { some: { status: "PUBLISHED", deletedAt: null } },
+          // `_count.children` mirrors the consumer-facing ABAC at
+          // videoChildrenFilter (apps/admin/src/graphql/types/video.ts):
+          // only count children that have a PUBLISHED locale and aren't
+          // soft-deleted. Without this filter the search-card "{n} episodes"
+          // pill drifts from what the watch page actually renders. Self-
+          // referential rows (parent_id = child_id) — a data-quality issue
+          // seen for `1-jesus-our-loving-pursuer` — can still inflate the
+          // count; web's normalizeAdminVideo filters those client-side, but
+          // the count is computed before that pass. Acceptable today; if
+          // self-ref inflation becomes a UX issue, switch to a raw SQL
+          // count that adds `WHERE child_id <> parent_id`.
+          _count: {
+            select: {
+              children: {
+                where: {
+                  child: {
+                    deletedAt: null,
+                    locales: {
+                      some: { status: "PUBLISHED", deletedAt: null },
+                    },
+                  },
                 },
               },
             },
           },
         },
-      },
-    })
+      }),
+    )
   } catch (err) {
     const log = logger ?? console
     log.error(
@@ -616,6 +642,8 @@ export class HybridSearchService {
   }
 
   async searchWithTrace(params: SearchParams): Promise<SearchWithTraceResult> {
+    const totalStartedAt = nowMs()
+    const timing = new SearchTimingRecorder()
     const { query, locale } = params
 
     // Decode the opt-in pipeline mode. Unknown values warn-and-fall-back
@@ -649,6 +677,8 @@ export class HybridSearchService {
     // process-local counters the health probe exposes.
     let queryEmbeddingText: string | null = null
     let embeddingFailed = false
+    let embeddingMs = 0
+    const embeddingStartedAt = nowMs()
     recordAttempt()
     try {
       const vector = await this.embedder(query)
@@ -662,6 +692,8 @@ export class HybridSearchService {
       this.logger.error(
         `[search] event=query_embedding_failure error_class=${errorClass} message=${message}`,
       )
+    } finally {
+      embeddingMs = elapsedMs(embeddingStartedAt)
     }
 
     // Step 2: Run retrieval in parallel. allSettled keeps partial
@@ -673,6 +705,45 @@ export class HybridSearchService {
       promise: Promise<RankedItem[]>
     }
     const retrievals: Retrieval[] = []
+    const retrieverTimings = new Map<string, SearchRetrieverTiming>()
+    const retrievalsStartedAt = nowMs()
+    const skippedRetrieval = (label: string): Promise<RankedItem[]> => {
+      retrieverTimings.set(label, {
+        label,
+        status: "skipped",
+        elapsedMs: 0,
+        resultCount: 0,
+      })
+      return Promise.resolve([])
+    }
+    const timedRetrieval = (
+      label: string,
+      run: () => Promise<RankedItem[]>,
+    ): Promise<RankedItem[]> => {
+      const startedAt = nowMs()
+      return Promise.resolve()
+        .then(run)
+        .then(
+          (value) => {
+            retrieverTimings.set(label, {
+              label,
+              status: "fulfilled",
+              elapsedMs: elapsedMs(startedAt),
+              resultCount: value.length,
+            })
+            return value
+          },
+          (error) => {
+            retrieverTimings.set(label, {
+              label,
+              status: "rejected",
+              elapsedMs: elapsedMs(startedAt),
+              resultCount: 0,
+            })
+            throw error
+          },
+        )
+    }
 
     if (wantsVideos) {
       // Semantic-video is shared by every embedding-backed pipeline.
@@ -680,12 +751,20 @@ export class HybridSearchService {
         label: "semantic-video",
         promise:
           queryEmbeddingText != null
-            ? (searchVideoSemantic(this.prisma, {
-                queryEmbedding: queryEmbeddingText,
-                locale,
-                limit: overfetchLimit,
-              }) as Promise<RankedItem[]>)
-            : Promise.resolve([]),
+            ? timedRetrieval(
+                "semantic-video",
+                () =>
+                  searchVideoSemantic(
+                    this.prisma,
+                    {
+                      queryEmbedding: queryEmbeddingText,
+                      locale,
+                      limit: overfetchLimit,
+                    },
+                    timing,
+                  ) as Promise<RankedItem[]>,
+              )
+            : skippedRetrieval("semantic-video"),
       })
 
       if (pipelineMode === "keyword-first") {
@@ -696,38 +775,70 @@ export class HybridSearchService {
         // strictly weaker than the weighted one for this workload.
         retrievals.push({
           label: "keyword-weighted-video",
-          promise: searchByKeywordWeighted(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "keyword-weighted-video",
+            () =>
+              searchByKeywordWeighted(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
         })
         retrievals.push({
           label: "trigram-video",
-          promise: searchByTrigram(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "trigram-video",
+            () =>
+              searchByTrigram(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
         })
         retrievals.push({
           label: "exact-title-video",
-          promise: searchByExactTitle(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "exact-title-video",
+            () =>
+              searchByExactTitle(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
         })
       } else if (!semanticOnly) {
         // Hybrid path — UNCHANGED from R4. Byte-identity locked in by
         // hybrid-search.regression.test.ts.
         retrievals.push({
           label: "keyword-video",
-          promise: searchVideoKeyword(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "keyword-video",
+            () =>
+              searchVideoKeyword(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
         })
       }
     }
@@ -737,26 +848,43 @@ export class HybridSearchService {
         label: "semantic-experience",
         promise:
           queryEmbeddingText != null
-            ? (searchExperienceSemantic(this.prisma, {
-                queryEmbedding: queryEmbeddingText,
-                locale,
-                limit: overfetchLimit,
-              }) as Promise<RankedItem[]>)
-            : Promise.resolve([]),
+            ? timedRetrieval(
+                "semantic-experience",
+                () =>
+                  searchExperienceSemantic(
+                    this.prisma,
+                    {
+                      queryEmbedding: queryEmbeddingText,
+                      locale,
+                      limit: overfetchLimit,
+                    },
+                    timing,
+                  ) as Promise<RankedItem[]>,
+              )
+            : skippedRetrieval("semantic-experience"),
       })
       if (!semanticOnly) {
         retrievals.push({
           label: "keyword-experience",
-          promise: searchExperienceKeyword(this.prisma, {
-            query,
-            locale,
-            limit: overfetchLimit,
-          }) as Promise<RankedItem[]>,
+          promise: timedRetrieval(
+            "keyword-experience",
+            () =>
+              searchExperienceKeyword(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
         })
       }
     }
 
     const outcomes = await Promise.allSettled(retrievals.map((r) => r.promise))
+    const retrievalsMs = elapsedMs(retrievalsStartedAt)
     const failedRetrievers: string[] = []
     const lists = outcomes.map((outcome, i) =>
       this.unwrapOutcome(outcome, retrievals[i]!.label, failedRetrievers),
@@ -794,7 +922,9 @@ export class HybridSearchService {
     // normalizes by dividing by the number of input lists, so empty
     // ones dilute scores from lists that did contribute.
     const nonEmptyLists = lists.filter((list) => list.length > 0)
+    const fusionStartedAt = nowMs()
     const fused = fuseRankedLists(nonEmptyLists, RRF_K)
+    const fusionMs = elapsedMs(fusionStartedAt)
 
     // Snapshot pre-cap fused scores so the debug payload can surface
     // both numbers (the cap mutates `result.score` in place).
@@ -809,18 +939,24 @@ export class HybridSearchService {
     // fused result whose ONLY contributing list was semantic AND whose
     // video core_id is not represented in the top-N keyword-side
     // core_ids. Hybrid mode never reaches this step.
+    let dilutionCapMs = 0
     if (pipelineMode === "keyword-first" && isDilutionCapEnabled()) {
+      const dilutionCapStartedAt = nowMs()
       applyDilutionCap(fused, labeledLists, query, debugByKey)
+      dilutionCapMs = elapsedMs(dilutionCapStartedAt)
     }
 
     // Step 4: Dedup one extra result beyond the page window so we know
     // whether more results exist (drives hasMore without a full count
     // pass).
+    const dedupeStartedAt = nowMs()
     const deduped = deduplicateResults(fused, offset + limit + 1)
 
     // Step 5: Paginate and map to API contract.
     const page = deduped.slice(offset, offset + limit)
     const hasMore = deduped.length > offset + limit
+    const dedupeMs = elapsedMs(dedupeStartedAt)
+    const mappingStartedAt = nowMs()
     const mapped = page.map((result) => {
       const base = mapToSearchResult(result)
       if (params.debug !== true) return base
@@ -829,15 +965,19 @@ export class HybridSearchService {
       if (trace == null) return base
       return { ...base, debug: trace }
     })
+    const mappingMs = elapsedMs(mappingStartedAt)
 
     // Hydrate card display fields for video results in one batched query.
     // Experience rows pass through untouched.
+    const hydrationStartedAt = nowMs()
     const results = await hydrateCardDisplayFields(
       this.prisma,
       mapped,
       locale,
       this.logger,
+      timing,
     )
+    const hydrationMs = elapsedMs(hydrationStartedAt)
 
     const searchMode = queryEmbeddingText != null ? "hybrid" : "keyword-only"
     const contributingRetrievers = labeledLists
@@ -857,6 +997,22 @@ export class HybridSearchService {
       // empty degraded response without lexical fallback.
       searchMode,
     }
+    const timings: SearchTimingSummary = {
+      pipelineMode,
+      totalMs: elapsedMs(totalStartedAt),
+      embeddingMs,
+      retrievalsMs,
+      fusionMs,
+      dilutionCapMs,
+      dedupeMs,
+      mappingMs,
+      hydrationMs,
+      retrievers: retrievals.flatMap((retrieval) => {
+        const retrieverTiming = retrieverTimings.get(retrieval.label)
+        return retrieverTiming == null ? [] : [retrieverTiming]
+      }),
+      db: timing.snapshotDbTimings(),
+    }
 
     return {
       response,
@@ -868,6 +1024,7 @@ export class HybridSearchService {
         failedRetrievers,
         contributingRetrievers,
       },
+      timings,
     }
   }
 

--- a/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
+++ b/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
@@ -19,47 +19,73 @@ tags:
 ## Problem
 
 After web opted into Admin `mode="keyword-first"`, production Watch semantic
-search sometimes sits in the loading state until the web Admin GraphQL client
-hits its 15 second timeout. Direct production probes showed the search action
-can return correct semantic results, but cold keyword-first calls can cross the
-caller budget.
+search can sit in the loading state for several seconds. Historical probes were
+framed against the default 15 second Admin GraphQL client, but the current Web
+semantic-search path uses `semanticSearchAdminClient` with a 45 second bounded
+timeout; treat this ticket as latency recovery, not only timeout avoidance.
+Direct production probes showed the search action can return correct semantic
+results, but cold keyword-first calls can still exceed an acceptable user-facing
+budget.
 
 The slow path is Admin video semantic retrieval. Production Web semantic
 canaries through the real Admin GraphQL path took roughly 4.7-7.3 seconds, and
-Railway HTTP logs showed Web `POST /watch` search-action requests near the 15
-second Admin caller budget. The current safe slice keeps Admin's existing
-best-evidence-per-video semantics, but removes expensive image/dub hydration
-and `embedding::text` projection from the unbounded source-collapse work.
+Railway HTTP logs showed Web `POST /watch` search-action requests near the
+historical 15 second Admin caller budget. The current safe slice keeps Admin's
+existing transcript best-evidence-per-video semantics, but removes expensive
+image/dub hydration and `embedding::text` projection from the unbounded
+candidate-collapse work.
 
-An HNSW-first raw nearest-neighbor window remains the likely next performance
-lever, but it must be gated: if one long video contributes many top chunks, a
-pre-dedup row window can collapse to too few distinct videos and degrade
-semantic diversity.
+An HNSW-first raw nearest-neighbor window remains a possible follow-up
+performance lever only if the safe slice and instrumentation show the semantic
+SQL still dominates. It must be gated: if one long video contributes many top
+chunks, a pre-dedup row window can collapse to too few distinct videos, preserve
+diversity while losing recall, and degrade semantic relevance.
 
 ## What To Build
 
 - [x] Move image lookup, dub playback lookup, and `embedding::text` hydration
-      after scene/transcript candidates are narrowed.
+      after transcript candidates are narrowed.
 - [x] Preserve the existing per-source best-evidence-per-video semantics for
       the default path.
 - [x] Keep the existing `semantic-video` retriever label and public search
       response shape unchanged.
 - [x] Do not solve latency by timing out retrievers and returning degraded
       results as the primary behavior.
-- [ ] Measure post-deploy Web/Admin semantic canaries and compare against the
-      2026-06-12 baseline: `the bible project` 7.0s, `jesus` 7.3s,
+- [x] Add safe timing logs for Admin search stages, retriever fan-out, raw
+      retriever SQL, card hydration SQL, and trace-write overhead without
+      changing the public search response.
+- [ ] Measure repeated cold and warm Web/Admin semantic canaries after the
+      safe-slice hydration/projection deploy and compare against the 2026-06-12
+      baseline: `the bible project` 7.0s, `jesus` 7.3s,
       `hope when life is hard` 4.7s.
-- [ ] Prototype HNSW-first source windows only with a distinct-video guarantee
-      or duplicate-heavy Mastra no-regression proof.
+- [ ] Record p50/p95/p99/max latency, timeout/error count, response
+      `searchMode`, top-N video IDs, evidence/snippet parity, and
+      image/playback null-rate deltas. Exclude degraded keyword-only responses
+      from semantic-latency success counts.
+- [ ] Close this ticket if the safe slice meets the agreed user-visible latency
+      target and preserves result quality; only move to HNSW-first work if the
+      timing logs show semantic SQL remains the dominant bottleneck.
+
+## Deferred Follow-Up
+
+- [ ] Prototype HNSW-first transcript windows only with a recall, diversity,
+      and duplicate-heavy Mastra no-regression proof against the current
+      default path.
 - [ ] Prove any HNSW-first rewrite uses HNSW on production-shaped data with
-      `EXPLAIN (ANALYZE, BUFFERS)`.
+      `EXPLAIN (ANALYZE, BUFFERS)` and end-to-end Admin GraphQL timing under
+      representative cold/warm cache states.
+- [ ] Treat scene evidence as separate scope: restoring mixed scene/transcript
+      semantic-video retrieval would require updating
+      `hybrid-search-retrievers.ts`, transcript-only regression tests, Mastra
+      relevance proof, and EXPLAIN proof.
 
 ## Entry Points - Read These First
 
 1. `apps/admin/src/services/hybrid-search-retrievers.ts` - video semantic SQL.
 2. `apps/admin/src/services/hybrid-search.service.ts` - retriever fan-out and
    RRF orchestration.
-3. `apps/web/src/lib/admin-client.ts` - 15 second Admin GraphQL caller budget.
+3. `apps/web/src/lib/admin-client.ts` - default 15 second Admin GraphQL client
+   and 45 second semantic-search client.
 4. `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
    - pgvector HNSW planner failure modes and index expectations.
 
@@ -70,3 +96,5 @@ semantic diversity.
 - `pnpm --filter @forge/admin lint -- src/services/hybrid-search-retrievers.ts src/services/hybrid-search-retrievers.test.ts src/services/transcript-embedding-ingest.contract.test.ts`
 - Mastra content-search eval gate for any ranking/windowing change that can
   alter candidate recall.
+- Search timing logs include stage and DB-layer timings for keyword-first,
+  hybrid, semantic-only, and degraded keyword-only probes.

--- a/docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md
+++ b/docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md
@@ -1,0 +1,150 @@
+---
+title: "Admin search stage and DB timing instrumentation"
+date: "2026-06-24"
+category: "performance-issues"
+module: "apps/admin"
+problem_type: "performance_issue"
+component: "database"
+symptoms:
+  - "Watch search can spend several seconds in Admin before the caller timeout"
+  - "Route-level latency does not identify whether embedding, retrieval SQL, fusion, hydration, or trace writes are slow"
+root_cause: "missing_tooling"
+resolution_type: "tooling_addition"
+severity: "high"
+tags:
+  - admin
+  - search
+  - latency
+  - timing
+  - observability
+  - pgvector
+---
+
+# Admin Search Stage and DB Timing Instrumentation
+
+## Problem
+
+Admin search latency debugging needs more than one request duration. A
+keyword-first or hybrid search fans out through embedding generation, multiple
+retrievers, reciprocal-rank fusion, dilution-cap logic, dedupe, mapping, card
+hydration, and trace writes. When a production call takes seconds, a single
+route timer cannot tell whether the bottleneck is vector SQL, lexical SQL,
+Prisma hydration, embedding generation, or the trace side effect.
+
+## Symptoms
+
+- Web Watch search waits several seconds for Admin search and can approach the
+  15 second GraphQL caller timeout.
+- Semantic, hybrid, keyword-first, and degraded keyword-only requests all share
+  the same public response shape, so timing must come from server-side
+  instrumentation.
+- Search trace persistence is intentionally swallowed on failure, which means
+  trace health and search performance need separate observability.
+
+## What Didn't Work
+
+- Measuring only the REST or GraphQL route duration showed that search was slow
+  but not where time was spent.
+- Timing retriever promises without timing the raw SQL hid whether slow
+  retrievers were blocked in PostgreSQL, mapping code, or later hydration.
+- Adding timing fields to the public search response would have changed the
+  consumer contract and leaked operational detail to clients that do not need
+  it.
+
+## Solution
+
+Add a request-scoped timing recorder inside `HybridSearchService.searchWithTrace`
+and pass it down to every retriever that performs database work. Keep timings in
+the internal `SearchWithTraceResult`, then log them from REST, GraphQL, and
+internal eval route boundaries with safe key/value fields.
+
+The timing model should cover three layers:
+
+- Route layer: `route`, requested mode, resolved pipeline mode, response
+  `searchMode`, outcome, result count, total search time, and trace-write time.
+- Orchestrator layer: embedding, retriever fan-out wall time, fusion,
+  dilution-cap, dedupe, mapping, and hydration.
+- Database layer: each raw retriever SQL query and the batched card-hydration
+  Prisma query.
+
+The database labels should identify the query shape, not user input:
+
+```text
+semantic-video.query
+keyword-video.query
+semantic-experience.query
+keyword-experience.query
+keyword-weighted-video.query
+trigram-video.query
+exact-title-video.query
+hydration.video.findMany
+```
+
+The retriever labels should stay aligned with existing search debug labels so
+operators can compare result contribution and elapsed time without learning a
+second vocabulary:
+
+```text
+semantic-video
+keyword-video
+semantic-experience
+keyword-experience
+keyword-weighted-video
+trigram-video
+exact-title-video
+```
+
+Implementation anchors:
+
+- `apps/admin/src/services/hybrid-search-timing.ts` owns the shared recorder and
+  key/value log formatting.
+- `apps/admin/src/services/hybrid-search.service.ts` starts the request timer,
+  wraps retriever promises, snapshots DB timings, and returns timings alongside
+  the private trace summary.
+- `apps/admin/src/services/hybrid-search-retrievers.ts` wraps hybrid semantic
+  and keyword SQL with database timing labels.
+- `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts` wraps the
+  keyword-first SQL paths with database timing labels.
+- `apps/admin/src/app/api/search/route.ts`,
+  `apps/admin/src/graphql/queries/hybrid-search.ts`, and
+  `apps/admin/src/app/api/internal/search-eval/search/route.ts` emit the
+  timing log line.
+
+## Why This Works
+
+The route boundary knows safe request dimensions and trace-write cost, while
+the service knows stage timing, and the retrievers know exact database query
+boundaries. Passing a small recorder down the existing call chain keeps those
+responsibilities intact.
+
+The logged timing line remains operational-only. It does not add query text,
+vectors, debug payloads, bearer details, IP addresses, or public response
+fields. That preserves the search response contract while still producing the
+granularity needed to compare keyword-first, hybrid, semantic-only, and
+keyword-only degraded runs.
+
+Recording both retriever elapsed time and DB elapsed time is important. If a
+retriever time is high and the matching DB query time is low, the bottleneck is
+outside PostgreSQL. If they track closely, the next optimization pass should
+move to `EXPLAIN (ANALYZE, BUFFERS)`, indexes, query shape, or hydration
+projection.
+
+## Prevention
+
+- Do not add a new search retriever without adding both a retriever timing label
+  and a database timing label for its SQL.
+- Keep timing logs free of raw query text, vectors, tokens, cookies, and user
+  identifiers.
+- Keep timing data out of public REST and GraphQL response types unless there
+  is a separate product decision to expose an authenticated diagnostics surface.
+- When optimizing semantic SQL, compare timing logs with production-shaped
+  `EXPLAIN (ANALYZE, BUFFERS)` output before changing ranking semantics.
+- Treat keyword-only timing as the degraded embedding-failure path; it is useful
+  for isolating lexical costs, not proof that semantic quality is preserved.
+
+## Related Issues
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `docs/solutions/platform/admin-search-trace-retention-pattern.md`
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`


### PR DESCRIPTION
## Summary

Admin search now emits safe, structured timing logs that identify where latency is spent without changing the public REST or GraphQL response shape. The log line covers the route boundary, embedding, retriever fan-out, fusion, dilution cap, dedupe, mapping, card hydration, trace-write overhead, and each raw DB query underneath the retrievers.

This restores the observability needed for feat-175 in a narrower shape: measure the real production bottleneck first, then only pursue HNSW-first rewrites if the timing logs show semantic SQL remains dominant. The roadmap now calls out the current 45s Web semantic-search client, the transcript-only safe slice, and the result-quality checks needed before counting latency as recovered.

## Timing Evidence

Local throwaway Admin Postgres probe with seeded video rows, deterministic embeddings, and real pgvector/Prisma SQL:

| Probe | Query | Total | Retrieval wall | DB total | Hydration |
| --- | --- | ---: | ---: | ---: | ---: |
| hybrid | the bible project | 73.6ms | 66.4ms | 137.3ms | 6.1ms |
| hybrid | jesus | 6.1ms | 3.1ms | 6.8ms | 2.5ms |
| keyword-first | the bible project | 16.5ms | 5.5ms | 21.0ms | 7.1ms |
| keyword-first | jesus | 7.1ms | 3.5ms | 10.9ms | 3.2ms |
| semantic-only | jesus | 3.7ms | 1.2ms | 3.3ms | 2.1ms |
| degraded keyword-only | hope when life is hard | 11.0ms | 5.6ms | 19.0ms | 5.2ms |

`db_total_ms` intentionally sums parallel DB spans, so it can exceed route wall time.

## Test Plan

- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin exec eslint src/services/hybrid-search-timing.ts src/services/hybrid-search.service.ts src/services/hybrid-search-retrievers.ts src/services/hybrid-search-keyword-first-retrievers.ts src/app/api/search/route.ts src/graphql/queries/hybrid-search.ts src/app/api/internal/search-eval/search/route.ts src/services/hybrid-search.service.test.ts src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search-keyword-first-retrievers.test.ts src/app/api/search/route.test.ts src/graphql/queries/hybrid-search.test.ts src/app/api/internal/search-eval/search/route.test.ts src/services/hybrid-search.keyword-first.test.ts`
- `pnpm --filter @forge/admin test -- src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search.service.test.ts src/services/hybrid-search.keyword-first.test.ts src/services/hybrid-search.regression.test.ts src/services/transcript-embedding-ingest.contract.test.ts src/services/hybrid-search-keyword-first-retrievers.test.ts src/app/api/search/route.test.ts src/graphql/queries/hybrid-search.test.ts src/app/api/internal/search-eval/search/route.test.ts`
- `python /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
