### PR TITLE
perf(search): overlap keyword-first lexical retrieval

### DIFF
--- a/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/services/hybrid-search.service", () => {
     totalMs: 1,
     embeddingMs: 1,
     retrievalsMs: 0,
+    retrievalWaitMs: 0,
     fusionMs: 0,
     dilutionCapMs: 0,
     dedupeMs: 0,

--- a/apps/admin/src/app/api/search/route.test.ts
+++ b/apps/admin/src/app/api/search/route.test.ts
@@ -20,6 +20,7 @@ const makeTimings = () => ({
   totalMs: 1,
   embeddingMs: 1,
   retrievalsMs: 0,
+  retrievalWaitMs: 0,
   fusionMs: 0,
   dilutionCapMs: 0,
   dedupeMs: 0,

--- a/apps/admin/src/graphql/queries/hybrid-search.test.ts
+++ b/apps/admin/src/graphql/queries/hybrid-search.test.ts
@@ -16,6 +16,7 @@ const makeTimings = () => ({
   totalMs: 1,
   embeddingMs: 1,
   retrievalsMs: 0,
+  retrievalWaitMs: 0,
   fusionMs: 0,
   dilutionCapMs: 0,
   dedupeMs: 0,

--- a/apps/admin/src/services/hybrid-search-timing.test.ts
+++ b/apps/admin/src/services/hybrid-search-timing.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { activeTimingIntervalsMs } from "./hybrid-search-timing"
+
+describe("activeTimingIntervalsMs", () => {
+  it("merges overlapping intervals and excludes idle gaps", () => {
+    expect(
+      activeTimingIntervalsMs([
+        { startedAt: 20, endedAt: 35 },
+        { startedAt: 0, endedAt: 10 },
+        { startedAt: 5, endedAt: 15 },
+        { startedAt: 28, endedAt: 40 },
+      ]),
+    ).toBe(35)
+  })
+
+  it("returns 0 for no active retrieval intervals", () => {
+    expect(activeTimingIntervalsMs([])).toBe(0)
+  })
+})

--- a/apps/admin/src/services/hybrid-search-timing.ts
+++ b/apps/admin/src/services/hybrid-search-timing.ts
@@ -26,6 +26,7 @@ export type SearchTimingSummary = {
   totalMs: number
   embeddingMs: number
   retrievalsMs: number
+  retrievalWaitMs: number
   fusionMs: number
   dilutionCapMs: number
   dedupeMs: number
@@ -60,6 +61,37 @@ export function boundedMs(value: number): number {
 
 export function elapsedMs(startedAt: number): number {
   return boundedMs(nowMs() - startedAt)
+}
+
+export type SearchTimingInterval = {
+  startedAt: number
+  endedAt: number
+}
+
+export function activeTimingIntervalsMs(
+  intervals: readonly SearchTimingInterval[],
+): number {
+  if (intervals.length === 0) return 0
+
+  const sorted = [...intervals].sort((a, b) => a.startedAt - b.startedAt)
+  let activeMs = 0
+  let currentStart = sorted[0]!.startedAt
+  let currentEnd = sorted[0]!.endedAt
+
+  for (let i = 1; i < sorted.length; i++) {
+    const interval = sorted[i]!
+    if (interval.startedAt <= currentEnd) {
+      currentEnd = Math.max(currentEnd, interval.endedAt)
+      continue
+    }
+
+    activeMs += Math.max(0, currentEnd - currentStart)
+    currentStart = interval.startedAt
+    currentEnd = interval.endedAt
+  }
+
+  activeMs += Math.max(0, currentEnd - currentStart)
+  return boundedMs(activeMs)
 }
 
 function defaultResultCount(value: unknown): number {
@@ -121,6 +153,7 @@ export function formatSearchTimingLogFields(
     `total_ms=${timings.totalMs}`,
     `embedding_ms=${timings.embeddingMs}`,
     `db_retrievals_ms=${timings.retrievalsMs}`,
+    `retrieval_wait_ms=${timings.retrievalWaitMs}`,
     `db_total_ms=${dbTotalMs}`,
     `fusion_ms=${timings.fusionMs}`,
     `dilution_cap_ms=${timings.dilutionCapMs}`,

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -6,8 +6,9 @@
  *      called, the three keyword-first retrievers are NOT.
  *   2. The keyword-first path swaps `searchVideoKeyword` for the three
  *      new retrievers (semantic-video stays shared between both modes).
- *   3. Empty-list filtering before fusion is preserved.
- *   4. Per-retriever failures via `Promise.allSettled` keep the rest
+ *   3. Keyword-first lexical retrievers start while embedding is pending.
+ *   4. Empty-list filtering before fusion is preserved.
+ *   5. Per-retriever failures via `Promise.allSettled` keep the rest
  *      of the response intact.
  *
  * Real-DB integration tests (Bible Project headline against seeded
@@ -60,6 +61,22 @@ const mockPrisma = {
 
 const successEmbedder = (): QueryEmbedder =>
   vi.fn().mockResolvedValue([0.1, 0.2, 0.3])
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+async function flushQueuedPromises(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+async function delayMs(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 function setupAllRetrieversEmpty() {
   vi.mocked(searchVideoSemantic).mockResolvedValue([])
@@ -119,6 +136,74 @@ describe("HybridSearchService keyword-first branch", () => {
         limit: 60,
       },
       expect.any(Object),
+    )
+  })
+
+  it("starts keyword-first lexical retrievers while query embedding is pending", async () => {
+    const embedding = deferred<number[]>()
+    const embedder: QueryEmbedder = vi.fn(() => embedding.promise)
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder,
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const searchPromise = service.search({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+    })
+    await flushQueuedPromises()
+
+    expect(embedder).toHaveBeenCalledWith("the bible project")
+    expect(searchByKeywordWeighted).toHaveBeenCalled()
+    expect(searchByTrigram).toHaveBeenCalled()
+    expect(searchByExactTitle).toHaveBeenCalled()
+    expect(searchVideoSemantic).not.toHaveBeenCalled()
+
+    embedding.resolve([0.1, 0.2, 0.3])
+    await searchPromise
+
+    expect(searchVideoSemantic).toHaveBeenCalled()
+  })
+
+  it("does not charge embedding wait time to db retrieval timing", async () => {
+    const embedding = deferred<number[]>()
+    const delayedEmpty = async () => {
+      await delayMs(20)
+      return []
+    }
+    vi.mocked(searchByKeywordWeighted).mockImplementation(delayedEmpty)
+    vi.mocked(searchByTrigram).mockImplementation(delayedEmpty)
+    vi.mocked(searchByExactTitle).mockImplementation(delayedEmpty)
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: vi.fn(() => embedding.promise),
+      logger: { warn: vi.fn(), error: vi.fn() },
+    })
+
+    const searchPromise = service.searchWithTrace({
+      query: "the bible project",
+      locale: "en",
+      mode: "keyword-first",
+    })
+    await flushQueuedPromises()
+    await delayMs(40)
+
+    expect(searchByKeywordWeighted).toHaveBeenCalled()
+    expect(searchByTrigram).toHaveBeenCalled()
+    expect(searchByExactTitle).toHaveBeenCalled()
+    expect(searchVideoSemantic).not.toHaveBeenCalled()
+
+    embedding.resolve([0.1, 0.2, 0.3])
+    const traced = await searchPromise
+
+    expect(traced.timings.embeddingMs).toBeGreaterThanOrEqual(35)
+    expect(traced.timings.retrievalsMs).toBeGreaterThanOrEqual(15)
+    expect(traced.timings.retrievalsMs).toBeLessThan(traced.timings.embeddingMs)
+    expect(traced.timings.retrievalWaitMs).toBeLessThan(
+      traced.timings.embeddingMs / 2,
     )
   })
 
@@ -208,6 +293,62 @@ describe("HybridSearchService keyword-first branch", () => {
     expect(loggerError).toHaveBeenCalledWith(
       expect.stringContaining("trigram-video retrieval failed"),
     )
+  })
+
+  it("handles a fast keyword-first lexical rejection while embedding is pending", async () => {
+    const embedding = deferred<number[]>()
+    const loggerError = vi.fn()
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on("unhandledRejection", onUnhandledRejection)
+    vi.mocked(searchByTrigram).mockRejectedValue(new Error("boom trigram"))
+    vi.mocked(searchByKeywordWeighted).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-1",
+        videoCoreId: null,
+        videoSlug: "a",
+        videoTitle: "A",
+        imageUrl: null,
+        description: "kw weighted survivor",
+        rank: 0.7,
+      },
+    ])
+
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: vi.fn(() => embedding.promise),
+      logger: { warn: vi.fn(), error: loggerError },
+    })
+
+    try {
+      const searchPromise = service.search({
+        query: "jesus",
+        locale: "en",
+        mode: "keyword-first",
+      })
+      await flushQueuedPromises()
+
+      expect(searchByTrigram).toHaveBeenCalled()
+      expect(loggerError).not.toHaveBeenCalledWith(
+        expect.stringContaining("trigram-video retrieval failed"),
+      )
+
+      embedding.resolve([0.1, 0.2, 0.3])
+      const result = await searchPromise
+      await flushQueuedPromises()
+
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]!.id).toBe("vid-1")
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining("trigram-video retrieval failed"),
+      )
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection)
+    }
   })
 
   it("video-only contentTypes still routes through the keyword-first stack (no experience dispatch)", async () => {

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -233,6 +233,7 @@ describe("HybridSearchService", () => {
       totalMs: expect.any(Number),
       embeddingMs: expect.any(Number),
       retrievalsMs: expect.any(Number),
+      retrievalWaitMs: expect.any(Number),
       fusionMs: expect.any(Number),
       dilutionCapMs: 0,
       dedupeMs: expect.any(Number),
@@ -370,6 +371,7 @@ describe("HybridSearchService", () => {
         totalMs: 123.4,
         embeddingMs: 15.2,
         retrievalsMs: 100,
+        retrievalWaitMs: 80,
         fusionMs: 1,
         dilutionCapMs: 0,
         dedupeMs: 0.4,
@@ -400,6 +402,7 @@ describe("HybridSearchService", () => {
     expect(line).toContain("requested_mode=keyword_first")
     expect(line).toContain("pipeline_mode=keyword-first")
     expect(line).toContain("embedding_ms=15.2")
+    expect(line).toContain("retrieval_wait_ms=80")
     expect(line).toContain("retriever_semantic_video_ms=99")
     expect(line).toContain("db_semantic_video_query_ms=98")
     expect(line).toContain("trace_write_ms=1.2")

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -39,10 +39,13 @@ import {
   tokenizeForExactTitle,
 } from "./hybrid-search-keyword-first-retrievers"
 import {
+  activeTimingIntervalsMs,
+  boundedMs,
   elapsedMs,
   nowMs,
   recordSearchDbTiming,
   SearchTimingRecorder,
+  type SearchTimingInterval,
   type SearchRetrieverTiming,
   type SearchTimingSummary,
 } from "./hybrid-search-timing"
@@ -670,7 +673,120 @@ export class HybridSearchService {
     const wantsVideos = requested.includes("video")
     const wantsExperiences = requested.includes("experience")
 
-    // Step 1: Embed the user's query. Degrade gracefully if the
+    // Step 1: Prepare retrieval wrappers before embedding. Keyword-first
+    // video lexical retrievers do not need the query embedding, so they
+    // can start while the embedding provider is still in flight.
+    type Retrieval = {
+      label: string
+      promise: Promise<RankedItem[]>
+    }
+    const retrievals: Retrieval[] = []
+    const retrieverTimings = new Map<string, SearchRetrieverTiming>()
+    const retrievalIntervals: SearchTimingInterval[] = []
+    const skippedRetrieval = (label: string): Promise<RankedItem[]> => {
+      retrieverTimings.set(label, {
+        label,
+        status: "skipped",
+        elapsedMs: 0,
+        resultCount: 0,
+      })
+      return Promise.resolve([])
+    }
+    const timedRetrieval = (
+      label: string,
+      run: () => Promise<RankedItem[]>,
+    ): Promise<RankedItem[]> => {
+      const startedAt = nowMs()
+      return Promise.resolve()
+        .then(run)
+        .then(
+          (value) => {
+            const endedAt = nowMs()
+            retrievalIntervals.push({ startedAt, endedAt })
+            retrieverTimings.set(label, {
+              label,
+              status: "fulfilled",
+              elapsedMs: boundedMs(endedAt - startedAt),
+              resultCount: value.length,
+            })
+            return value
+          },
+          (error) => {
+            const endedAt = nowMs()
+            retrievalIntervals.push({ startedAt, endedAt })
+            retrieverTimings.set(label, {
+              label,
+              status: "rejected",
+              elapsedMs: boundedMs(endedAt - startedAt),
+              resultCount: 0,
+            })
+            throw error
+          },
+        )
+    }
+
+    const earlyKeywordFirstRetrievals: Retrieval[] = []
+    if (wantsVideos && pipelineMode === "keyword-first") {
+      // Start the three-list lexical stack before embedding resolves.
+      // Attaching allSettled immediately prevents a fast DB rejection
+      // from surfacing as an unhandled promise rejection while embedding
+      // is still pending.
+      earlyKeywordFirstRetrievals.push(
+        {
+          label: "keyword-weighted-video",
+          promise: timedRetrieval(
+            "keyword-weighted-video",
+            () =>
+              searchByKeywordWeighted(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
+        },
+        {
+          label: "trigram-video",
+          promise: timedRetrieval(
+            "trigram-video",
+            () =>
+              searchByTrigram(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
+        },
+        {
+          label: "exact-title-video",
+          promise: timedRetrieval(
+            "exact-title-video",
+            () =>
+              searchByExactTitle(
+                this.prisma,
+                {
+                  query,
+                  locale,
+                  limit: overfetchLimit,
+                },
+                timing,
+              ) as Promise<RankedItem[]>,
+          ),
+        },
+      )
+    }
+    const earlyRetrievalOutcomes = Promise.allSettled(
+      earlyKeywordFirstRetrievals.map((r) => r.promise),
+    )
+
+    // Step 2: Embed the user's query. Degrade gracefully if the
     // provider is unavailable — keyword search alone still returns
     // useful results. Failures are logged at error level (a silent
     // warn let feat-097 hide in production for days) and tracked via
@@ -696,55 +812,10 @@ export class HybridSearchService {
       embeddingMs = elapsedMs(embeddingStartedAt)
     }
 
-    // Step 2: Run retrieval in parallel. allSettled keeps partial
-    // results when one retrieval fails (e.g. pgvector timeout but
+    // Step 3: Run embedding-gated retrieval in parallel. allSettled keeps
+    // partial results when one retrieval fails (e.g. pgvector timeout but
     // keyword succeeds). Each retrieval is paired with a label so
     // outcomes can map back to their source for logging.
-    type Retrieval = {
-      label: string
-      promise: Promise<RankedItem[]>
-    }
-    const retrievals: Retrieval[] = []
-    const retrieverTimings = new Map<string, SearchRetrieverTiming>()
-    const retrievalsStartedAt = nowMs()
-    const skippedRetrieval = (label: string): Promise<RankedItem[]> => {
-      retrieverTimings.set(label, {
-        label,
-        status: "skipped",
-        elapsedMs: 0,
-        resultCount: 0,
-      })
-      return Promise.resolve([])
-    }
-    const timedRetrieval = (
-      label: string,
-      run: () => Promise<RankedItem[]>,
-    ): Promise<RankedItem[]> => {
-      const startedAt = nowMs()
-      return Promise.resolve()
-        .then(run)
-        .then(
-          (value) => {
-            retrieverTimings.set(label, {
-              label,
-              status: "fulfilled",
-              elapsedMs: elapsedMs(startedAt),
-              resultCount: value.length,
-            })
-            return value
-          },
-          (error) => {
-            retrieverTimings.set(label, {
-              label,
-              status: "rejected",
-              elapsedMs: elapsedMs(startedAt),
-              resultCount: 0,
-            })
-            throw error
-          },
-        )
-    }
-
     if (wantsVideos) {
       // Semantic-video is shared by every embedding-backed pipeline.
       retrievals.push({
@@ -773,54 +844,9 @@ export class HybridSearchService {
         // (Algolia-like). The legacy R4 `searchVideoKeyword` is NOT
         // dispatched on this branch — its concatenated tsvector is
         // strictly weaker than the weighted one for this workload.
-        retrievals.push({
-          label: "keyword-weighted-video",
-          promise: timedRetrieval(
-            "keyword-weighted-video",
-            () =>
-              searchByKeywordWeighted(
-                this.prisma,
-                {
-                  query,
-                  locale,
-                  limit: overfetchLimit,
-                },
-                timing,
-              ) as Promise<RankedItem[]>,
-          ),
-        })
-        retrievals.push({
-          label: "trigram-video",
-          promise: timedRetrieval(
-            "trigram-video",
-            () =>
-              searchByTrigram(
-                this.prisma,
-                {
-                  query,
-                  locale,
-                  limit: overfetchLimit,
-                },
-                timing,
-              ) as Promise<RankedItem[]>,
-          ),
-        })
-        retrievals.push({
-          label: "exact-title-video",
-          promise: timedRetrieval(
-            "exact-title-video",
-            () =>
-              searchByExactTitle(
-                this.prisma,
-                {
-                  query,
-                  locale,
-                  limit: overfetchLimit,
-                },
-                timing,
-              ) as Promise<RankedItem[]>,
-          ),
-        })
+        // The keyword-first lexical promises were already started above
+        // so they can overlap the embedding provider call.
+        retrievals.push(...earlyKeywordFirstRetrievals)
       } else if (!semanticOnly) {
         // Hybrid path — UNCHANGED from R4. Byte-identity locked in by
         // hybrid-search.regression.test.ts.
@@ -883,8 +909,19 @@ export class HybridSearchService {
       }
     }
 
-    const outcomes = await Promise.allSettled(retrievals.map((r) => r.promise))
-    const retrievalsMs = elapsedMs(retrievalsStartedAt)
+    const settledRetrieval = (promise: Promise<RankedItem[]>) =>
+      Promise.allSettled([promise]).then(([outcome]) => outcome!)
+    const retrievalWaitStartedAt = nowMs()
+    const outcomes = await Promise.all(
+      retrievals.map((retrieval) => {
+        const earlyIndex = earlyKeywordFirstRetrievals.indexOf(retrieval)
+        return earlyIndex >= 0
+          ? earlyRetrievalOutcomes.then((outcomes) => outcomes[earlyIndex]!)
+          : settledRetrieval(retrieval.promise)
+      }),
+    )
+    const retrievalWaitMs = elapsedMs(retrievalWaitStartedAt)
+    const retrievalsMs = activeTimingIntervalsMs(retrievalIntervals)
     const failedRetrievers: string[] = []
     const lists = outcomes.map((outcome, i) =>
       this.unwrapOutcome(outcome, retrievals[i]!.label, failedRetrievers),
@@ -918,7 +955,7 @@ export class HybridSearchService {
       }
     }
 
-    // Step 3: Fuse ranked lists via RRF. Drop empty lists first — RRF
+    // Step 4: Fuse ranked lists via RRF. Drop empty lists first — RRF
     // normalizes by dividing by the number of input lists, so empty
     // ones dilute scores from lists that did contribute.
     const nonEmptyLists = lists.filter((list) => list.length > 0)
@@ -934,7 +971,7 @@ export class HybridSearchService {
       if (trace != null) trace.fusedScore = result.score
     }
 
-    // Step 3b: Semantic-dilution cap. Active only in keyword-first mode
+    // Step 4b: Semantic-dilution cap. Active only in keyword-first mode
     // and only when an exact-title hit exists. Halves the score of any
     // fused result whose ONLY contributing list was semantic AND whose
     // video core_id is not represented in the top-N keyword-side
@@ -946,13 +983,13 @@ export class HybridSearchService {
       dilutionCapMs = elapsedMs(dilutionCapStartedAt)
     }
 
-    // Step 4: Dedup one extra result beyond the page window so we know
+    // Step 5: Dedup one extra result beyond the page window so we know
     // whether more results exist (drives hasMore without a full count
     // pass).
     const dedupeStartedAt = nowMs()
     const deduped = deduplicateResults(fused, offset + limit + 1)
 
-    // Step 5: Paginate and map to API contract.
+    // Step 6: Paginate and map to API contract.
     const page = deduped.slice(offset, offset + limit)
     const hasMore = deduped.length > offset + limit
     const dedupeMs = elapsedMs(dedupeStartedAt)
@@ -1002,6 +1039,7 @@ export class HybridSearchService {
       totalMs: elapsedMs(totalStartedAt),
       embeddingMs,
       retrievalsMs,
+      retrievalWaitMs,
       fusionMs,
       dilutionCapMs,
       dedupeMs,

--- a/docs/plans/2026-06-24-001-perf-admin-search-parallel-keyword-plan.md
+++ b/docs/plans/2026-06-24-001-perf-admin-search-parallel-keyword-plan.md
@@ -1,0 +1,154 @@
+---
+title: "perf: Parallelize keyword-first Admin search retrieval"
+type: "perf"
+date: "2026-06-24"
+execution: "code"
+---
+
+# perf: Parallelize keyword-first Admin search retrieval
+
+## Summary
+
+Reduce Admin `keyword-first` search latency by starting lexical video retrieval before query embedding finishes, while keeping ranking semantics, response shape, and existing timing logs unchanged.
+
+---
+
+## Problem Frame
+
+Production timing logs from `feat-175` show `keyword-first` searches wait on embedding before dispatching lexical retrievers that do not need the embedding. That sequencing adds avoidable wall time before the same fused candidate lists can be processed. The first latency slice should overlap independent work before changing semantic SQL, hydration projection, or ranking logic.
+
+---
+
+## Requirements
+
+### Latency Behavior
+
+- R1. `keyword-first` video lexical retrievers start without waiting for query embedding.
+- R2. Semantic video and semantic experience retrieval still run only after a successful embedding.
+- R3. Embedding failure still degrades to the existing keyword-only behavior for public hybrid and keyword-first modes.
+
+### Contract Preservation
+
+- R4. Public REST and GraphQL search response shapes remain unchanged.
+- R5. Existing retriever labels, timing labels, `searchMode`, and dilution-cap behavior remain compatible with current production logs.
+- R6. `hybrid` and public-fallback unknown modes keep their existing retriever dispatch behavior.
+- R7. Internal `semantic-only` mode still skips lexical retrievers.
+
+### Verification
+
+- R8. Tests prove lexical retrievers can be in flight while embedding is still pending.
+- R9. The merged change is measured in production with the same representative GraphQL and internal eval queries used for the baseline timing sample.
+
+---
+
+## Key Technical Decisions
+
+- **Overlap, do not rerank:** The PR should change when independent retriever promises are created, not how results are scored, fused, capped, deduped, or hydrated. This keeps result quality stable.
+- **Keep the single orchestrator:** `HybridSearchService.searchWithTrace` remains the branching point for `hybrid`, `keyword-first`, and `semantic-only`, matching the existing keyword-first extension pattern.
+- **Make retrieval timing overlap-aware:** `embedding_ms` still measures only embedding. For `keyword-first`, `db_retrievals_ms` should measure the full overlap-aware retrieval phase from the first early lexical retriever launch until all early lexical and embedding-gated semantic retrievers have settled. Stage timings are not additive after this change; per-retriever and DB labels remain the source for individual SQL durations.
+- **Defer SQL and hydration changes:** `semantic-video.query` and `hydration.video.findMany` are the larger remaining bottlenecks, but this PR should not change SQL shape or Prisma hydration. Those need separate EXPLAIN/projection work and quality checks.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant Search as searchWithTrace
+  participant Lexical as Keyword-first lexical DB
+  participant Embed as Query embedding
+  participant Semantic as Semantic DB
+  participant Fusion as Fusion and hydration
+
+  Search->>Lexical: start keyword-weighted/trigram/exact-title promises
+  Search->>Embed: start embedding request
+  Embed-->>Search: vector or failure
+  alt embedding succeeds
+    Search->>Semantic: start semantic retrievers
+  else embedding fails
+    Search->>Semantic: record semantic retrievers as skipped
+  end
+  Search->>Search: await all retriever promises
+  Search->>Fusion: fuse, cap, dedupe, hydrate, return
+```
+
+---
+
+## Implementation Units
+
+### U1. Start Keyword-First Lexical Retrieval Before Embedding Resolves
+
+- **Goal:** Reorder `keyword-first` video retrieval setup so lexical DB promises are created immediately, while semantic retrievers remain embedding-gated.
+- **Requirements:** R1, R2, R3, R5, R7
+- **Dependencies:** none
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+- **Approach:** Introduce an early lexical retrieval collection for the `keyword-first` video branch using the existing `timedRetrieval` wrapper and `SearchTimingRecorder`. Attach a rejection handler immediately by starting an early `Promise.allSettled` over those lexical promises before crossing any embedding `await`. Start embedding in parallel, append semantic retrievers after embedding succeeds, or mark them skipped after failure. Merge early lexical outcomes with semantic outcomes through the existing labeled failure-isolation path.
+- **Patterns to follow:** `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`; `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
+- **Test scenarios:** Covered in U2.
+- **Verification:** A code review can see lexical retriever calls no longer sit behind `await this.embedder(query)`, and no fusion or response-mapping code changed.
+
+### U2. Add Orchestrator Coverage For Overlap And Mode Safety
+
+- **Goal:** Prove the reordering preserves mode contracts and creates the intended overlap.
+- **Requirements:** R1, R3, R6, R7, R8
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.keyword-first.test.ts`
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+- **Approach:** Add a test where the embedder promise is held pending and `mode="keyword-first"` is invoked; assert the lexical retrievers have already been dispatched before resolving the embedding. Keep existing embedding-failure and semantic-only expectations green so the public degradation and eval-only semantic isolation contracts are protected.
+- **Patterns to follow:** `docs/solutions/best-practices/test-first-regression-snapshot-byte-identical-default-20260429.md`
+- **Test scenarios:**
+  - `keyword-first` with a pending embedder dispatches `keyword-weighted-video`, `trigram-video`, and `exact-title-video` before the embedding resolves.
+  - `keyword-first` with a pending embedder and a rejecting lexical retriever keeps the rejection handled through the settled-outcome path.
+  - `keyword-first` with embedding failure still returns `searchMode="keyword-only"` and keeps semantic retrievers skipped.
+  - Existing hybrid and unknown-mode regression coverage still proves keyword-first lexical retrievers are not dispatched outside the keyword-first branch.
+  - `semantic-only` still does not dispatch keyword-first lexical retrievers.
+- **Verification:** Focused Vitest coverage passes for the Admin hybrid search service suite.
+
+### U3. Measure Production After Merge
+
+- **Goal:** Compare the merged PR against the current production timing baseline using the same timing logs.
+- **Requirements:** R5, R9
+- **Dependencies:** U1, U2
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- **Approach:** Before merge, use the existing production baseline traces to estimate the theoretical overlap ceiling for each query: the visible win is bounded by the lexical DB work that can fit under embedding time, and can still be masked by semantic SQL or hydration. After the PR deploys to Railway production, run representative `keyword-first`, `hybrid`, and `semantic-only` searches through Admin production with at least two passes of `the bible project`, `jesus`, and `hope when life is hard`. Capture client time, `total_ms`, `embedding_ms`, `db_retrievals_ms`, retriever timings, DB timings, `hydration_ms`, and `trace_write_ms`. Report whether `keyword-first` total wall time moved toward the overlap ceiling, and name semantic SQL, hydration, or embedding as the remaining dominant blocker when it does not.
+- **Patterns to follow:** Existing production timing log format from `formatSearchTimingLogLine`.
+- **Test scenarios:** Test expectation: none -- this unit is operational measurement after deploy.
+- **Verification:** The final report includes before/after timings and names the remaining dominant bottleneck.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Reorder independent keyword-first lexical retrieval relative to embedding.
+- Preserve current result quality by leaving retrieval SQL, RRF, dilution cap, dedupe, hydration, and public response mapping unchanged.
+- Run production timing probes after deployment.
+
+### Deferred to Follow-Up Work
+
+- Optimize `semantic-video.query` using production-shaped `EXPLAIN (ANALYZE, BUFFERS)`.
+- Replace broad hydration with a lean search-card projection or denormalized search result table.
+- Cache query embeddings by normalized query, locale, and embedding model version.
+- Move trace writes fully off the request path.
+
+---
+
+## Risks & Dependencies
+
+- **Unhandled promise timing:** Starting lexical promises earlier means they may reject before semantic retrievers are created. The implementation must attach an immediate settled-outcome promise before awaiting embedding so Node does not emit unhandled rejections.
+- **Metric interpretation:** `db_retrievals_ms` becomes an overlap-aware retrieval phase metric in `keyword-first`; it is no longer additive with `embedding_ms`. The comparison should use `total_ms`, retriever-specific timings, and DB-specific timings together.
+- **Production variance:** Embedding and DB timings vary between cold and warm runs. The report should compare patterns across several queries rather than claiming success from one fast request.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `apps/admin/AGENTS.md`

--- a/docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md
+++ b/docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md
@@ -1,6 +1,7 @@
 ---
 title: "Admin search stage and DB timing instrumentation"
 date: "2026-06-24"
+last_updated: "2026-06-25"
 category: "performance-issues"
 module: "apps/admin"
 problem_type: "performance_issue"
@@ -80,6 +81,20 @@ exact-title-video.query
 hydration.video.findMany
 ```
 
+When keyword-first mode overlaps video lexical retrieval with embedding, keep
+two retrieval clocks:
+
+- `db_retrievals_ms`: merged active retriever interval time. This measures
+  database/retriever work and must not grow just because the embedding provider
+  is still pending.
+- `retrieval_wait_ms`: the final orchestrator wait after the full retrieval
+  list has been assembled. This is the critical-path wait surface and may be
+  small when early lexical retrievers already settled before embedding returned.
+
+Do not compute `db_retrievals_ms` from a single wall-clock span that starts
+when early keyword-first retrievers launch. That double-counts embedding wait
+as database latency and makes production bottleneck reports misleading.
+
 The retriever labels should stay aligned with existing search debug labels so
 operators can compare result contribution and elapsed time without learning a
 second vocabulary:
@@ -129,6 +144,42 @@ outside PostgreSQL. If they track closely, the next optimization pass should
 move to `EXPLAIN (ANALYZE, BUFFERS)`, indexes, query shape, or hydration
 projection.
 
+For overlapped phases, stage timings are not additive. Compare `total_ms`,
+`embedding_ms`, `db_retrievals_ms`, `retrieval_wait_ms`, per-retriever timings,
+and per-DB labels together. A healthy keyword-first overlap can reduce
+`total_ms` while leaving individual lexical DB timings unchanged.
+
+## Async Overlap Follow-Up
+
+Keyword-first video lexical retrievers only depend on `query`, `locale`, and
+`limit`, so they can start before `await embedder(query)`. Semantic retrievers
+still require `queryEmbeddingText`, so keep them embedding-gated and skip them
+when embedding fails.
+
+The safe orchestration shape is:
+
+```ts
+const earlyKeywordFirstRetrievals = [
+  keywordWeightedVideo(),
+  trigramVideo(),
+  exactTitleVideo(),
+]
+const earlyRetrievalOutcomes = Promise.allSettled(
+  earlyKeywordFirstRetrievals.map((r) => r.promise),
+)
+
+const vector = await embedder(query)
+
+retrievals.push(semanticVideo(vector))
+retrievals.push(...earlyKeywordFirstRetrievals)
+```
+
+Attach `Promise.allSettled` immediately to early lexical promises. A fast DB
+rejection can otherwise surface as an unhandled promise rejection while the
+embedding provider is still pending. After embedding resolves, reuse the early
+settled outcomes in the final retriever order so RRF input order and debug
+labels remain unchanged.
+
 ## Prevention
 
 - Do not add a new search retriever without adding both a retriever timing label
@@ -141,10 +192,19 @@ projection.
   `EXPLAIN (ANALYZE, BUFFERS)` output before changing ranking semantics.
 - Treat keyword-only timing as the degraded embedding-failure path; it is useful
   for isolating lexical costs, not proof that semantic quality is preserved.
+- Keep tests that hold the embedder pending and prove keyword-first lexical
+  retrievers start before semantic retrieval.
+- Keep a fast-rejection test for early keyword-first lexical retrievers so the
+  immediate settled handler does not regress.
+- Keep interval tests for merged active retrieval timing; overlapping DB
+  intervals and idle embedding gaps should not be double-counted.
 
 ## Related Issues
 
 - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-24-001-perf-admin-search-parallel-keyword-plan.md`
 - `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
 - `docs/solutions/platform/admin-search-trace-retention-pattern.md`
 - `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
+- GitHub issue `JesusFilm/forge#979` — adjacent statement-timeout follow-up for
+  hybrid-search SQL paths.

--- a/docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md
+++ b/docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md
@@ -140,15 +140,19 @@ DB call. All three honor `OVERFETCH_FACTOR = 3` via the `limit` param.
 ## Branched orchestrator — `HybridSearchService.search()`
 
 ```
+if mode === "keyword-first" && wantsVideos:
+  start keyword-weighted-video + trigram-video + exact-title-video
+  attach Promise.allSettled immediately
+  ↓
 embed(query)
   ↓
-build retrievals[]:
+build final retrievals[]:
   if wantsVideos:
     push semantic-video                         (shared)
     if mode === "keyword-first":
-      push keyword-weighted-video
-      push trigram-video
-      push exact-title-video
+      push pre-started keyword-weighted-video
+      push pre-started trigram-video
+      push pre-started exact-title-video
     else:                                        (hybrid path UNCHANGED)
       push keyword-video                         (R4)
   if wantsExperiences:
@@ -164,6 +168,16 @@ return { results, hasMore, query, searchMode }
                                        ↑
                               UNCHANGED degradation signal
 ```
+
+The three keyword-first video lexical retrievers do not need the query
+embedding, so they may run while the embedding provider is in flight. Semantic
+retrievers remain embedding-gated. Reuse the early settled outcomes in the final
+retriever order; do not let async overlap change RRF list order or debug labels.
+
+Timing attribution follows
+`docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`:
+`db_retrievals_ms` is active retriever time, while `retrieval_wait_ms` is the
+final await span. Overlapped stage timings are not additive.
 
 ## Semantic-dilution cap
 


### PR DESCRIPTION
## Summary

Keyword-first Admin search now starts its video lexical retrievers while the query embedding request is still in flight, so independent DB work no longer waits on the embedding provider. Semantic retrieval stays gated on embedding success, final retriever order is preserved for RRF/debug labels, and fast early lexical failures are handled through an immediately attached settled handler.

The timing logs now separate active retrieval work from final retrieval wait time. `db_retrievals_ms` reports merged active retriever intervals, while `retrieval_wait_ms` shows the remaining critical-path await span, so overlapped stages do not make embedding latency look like database latency.

## Design Notes

| Concern | Decision |
|---|---|
| Search quality | Preserve the existing retriever list order: `semantic-video` first, then keyword-first lexical lists. |
| Failure isolation | Attach `Promise.allSettled` immediately to early keyword-first lexical promises so a quick DB rejection cannot become an unhandled rejection while embedding is pending. |
| Timing attribution | Keep DB/retriever active time separate from overlap wait time; stage timings are intentionally not additive after this change. |
| Scope | Only video lexical keyword-first retrievers move earlier. Experience keyword and all semantic retrievers keep their existing embedding-gated placement. |

## Validation

- `pnpm --filter @forge/admin test -- src/services/hybrid-search.service.test.ts src/services/hybrid-search.keyword-first.test.ts src/services/hybrid-search.regression.test.ts src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search-keyword-first-retrievers.test.ts src/services/hybrid-search-timing.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin exec eslint src/services/hybrid-search.service.ts src/services/hybrid-search.keyword-first.test.ts src/services/hybrid-search-timing.ts src/services/hybrid-search-timing.test.ts src/services/hybrid-search.service.test.ts src/app/api/search/route.test.ts src/app/api/internal/search-eval/search/route.test.ts src/graphql/queries/hybrid-search.test.ts`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
- `git diff --check`

## Post-Deploy Monitoring & Validation

After this reaches production, run repeated Admin searches for `the bible project`, `jesus`, and `hope when life is hard` through the same production GraphQL path and compare against the prior keyword-first baseline. The first read should focus on `total_ms`, `embedding_ms`, `db_retrievals_ms`, `retrieval_wait_ms`, `db_semantic_video_query_ms`, `db_hydration_video_findmany_ms`, per-retriever timings, `search_mode`, and `result_count`.

Healthy outcome: no new `retrieval_failure` events, `search_mode=hybrid`, final result quality/top videos remain stable, and keyword-first lexical DB timings overlap embedding rather than extending the visible critical path.

Failure triggers: keyword-first `total_ms` regresses materially on the same queries, early lexical retriever failures appear, `search_mode` degrades to keyword-only, or the new `retrieval_wait_ms` suggests the request still waits mostly on lexical retrieval after embedding resolves.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
