### PR TITLE
feat(chat): extract sidebar into hook + sub-components (feat-203)

### DIFF
--- a/apps/chat/CLAUDE.md
+++ b/apps/chat/CLAUDE.md
@@ -20,7 +20,12 @@ src/
   components/
     shell/
       app-shell.tsx      'use client' — owns conversation state (useConversations) + sidebar view state (collapsed rail / mobile drawer open); matchMedia breakpoint reset, body scroll-lock, <main> inert focus-trap
-      sidebar.tsx        'use client' — responsive left rail: desktop expanded ↔ collapsed icon-rail + mobile off-canvas drawer. Holds local UI mechanics (collapse clip animation, Escape-to-close, drawer focus trap/restore); conversation data is props
+      sidebar.tsx        'use client' — responsive left rail composition (scrim + <aside>): desktop expanded ↔ collapsed icon-rail + mobile off-canvas drawer. Presentational shell now — UI mechanics live in use-sidebar-chrome, collapsed-style policy in sidebar-collapsed-styles, sub-rows in the sidebar-* components
+      use-sidebar-chrome.ts        'use client' — sidebar UI-mechanics hook: collapse clip state machine (+ 400ms fallback timer), Escape-to-close listener, drawer focus trap/restore. Derives presentation from collapsed/mobileOpen; owns no view state
+      sidebar-collapsed-styles.ts  collapsedStyles(collapsed) → the md:-scoped collapsed-rail class policy in one slot-keyed map (header/brand/wordmark/newButton/nav)
+      sidebar-header.tsx           Brand mark + wordmark + the three mutually-exclusive controls (desktop collapse toggle / collapsed expand affordance / mobile close X); presentational
+      sidebar-new-conversation.tsx New-conversation action (full-width labeled ↔ centered icon-only when collapsed); presentational
+      sidebar-conversation-list.tsx Conversation history nav (select + per-row replying pulse; hidden when collapsed); presentational
       icons.tsx          Inline line-icon components (panel/compose/menu/close) — currentColor, no icon dependency, no emoji
     chat/
       chat.tsx           Conversation pane — the centered 680px reading "room" (presentational)
@@ -43,11 +48,13 @@ public/                  Static assets served by URL (Next.js convention, matche
 - **State ownership:** all conversation state lives in `useConversations`,
   consumed by `AppShell`, which also owns sidebar _view_ state (`collapsed`,
   `mobileOpen`). Data flows one way: `useConversations`/view-state → `AppShell`
-  → `Sidebar` / `Chat` → leaf components. `chat.tsx` is fully presentational;
-  `sidebar.tsx` is presentational for _data_ but holds local _UI mechanics_
-  (collapse clip animation, Escape listener, drawer focus trap). Pulling those
-  mechanics into a hook + sub-components is tracked in
-  `docs/roadmap/ai-chat/feat-203`.
+  → `Sidebar` / `Chat` → leaf components. Both `chat.tsx` and `sidebar.tsx` are
+  presentational compositions now: `sidebar.tsx` lays out the scrim + `<aside>`
+  and delegates its local _UI mechanics_ (collapse clip animation, Escape
+  listener, drawer focus trap) to the `useSidebarChrome` hook, its collapsed
+  class policy to `collapsedStyles`, and its rows to the `sidebar-*`
+  sub-components (feat-203). State ownership stays in `AppShell` — the hook
+  only derives presentation from the `collapsed`/`mobileOpen` flags.
 - **The stub seam:** reply generation is isolated in `lib/chat-stub.ts`. The
   hook only orchestrates timing, the per-conversation pending/double-send guard,
   and which conversation a reply lands in. The `Message` type lives in
@@ -136,12 +143,14 @@ roadmap ticket that settles the integration path (above) as explicit
 
 ## Key Conventions
 
-- Server Components by default. Client components are the interactive ones:
-  `shell/app-shell.tsx`, `shell/sidebar.tsx`, `chat/chat.tsx`,
-  `chat/composer.tsx`, and `chat/empty-state.tsx`. `chat/message-list.tsx` is a
-  pure presentational render (no hooks/handlers) so it carries no `'use client'`
-  and inherits its parent's client context — `shell/icons.tsx` (stateless SVG
-  components) is the same. `brand/*`, `lib/cn.ts`, and the `app/` entry files
+- Server Components by default. Client components are the ones holding hooks:
+  `shell/app-shell.tsx`, `shell/sidebar.tsx`, `shell/use-sidebar-chrome.ts`,
+  `chat/chat.tsx`, `chat/composer.tsx`, and `chat/empty-state.tsx`.
+  `chat/message-list.tsx` and the `shell/sidebar-{header,new-conversation,conversation-list}.tsx`
+  sub-components carry no `'use client'` — they have event handlers but no hooks,
+  so they inherit the client context of the `'use client'` modules that import
+  them (`shell/icons.tsx`, the stateless SVGs, is the same). `shell/sidebar-collapsed-styles.ts`
+  (a pure class-map function), `brand/*`, `lib/cn.ts`, and the `app/` entry files
   stay server / framework-agnostic.
 - Strict TypeScript, `src/` layout, `@/*` path alias — config mirrors
   `apps/web` (the CI-proven template).
@@ -150,7 +159,9 @@ roadmap ticket that settles the integration path (above) as explicit
 - Tests colocated (`*.test.ts(x)`); component tests use plain
   `react-dom/client` + `act` with per-file `// @vitest-environment jsdom`
   (the `apps/admin` style — no testing-library). The behavioral suite lives in
-  `components/shell/app-shell.test.tsx` (AppShell owns the state).
+  `components/shell/app-shell.test.tsx` (AppShell owns the state); the extracted
+  `use-sidebar-chrome` hook has its own colocated unit test for its state machine
+  in isolation.
 - Runs on port **3200**.
 
 ### Comments

--- a/apps/chat/src/components/shell/sidebar-collapsed-styles.test.ts
+++ b/apps/chat/src/components/shell/sidebar-collapsed-styles.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  collapsedStyles,
+  type CollapsedStyles,
+} from "./sidebar-collapsed-styles"
+
+// Drive the slot list off the function's own output, not a hand-listed array:
+// the return type forces every CollapsedStyles key to be present, so a newly
+// added slot is covered automatically with no list to drift out of sync.
+const SLOTS = Object.keys(collapsedStyles(true)) as (keyof CollapsedStyles)[]
+
+describe("collapsedStyles", () => {
+  it("applies no collapsed styling when the rail is expanded", () => {
+    const styles = collapsedStyles(false)
+    // Expanded: every slot short-circuits to false so `cn()` drops it and the
+    // rail renders in its full form.
+    for (const slot of SLOTS) {
+      expect(styles[slot]).toBe(false)
+    }
+  })
+
+  it("emits a non-empty class fragment for every slot when collapsed", () => {
+    const styles = collapsedStyles(true)
+    for (const slot of SLOTS) {
+      expect(typeof styles[slot]).toBe("string")
+      expect(styles[slot]).not.toBe("")
+    }
+  })
+
+  it("scopes every collapsed class to the md breakpoint (collapse is desktop-only)", () => {
+    // The load-bearing invariant: the mobile drawer must always show full
+    // content, so each collapsed fragment must be `md:`-prefixed on every token.
+    // A stray unprefixed utility here would leak the icon-rail into the drawer.
+    const styles = collapsedStyles(true)
+    for (const slot of SLOTS) {
+      const tokens = (styles[slot] as string).split(/\s+/).filter(Boolean)
+      for (const token of tokens) {
+        expect(token.startsWith("md:")).toBe(true)
+      }
+    }
+  })
+})

--- a/apps/chat/src/components/shell/sidebar-collapsed-styles.ts
+++ b/apps/chat/src/components/shell/sidebar-collapsed-styles.ts
@@ -1,0 +1,43 @@
+/**
+ * The collapsed-rail style policy in one place. Every collapsed presentation is
+ * `md:`-scoped (collapse is desktop-only; the mobile drawer always shows full
+ * content), so each slot is empty unless `collapsed` is set. Sidebar computes
+ * this once and hands the relevant slots to its sub-components, replacing the
+ * `collapsed && …` fragments that were dispersed across the JSX.
+ */
+export type CollapsedStyles = {
+  /** Header row: drop horizontal padding so the icon-rail centers. */
+  header: string | false
+  /** Brand container: center the mark in the narrow rail. */
+  brand: string | false
+  /** Brand mark: fade out on hover/focus to reveal the expand toggle beneath. */
+  brandMark: string | false
+  /** Wordmark: hidden in the icon rail. */
+  wordmark: string | false
+  /** New-conversation wrapper: drop padding to center the icon button. */
+  newButtonWrap: string | false
+  /** New-conversation button: shrink to a centered icon-only target. */
+  newButton: string | false
+  /** New-conversation label: hidden in the icon rail. */
+  newButtonLabel: string | false
+  /** Conversation nav: hidden entirely in the icon rail. */
+  nav: string | false
+}
+
+/** Build the collapsed-style slot map for the current collapsed flag. */
+export function collapsedStyles(collapsed: boolean): CollapsedStyles {
+  return {
+    header: collapsed && "md:px-0",
+    brand: collapsed && "md:justify-center",
+    brandMark:
+      collapsed &&
+      "md:transition-opacity md:duration-300 md:group-hover/brand:opacity-0 md:group-focus-within/brand:opacity-0",
+    wordmark: collapsed && "md:hidden",
+    newButtonWrap: collapsed && "md:px-0",
+    newButton:
+      collapsed &&
+      "md:mx-auto md:w-10 md:justify-center md:gap-0 md:border-transparent md:p-0 md:py-2.5 md:hover:border-transparent",
+    newButtonLabel: collapsed && "md:hidden",
+    nav: collapsed && "md:hidden",
+  }
+}

--- a/apps/chat/src/components/shell/sidebar-conversation-list.test.tsx
+++ b/apps/chat/src/components/shell/sidebar-conversation-list.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { type Conversation } from "@/lib/conversations"
+
+import { collapsedStyles } from "./sidebar-collapsed-styles"
+import { ConversationList } from "./sidebar-conversation-list"
+;(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+const conversations: Conversation[] = [
+  { id: "a", title: "First chat", messages: [] },
+  { id: "b", title: "Second chat", messages: [] },
+]
+
+type Overrides = {
+  activeId?: string
+  conversations?: Conversation[]
+  pendingIds?: ReadonlySet<string>
+  onSelect?: (id: string) => void
+  onCloseMobile?: () => void
+}
+
+function render(overrides: Overrides = {}) {
+  const props = {
+    conversations: overrides.conversations ?? conversations,
+    activeId: overrides.activeId ?? "a",
+    pendingIds: overrides.pendingIds ?? new Set<string>(),
+    styles: collapsedStyles(false),
+    onSelect: overrides.onSelect ?? (() => {}),
+    onCloseMobile: overrides.onCloseMobile ?? (() => {}),
+  }
+  act(() => {
+    root.render(<ConversationList {...props} />)
+  })
+}
+
+function rowByTitle(title: string): HTMLButtonElement {
+  const btn = Array.from(
+    container.querySelectorAll<HTMLButtonElement>("nav button"),
+  ).find((b) => b.textContent?.includes(title))
+  if (!btn) throw new Error(`row "${title}" not found`)
+  return btn
+}
+
+describe("ConversationList", () => {
+  it("selects a conversation and closes the mobile drawer on row click", () => {
+    const onSelect = vi.fn()
+    const onCloseMobile = vi.fn()
+    render({ onSelect, onCloseMobile })
+
+    act(() => {
+      rowByTitle("Second chat").click()
+    })
+
+    // Both fire on a single click — selecting also dismisses the drawer.
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenCalledWith("b")
+    expect(onCloseMobile).toHaveBeenCalledTimes(1)
+  })
+
+  it("marks only the active row with aria-current", () => {
+    render({ activeId: "b" })
+    expect(rowByTitle("Second chat").getAttribute("aria-current")).toBe("true")
+    expect(rowByTitle("First chat").getAttribute("aria-current")).toBeNull()
+  })
+
+  it("renders the replying pulse only on conversations awaiting a reply", () => {
+    render({ pendingIds: new Set(["a"]) })
+    expect(
+      rowByTitle("First chat").querySelector("[data-replying]"),
+    ).not.toBeNull()
+    expect(
+      rowByTitle("Second chat").querySelector("[data-replying]"),
+    ).toBeNull()
+    // The pulse carries an sr-only label so it is announced, not silent.
+    expect(rowByTitle("First chat").textContent).toContain("Replying")
+  })
+
+  it("renders the labeled nav with no rows when there are no conversations", () => {
+    render({ conversations: [], activeId: "" })
+    const nav = container.querySelector('nav[aria-label="Conversations"]')
+    expect(nav).not.toBeNull()
+    expect(nav?.querySelectorAll("li")).toHaveLength(0)
+  })
+})

--- a/apps/chat/src/components/shell/sidebar-conversation-list.tsx
+++ b/apps/chat/src/components/shell/sidebar-conversation-list.tsx
@@ -1,0 +1,74 @@
+import { cn } from "@/lib/cn"
+import { type Conversation } from "@/lib/conversations"
+
+import { type CollapsedStyles } from "./sidebar-collapsed-styles"
+
+type ConversationListProps = {
+  conversations: Conversation[]
+  activeId: string
+  pendingIds: ReadonlySet<string>
+  styles: CollapsedStyles
+  onSelect: (id: string) => void
+  onCloseMobile: () => void
+}
+
+/**
+ * The conversation history rail: a labeled nav whose rows select a conversation
+ * (and close the mobile drawer). The active row is highlighted; a row awaiting a
+ * reply shows a pulsing dot. Hidden entirely when the desktop rail is collapsed.
+ */
+export function ConversationList({
+  conversations,
+  activeId,
+  pendingIds,
+  styles,
+  onSelect,
+  onCloseMobile,
+}: ConversationListProps) {
+  return (
+    <nav
+      aria-label="Conversations"
+      className={cn("mt-4 flex-1 overflow-y-auto px-3 pb-5", styles.nav)}
+    >
+      <ul className="flex flex-col gap-0.5">
+        {conversations.map((conversation) => {
+          const active = conversation.id === activeId
+          const replying = pendingIds.has(conversation.id)
+          return (
+            <li key={conversation.id}>
+              <button
+                type="button"
+                aria-current={active ? "true" : undefined}
+                onClick={() => {
+                  onSelect(conversation.id)
+                  onCloseMobile()
+                }}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left text-sm transition-colors duration-300",
+                  active
+                    ? "bg-linen/[0.06] text-linen"
+                    : "text-ash hover:bg-linen/[0.03] hover:text-linen",
+                )}
+                title={conversation.title}
+              >
+                <span className="min-w-0 flex-1 truncate">
+                  {conversation.title}
+                </span>
+                {replying ? (
+                  <>
+                    <span
+                      aria-hidden="true"
+                      data-replying="true"
+                      className="size-1.5 shrink-0 rounded-full bg-lamplight [animation:vigil-pulse_2s_var(--ease-vigil)_infinite]"
+                    />
+                    <span className="sr-only">Replying</span>
+                  </>
+                ) : null}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/chat/src/components/shell/sidebar-header.test.tsx
+++ b/apps/chat/src/components/shell/sidebar-header.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { act, createRef } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { collapsedStyles } from "./sidebar-collapsed-styles"
+import { SidebarHeader } from "./sidebar-header"
+;(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+type Overrides = {
+  collapsed?: boolean
+  closeRef?: React.RefObject<HTMLButtonElement | null>
+  onToggleCollapsed?: () => void
+  onCloseMobile?: () => void
+}
+
+function render(overrides: Overrides = {}) {
+  const props = {
+    collapsed: overrides.collapsed ?? false,
+    styles: collapsedStyles(overrides.collapsed ?? false),
+    closeRef: overrides.closeRef ?? createRef<HTMLButtonElement>(),
+    onToggleCollapsed: overrides.onToggleCollapsed ?? (() => {}),
+    onCloseMobile: overrides.onCloseMobile ?? (() => {}),
+  }
+  act(() => {
+    root.render(<SidebarHeader {...props} />)
+  })
+}
+
+function buttonByLabel(label: string): HTMLButtonElement | undefined {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.getAttribute("aria-label") === label)
+}
+
+// Throws a descriptive error (not a bare undefined deref) if the button is
+// absent — mirrors app-shell.test.tsx's clickButton guard.
+function clickByLabel(label: string) {
+  const button = buttonByLabel(label)
+  if (!button) throw new Error(`button "${label}" not found`)
+  act(() => {
+    button.click()
+  })
+}
+
+describe("SidebarHeader", () => {
+  it("shows the collapse toggle (not the expand affordance) when expanded", () => {
+    render({ collapsed: false })
+    expect(buttonByLabel("Collapse sidebar")).toBeTruthy()
+    expect(buttonByLabel("Open sidebar")).toBeFalsy()
+    expect(container.textContent).toContain("jesusfilm.ai")
+  })
+
+  it("shows the expand affordance (not the collapse toggle) when collapsed", () => {
+    render({ collapsed: true })
+    expect(buttonByLabel("Open sidebar")).toBeTruthy()
+    expect(buttonByLabel("Collapse sidebar")).toBeFalsy()
+  })
+
+  it("fires onToggleCollapsed from the collapse toggle when expanded", () => {
+    const onToggleCollapsed = vi.fn()
+    render({ collapsed: false, onToggleCollapsed })
+    clickByLabel("Collapse sidebar")
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1)
+  })
+
+  it("fires onToggleCollapsed from the expand affordance when collapsed", () => {
+    const onToggleCollapsed = vi.fn()
+    render({ collapsed: true, onToggleCollapsed })
+    clickByLabel("Open sidebar")
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders the mobile close button in both collapsed states", () => {
+    // The X lives in the drawer regardless of the desktop collapse flag, so it
+    // must render whether expanded or collapsed.
+    render({ collapsed: false })
+    expect(buttonByLabel("Close sidebar")).toBeTruthy()
+    render({ collapsed: true })
+    expect(buttonByLabel("Close sidebar")).toBeTruthy()
+  })
+
+  it("fires onCloseMobile from the mobile close button", () => {
+    const onCloseMobile = vi.fn()
+    render({ onCloseMobile })
+    clickByLabel("Close sidebar")
+    expect(onCloseMobile).toHaveBeenCalledTimes(1)
+  })
+
+  it("forwards closeRef to the mobile close button so the drawer can focus it", () => {
+    const closeRef = createRef<HTMLButtonElement>()
+    render({ closeRef })
+    expect(closeRef.current).toBe(buttonByLabel("Close sidebar"))
+  })
+})

--- a/apps/chat/src/components/shell/sidebar-header.tsx
+++ b/apps/chat/src/components/shell/sidebar-header.tsx
@@ -1,0 +1,103 @@
+import { type RefObject } from "react"
+
+import { BrandLockup } from "@/components/brand/brand-lockup"
+import { cn } from "@/lib/cn"
+
+import { type CollapsedStyles } from "./sidebar-collapsed-styles"
+import { CloseIcon, PanelIcon } from "./icons"
+
+type SidebarHeaderProps = {
+  collapsed: boolean
+  styles: CollapsedStyles
+  closeRef: RefObject<HTMLButtonElement | null>
+  onToggleCollapsed: () => void
+  onCloseMobile: () => void
+}
+
+/**
+ * Sidebar top row: brand mark + wordmark on the left, and the three mutually
+ * exclusive controls on the right — the desktop collapse toggle (expanded
+ * only), the collapsed-rail expand affordance (hidden until the brand area is
+ * hovered/focused, with the "Open sidebar" tooltip), and the mobile drawer
+ * close (X, never on desktop). Purely presentational; collapse/close behavior
+ * is supplied by the parent via callbacks and `useSidebarChrome`.
+ */
+export function SidebarHeader({
+  collapsed,
+  styles,
+  closeRef,
+  onToggleCollapsed,
+  onCloseMobile,
+}: SidebarHeaderProps) {
+  return (
+    <div
+      className={cn("flex items-center gap-2 px-5 pt-6 pb-2", styles.header)}
+    >
+      <div
+        className={cn(
+          "group/brand relative flex min-w-0 flex-1 items-center",
+          styles.brand,
+        )}
+      >
+        {/* Brand mark + wordmark. When collapsed on desktop the wordmark is
+            hidden and the mark fades on hover to reveal the expand toggle. */}
+        <span className={cn("flex items-center gap-2.5", styles.brandMark)}>
+          <BrandLockup wordmark={false} />
+          <span
+            className={cn(
+              "whitespace-nowrap font-body text-[17px] font-medium tracking-[-0.005em] text-linen",
+              styles.wordmark,
+            )}
+          >
+            jesusfilm.ai
+          </span>
+        </span>
+
+        {/* Collapsed-only expand affordance: hidden until the brand area is
+            hovered/focused (desktop), with the Gemini "Open sidebar" tooltip. */}
+        {collapsed ? (
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            aria-label="Open sidebar"
+            className="absolute left-1/2 hidden size-10 -translate-x-1/2 items-center justify-center rounded-full text-linen opacity-0 transition-opacity duration-300 hover:bg-linen/[0.06] focus-visible:opacity-100 group-hover/brand:opacity-100 md:flex"
+          >
+            <PanelIcon className="size-5" />
+            {/* Visual tooltip only — aria-hidden so it doesn't duplicate the
+                button's "Open sidebar" accessible name. */}
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute left-[calc(100%+10px)] whitespace-nowrap rounded-lg bg-linen px-2.5 py-1 text-xs font-medium text-hearthblack opacity-0 transition-opacity duration-150 group-hover/brand:opacity-100"
+            >
+              Open sidebar
+            </span>
+          </button>
+        ) : null}
+      </div>
+
+      {/* Desktop collapse toggle (expanded only). */}
+      {!collapsed ? (
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-label="Collapse sidebar"
+          title="Collapse sidebar"
+          className="hidden size-9 shrink-0 items-center justify-center rounded-lg text-ash transition-colors duration-300 hover:bg-linen/[0.06] hover:text-linen md:inline-flex"
+        >
+          <PanelIcon className="size-5" />
+        </button>
+      ) : null}
+
+      {/* Mobile close (X) — always present in the drawer, never on desktop. */}
+      <button
+        ref={closeRef}
+        type="button"
+        onClick={onCloseMobile}
+        aria-label="Close sidebar"
+        className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-ash transition-colors duration-300 hover:bg-linen/[0.06] hover:text-linen md:hidden"
+      >
+        <CloseIcon className="size-5" />
+      </button>
+    </div>
+  )
+}

--- a/apps/chat/src/components/shell/sidebar-new-conversation.test.tsx
+++ b/apps/chat/src/components/shell/sidebar-new-conversation.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { collapsedStyles } from "./sidebar-collapsed-styles"
+import { NewConversationButton } from "./sidebar-new-conversation"
+;(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function render(onNew: () => void, onCloseMobile: () => void) {
+  act(() => {
+    root.render(
+      <NewConversationButton
+        styles={collapsedStyles(false)}
+        onNew={onNew}
+        onCloseMobile={onCloseMobile}
+      />,
+    )
+  })
+}
+
+describe("NewConversationButton", () => {
+  it("renders the labeled action", () => {
+    render(
+      () => {},
+      () => {},
+    )
+    expect(container.textContent).toContain("New conversation")
+  })
+
+  it("starts a new conversation and closes the mobile drawer on click", () => {
+    const onNew = vi.fn()
+    const onCloseMobile = vi.fn()
+    render(onNew, onCloseMobile)
+
+    const button = container.querySelector("button")
+    if (!button) throw new Error("New conversation button not found")
+    act(() => {
+      button.click()
+    })
+
+    // Both fire on a single click — a new chat also dismisses the drawer.
+    expect(onNew).toHaveBeenCalledTimes(1)
+    expect(onCloseMobile).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/chat/src/components/shell/sidebar-new-conversation.tsx
+++ b/apps/chat/src/components/shell/sidebar-new-conversation.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/cn"
+
+import { type CollapsedStyles } from "./sidebar-collapsed-styles"
+import { ComposeIcon } from "./icons"
+
+type NewConversationButtonProps = {
+  styles: CollapsedStyles
+  onNew: () => void
+  onCloseMobile: () => void
+}
+
+/**
+ * The "New conversation" action. Full-width labeled button when expanded or in
+ * the mobile drawer; a centered icon-only target when the desktop rail is
+ * collapsed. Starts a fresh conversation and closes the mobile drawer.
+ */
+export function NewConversationButton({
+  styles,
+  onNew,
+  onCloseMobile,
+}: NewConversationButtonProps) {
+  return (
+    <div className={cn("px-3 pt-4", styles.newButtonWrap)}>
+      <button
+        type="button"
+        onClick={() => {
+          onNew()
+          onCloseMobile()
+        }}
+        title="New conversation"
+        className={cn(
+          "flex w-full items-center gap-2.5 rounded-[10px] border border-linen/10 px-3.5 py-2.5 text-left text-sm font-medium text-linen transition-colors duration-300 hover:border-linen/20 hover:bg-linen/[0.04]",
+          styles.newButton,
+        )}
+      >
+        <ComposeIcon className="size-[18px] shrink-0 text-vesper" />
+        <span className={cn("whitespace-nowrap", styles.newButtonLabel)}>
+          New conversation
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/apps/chat/src/components/shell/sidebar.tsx
+++ b/apps/chat/src/components/shell/sidebar.tsx
@@ -1,12 +1,13 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
-
-import { BrandLockup } from "@/components/brand/brand-lockup"
 import { cn } from "@/lib/cn"
 import { type Conversation } from "@/lib/conversations"
 
-import { CloseIcon, ComposeIcon, PanelIcon } from "./icons"
+import { collapsedStyles } from "./sidebar-collapsed-styles"
+import { ConversationList } from "./sidebar-conversation-list"
+import { SidebarHeader } from "./sidebar-header"
+import { NewConversationButton } from "./sidebar-new-conversation"
+import { useSidebarChrome } from "./use-sidebar-chrome"
 
 type SidebarProps = {
   conversations: Conversation[]
@@ -30,7 +31,9 @@ export const SIDEBAR_ID = "app-sidebar"
  * toggle), and the mobile off-canvas drawer (slides in over a scrim, X to
  * close). Collapse is desktop-only — every collapsed style is `md:`-scoped, so
  * the drawer always shows full content. A brand extension built from the Vigil
- * tokens, not copied from the (single-surface) Vigil system.
+ * tokens, not copied from the (single-surface) Vigil system. Local UI mechanics
+ * (clip animation, Escape-to-close, drawer focus trap) live in
+ * `useSidebarChrome`; the collapsed-style policy lives in `collapsedStyles`.
  */
 export function Sidebar({
   conversations,
@@ -43,60 +46,15 @@ export function Sidebar({
   onToggleCollapsed,
   onCloseMobile,
 }: SidebarProps) {
-  const closeRef = useRef<HTMLButtonElement>(null)
-  const triggerRef = useRef<HTMLElement | null>(null)
+  const { clip, closeRef, handleToggleCollapsed, handleTransitionEnd } =
+    useSidebarChrome({
+      collapsed,
+      mobileOpen,
+      onToggleCollapsed,
+      onCloseMobile,
+    })
 
-  // Clip the rail while its width animates so expanded content is revealed
-  // left-to-right instead of reflowing; overflow is restored once collapsed and
-  // settled, so the "Open sidebar" tooltip can overflow to the right.
-  const [animatingCollapse, setAnimatingCollapse] = useState(false)
-  // Start clipping the moment a collapse/expand is initiated (not in an effect —
-  // that trips react-hooks/set-state-in-effect); onTransitionEnd clears it.
-  const handleToggleCollapsed = () => {
-    setAnimatingCollapse(true)
-    onToggleCollapsed()
-  }
-
-  // Clip during the width animation; keep overflow visible only once a collapsed
-  // rail has settled (so its hover tooltip can escape to the right).
-  const clip = animatingCollapse || !collapsed
-
-  // Fallback clear: if the width transitionend never fires (e.g. transitions
-  // disabled globally), drop the flag anyway so overflow can't latch hidden.
-  useEffect(() => {
-    if (!animatingCollapse) return
-    const id = setTimeout(() => setAnimatingCollapse(false), 400)
-    return () => clearTimeout(id)
-  }, [animatingCollapse])
-
-  // Escape closes the mobile drawer (parity with the X button and scrim).
-  useEffect(() => {
-    if (!mobileOpen) return
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onCloseMobile()
-    }
-    document.addEventListener("keydown", onKeyDown)
-    return () => document.removeEventListener("keydown", onKeyDown)
-  }, [mobileOpen, onCloseMobile])
-
-  // Mobile drawer focus: on open, store the trigger and focus the close button
-  // (AppShell marks <main> inert to trap focus); on close, restore the trigger.
-  // Desktop never enters this — `mobileOpen` is mobile-only.
-  useEffect(() => {
-    if (mobileOpen) {
-      triggerRef.current =
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : null
-      closeRef.current?.focus()
-    } else if (triggerRef.current) {
-      // Restore only if the trigger is still visible — after a resize past `md`
-      // the mobile hamburger is display:none, and focusing it drops focus to body.
-      const trigger = triggerRef.current
-      triggerRef.current = null
-      if (trigger.isConnected && trigger.offsetParent !== null) trigger.focus()
-    }
-  }, [mobileOpen])
+  const styles = collapsedStyles(collapsed)
 
   return (
     <>
@@ -118,9 +76,7 @@ export function Sidebar({
         role={mobileOpen ? "dialog" : undefined}
         aria-modal={mobileOpen ? true : undefined}
         aria-label={mobileOpen ? "Sidebar menu" : undefined}
-        onTransitionEnd={(event) => {
-          if (event.propertyName === "width") setAnimatingCollapse(false)
-        }}
+        onTransitionEnd={handleTransitionEnd}
         className={cn(
           "fixed inset-y-0 left-0 z-40 flex w-[300px] flex-col border-r border-linen/10",
           // Tailwind v4 maps translate-x-* to the `translate` property (not
@@ -138,158 +94,26 @@ export function Sidebar({
           collapsed ? "md:w-[68px]" : "md:w-[280px]",
         )}
       >
-        {/* Header: brand on the left, toggle/close on the right. */}
-        <div
-          className={cn(
-            "flex items-center gap-2 px-5 pt-6 pb-2",
-            collapsed && "md:px-0",
-          )}
-        >
-          <div
-            className={cn(
-              "group/brand relative flex min-w-0 flex-1 items-center",
-              collapsed && "md:justify-center",
-            )}
-          >
-            {/* Brand mark + wordmark. When collapsed on desktop the wordmark
-                is hidden and the mark fades on hover to reveal the expand
-                toggle beneath it. */}
-            <span
-              className={cn(
-                "flex items-center gap-2.5",
-                collapsed &&
-                  "md:transition-opacity md:duration-300 md:group-hover/brand:opacity-0 md:group-focus-within/brand:opacity-0",
-              )}
-            >
-              <BrandLockup wordmark={false} />
-              <span
-                className={cn(
-                  "whitespace-nowrap font-body text-[17px] font-medium tracking-[-0.005em] text-linen",
-                  collapsed && "md:hidden",
-                )}
-              >
-                jesusfilm.ai
-              </span>
-            </span>
-
-            {/* Collapsed-only expand affordance: hidden until the brand area
-                is hovered/focused (desktop), with the Gemini "Open sidebar"
-                tooltip. */}
-            {collapsed ? (
-              <button
-                type="button"
-                onClick={handleToggleCollapsed}
-                aria-label="Open sidebar"
-                className="absolute left-1/2 hidden size-10 -translate-x-1/2 items-center justify-center rounded-full text-linen opacity-0 transition-opacity duration-300 hover:bg-linen/[0.06] focus-visible:opacity-100 group-hover/brand:opacity-100 md:flex"
-              >
-                <PanelIcon className="size-5" />
-                {/* Visual tooltip only — aria-hidden so it doesn't duplicate
-                    the button's "Open sidebar" accessible name. */}
-                <span
-                  aria-hidden="true"
-                  className="pointer-events-none absolute left-[calc(100%+10px)] whitespace-nowrap rounded-lg bg-linen px-2.5 py-1 text-xs font-medium text-hearthblack opacity-0 transition-opacity duration-150 group-hover/brand:opacity-100"
-                >
-                  Open sidebar
-                </span>
-              </button>
-            ) : null}
-          </div>
-
-          {/* Desktop collapse toggle (expanded only). */}
-          {!collapsed ? (
-            <button
-              type="button"
-              onClick={handleToggleCollapsed}
-              aria-label="Collapse sidebar"
-              title="Collapse sidebar"
-              className="hidden size-9 shrink-0 items-center justify-center rounded-lg text-ash transition-colors duration-300 hover:bg-linen/[0.06] hover:text-linen md:inline-flex"
-            >
-              <PanelIcon className="size-5" />
-            </button>
-          ) : null}
-
-          {/* Mobile close (X) — always present in the drawer, never on desktop. */}
-          <button
-            ref={closeRef}
-            type="button"
-            onClick={onCloseMobile}
-            aria-label="Close sidebar"
-            className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-ash transition-colors duration-300 hover:bg-linen/[0.06] hover:text-linen md:hidden"
-          >
-            <CloseIcon className="size-5" />
-          </button>
-        </div>
-
-        {/* New conversation. Icon-only and centered when collapsed on desktop. */}
-        <div className={cn("px-3 pt-4", collapsed && "md:px-0")}>
-          <button
-            type="button"
-            onClick={() => {
-              onNew()
-              onCloseMobile()
-            }}
-            title="New conversation"
-            className={cn(
-              "flex w-full items-center gap-2.5 rounded-[10px] border border-linen/10 px-3.5 py-2.5 text-left text-sm font-medium text-linen transition-colors duration-300 hover:border-linen/20 hover:bg-linen/[0.04]",
-              collapsed &&
-                "md:mx-auto md:w-10 md:justify-center md:gap-0 md:border-transparent md:p-0 md:py-2.5 md:hover:border-transparent",
-            )}
-          >
-            <ComposeIcon className="size-[18px] shrink-0 text-vesper" />
-            <span className={cn("whitespace-nowrap", collapsed && "md:hidden")}>
-              New conversation
-            </span>
-          </button>
-        </div>
-
-        {/* Conversation history — hidden when collapsed on desktop. */}
-        <nav
-          aria-label="Conversations"
-          className={cn(
-            "mt-4 flex-1 overflow-y-auto px-3 pb-5",
-            collapsed && "md:hidden",
-          )}
-        >
-          <ul className="flex flex-col gap-0.5">
-            {conversations.map((conversation) => {
-              const active = conversation.id === activeId
-              const replying = pendingIds.has(conversation.id)
-              return (
-                <li key={conversation.id}>
-                  <button
-                    type="button"
-                    aria-current={active ? "true" : undefined}
-                    onClick={() => {
-                      onSelect(conversation.id)
-                      onCloseMobile()
-                    }}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-lg px-3.5 py-2.5 text-left text-sm transition-colors duration-300",
-                      active
-                        ? "bg-linen/[0.06] text-linen"
-                        : "text-ash hover:bg-linen/[0.03] hover:text-linen",
-                    )}
-                    title={conversation.title}
-                  >
-                    <span className="min-w-0 flex-1 truncate">
-                      {conversation.title}
-                    </span>
-                    {replying ? (
-                      <>
-                        <span
-                          aria-hidden="true"
-                          data-replying="true"
-                          className="size-1.5 shrink-0 rounded-full bg-lamplight [animation:vigil-pulse_2s_var(--ease-vigil)_infinite]"
-                        />
-                        <span className="sr-only">Replying</span>
-                      </>
-                    ) : null}
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        </nav>
+        <SidebarHeader
+          collapsed={collapsed}
+          styles={styles}
+          closeRef={closeRef}
+          onToggleCollapsed={handleToggleCollapsed}
+          onCloseMobile={onCloseMobile}
+        />
+        <NewConversationButton
+          styles={styles}
+          onNew={onNew}
+          onCloseMobile={onCloseMobile}
+        />
+        <ConversationList
+          conversations={conversations}
+          activeId={activeId}
+          pendingIds={pendingIds}
+          styles={styles}
+          onSelect={onSelect}
+          onCloseMobile={onCloseMobile}
+        />
       </aside>
     </>
   )

--- a/apps/chat/src/components/shell/use-sidebar-chrome.test.ts
+++ b/apps/chat/src/components/shell/use-sidebar-chrome.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode, useEffect } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useSidebarChrome } from "./use-sidebar-chrome"
+;(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+type HookProps = Parameters<typeof useSidebarChrome>[0]
+type Chrome = ReturnType<typeof useSidebarChrome>
+
+let container: HTMLDivElement
+let root: Root
+let latest: Chrome
+
+// Thin harness: calls the hook, publishes its return via `latest` from an effect
+// (act() flushes it, so `latest` is current after render()), and renders the
+// close button with the hook's ref so the focus-trap effect has a real target.
+function Harness(props: HookProps): ReactNode {
+  const chrome = useSidebarChrome(props)
+  useEffect(() => {
+    latest = chrome
+  })
+  return createElement("button", {
+    type: "button",
+    ref: chrome.closeRef,
+    "aria-label": "Close sidebar",
+  })
+}
+
+function render(props: HookProps) {
+  act(() => {
+    root.render(createElement(Harness, props))
+  })
+}
+
+const base: HookProps = {
+  collapsed: false,
+  mobileOpen: false,
+  onToggleCollapsed: () => {},
+  onCloseMobile: () => {},
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe("useSidebarChrome", () => {
+  it("clips while expanded and stops clipping once a collapsed rail has settled", () => {
+    render({ ...base, collapsed: false })
+    expect(latest.clip).toBe(true)
+
+    // Collapse with no animation flag set yet: a settled collapsed rail does
+    // not clip (so its tooltip can overflow).
+    render({ ...base, collapsed: true })
+    expect(latest.clip).toBe(false)
+  })
+
+  it("clips through the collapse animation until the width transition ends", () => {
+    const onToggleCollapsed = vi.fn()
+    render({ ...base, collapsed: false, onToggleCollapsed })
+
+    // Initiating a toggle sets the animating flag immediately.
+    act(() => {
+      latest.handleToggleCollapsed()
+    })
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1)
+
+    // Parent flips collapsed → true; clip stays true because we're animating.
+    render({ ...base, collapsed: true, onToggleCollapsed })
+    expect(latest.clip).toBe(true)
+
+    // The width transition ending clears the animating flag.
+    act(() => {
+      latest.handleTransitionEnd({
+        propertyName: "width",
+      } as Parameters<Chrome["handleTransitionEnd"]>[0])
+    })
+    expect(latest.clip).toBe(false)
+  })
+
+  it("ignores non-width transitions when clearing the animating flag", () => {
+    render({ ...base, collapsed: false })
+    act(() => {
+      latest.handleToggleCollapsed()
+    })
+    render({ ...base, collapsed: true })
+
+    act(() => {
+      latest.handleTransitionEnd({
+        propertyName: "opacity",
+      } as Parameters<Chrome["handleTransitionEnd"]>[0])
+    })
+    // Still animating — an unrelated transition must not drop the clip.
+    expect(latest.clip).toBe(true)
+  })
+
+  it("falls back to clearing the animating flag after 400ms if transitionend never fires", () => {
+    render({ ...base, collapsed: false })
+    act(() => {
+      latest.handleToggleCollapsed()
+    })
+    render({ ...base, collapsed: true })
+    expect(latest.clip).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+    expect(latest.clip).toBe(false)
+  })
+
+  it("closes the mobile drawer on Escape only while open", () => {
+    const onCloseMobile = vi.fn()
+    render({ ...base, mobileOpen: false, onCloseMobile })
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+    })
+    expect(onCloseMobile).not.toHaveBeenCalled()
+
+    render({ ...base, mobileOpen: true, onCloseMobile })
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+    })
+    expect(onCloseMobile).toHaveBeenCalledTimes(1)
+
+    // Other keys are ignored.
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }))
+    })
+    expect(onCloseMobile).toHaveBeenCalledTimes(1)
+  })
+
+  it("focuses the close button when the mobile drawer opens", () => {
+    render({ ...base, mobileOpen: false })
+    render({ ...base, mobileOpen: true })
+    expect(document.activeElement).toBe(
+      container.querySelector('button[aria-label="Close sidebar"]'),
+    )
+  })
+
+  it("removes the Escape listener when the drawer closes", () => {
+    const onCloseMobile = vi.fn()
+    render({ ...base, mobileOpen: true, onCloseMobile })
+    render({ ...base, mobileOpen: false, onCloseMobile })
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+    })
+    expect(onCloseMobile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/chat/src/components/shell/use-sidebar-chrome.ts
+++ b/apps/chat/src/components/shell/use-sidebar-chrome.ts
@@ -1,0 +1,105 @@
+"use client"
+
+import {
+  type RefObject,
+  type TransitionEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+type UseSidebarChromeOptions = {
+  collapsed: boolean
+  mobileOpen: boolean
+  onToggleCollapsed: () => void
+  onCloseMobile: () => void
+}
+
+type SidebarChrome = {
+  /** Whether the rail clips overflow right now (true while animating or expanded). */
+  clip: boolean
+  /** Attach to the mobile close (X) button so the drawer can focus it on open. */
+  closeRef: RefObject<HTMLButtonElement | null>
+  /** Wraps onToggleCollapsed to start the clip-during-animation flag. */
+  handleToggleCollapsed: () => void
+  /** Clears the clip flag once the rail's width transition finishes. */
+  handleTransitionEnd: (event: TransitionEvent<HTMLElement>) => void
+}
+
+/**
+ * Owns the sidebar's local UI mechanics so the JSX stays presentational: the
+ * collapse clip state machine (clip while the width animates, restore overflow
+ * once a collapsed rail settles so its tooltip can escape), an Escape listener
+ * that closes the mobile drawer, and the drawer focus trap (focus the close
+ * button on open; restore the trigger on close, only while it's still visible).
+ * State ownership (`collapsed`/`mobileOpen`) stays in AppShell — this hook only
+ * derives presentation from those flags and the toggle/close callbacks.
+ */
+export function useSidebarChrome({
+  collapsed,
+  mobileOpen,
+  onToggleCollapsed,
+  onCloseMobile,
+}: UseSidebarChromeOptions): SidebarChrome {
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const triggerRef = useRef<HTMLElement | null>(null)
+
+  // Clip the rail while its width animates so expanded content is revealed
+  // left-to-right instead of reflowing; overflow is restored once collapsed and
+  // settled, so the "Open sidebar" tooltip can overflow to the right.
+  const [animatingCollapse, setAnimatingCollapse] = useState(false)
+
+  // Start clipping the moment a collapse/expand is initiated (not in an effect —
+  // that trips react-hooks/set-state-in-effect); the transitionend clears it.
+  const handleToggleCollapsed = () => {
+    setAnimatingCollapse(true)
+    onToggleCollapsed()
+  }
+
+  // Clip during the width animation; keep overflow visible only once a collapsed
+  // rail has settled (so its hover tooltip can escape to the right).
+  const clip = animatingCollapse || !collapsed
+
+  const handleTransitionEnd = (event: TransitionEvent<HTMLElement>) => {
+    if (event.propertyName === "width") setAnimatingCollapse(false)
+  }
+
+  // Fallback clear: if the width transitionend never fires (e.g. transitions
+  // disabled globally), drop the flag anyway so overflow can't latch hidden.
+  useEffect(() => {
+    if (!animatingCollapse) return
+    const id = setTimeout(() => setAnimatingCollapse(false), 400)
+    return () => clearTimeout(id)
+  }, [animatingCollapse])
+
+  // Escape closes the mobile drawer (parity with the X button and scrim).
+  useEffect(() => {
+    if (!mobileOpen) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onCloseMobile()
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [mobileOpen, onCloseMobile])
+
+  // Mobile drawer focus: on open, store the trigger and focus the close button
+  // (AppShell marks <main> inert to trap focus); on close, restore the trigger.
+  // Desktop never enters this — `mobileOpen` is mobile-only.
+  useEffect(() => {
+    if (mobileOpen) {
+      triggerRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null
+      closeRef.current?.focus()
+    } else if (triggerRef.current) {
+      // Restore only if the trigger is still visible — after a resize past `md`
+      // the mobile hamburger is display:none, and focusing it drops focus to body.
+      const trigger = triggerRef.current
+      triggerRef.current = null
+      if (trigger.isConnected && trigger.offsetParent !== null) trigger.focus()
+    }
+  }, [mobileOpen])
+
+  return { clip, closeRef, handleToggleCollapsed, handleTransitionEnd }
+}

--- a/docs/roadmap/ai-chat/README.md
+++ b/docs/roadmap/ai-chat/README.md
@@ -11,23 +11,24 @@ from the main DS Year 1 roadmap.
 > index, and nothing regenerates or overwrites it. See `CLAUDE.md` in this
 > folder for the maintenance rules and why the lane is unregistered.
 
-## Status (June 24, 2026)
+## Status (June 25, 2026)
 
-- **Total tickets:** 8
+- **Total tickets:** 9
 - ✅ **Complete:** 4
-- 🟡 **In progress:** 0
+- 🟡 **In progress:** 1
 - 🔵 **Not started:** 4
 - 🔴 **Blocked:** 0
 
 ## Feature Index
 
-| ID                                                         | Feature                                                   | Owner    | Priority | Start      | Days | Status         | Code PR |
-| ---------------------------------------------------------- | --------------------------------------------------------- | -------- | -------- | ---------- | ---- | -------------- | ------- |
-| [feat-198](feat-198-seeker-agent-skeleton.md)              | Seeker Agent Skeleton                                     | jian wei | P2       | 2026-06-09 | 3    | ✅ complete    | #1279   |
-| [feat-199](feat-199-seeker-rag-retrieval-connection.md)    | Seeker Agent RAG Retrieval Connection                     | jian wei | P2       | 2026-06-10 | 3    | ✅ complete    | #1279   |
-| [feat-200](feat-200-chat-app-scaffold.md)                  | Chat app scaffold with stubbed agent                      | jian wei | P1       | 2026-06-10 | 3    | ✅ complete    | #1276   |
-| [feat-201](feat-201-chat-app-vigil-reskin.md)              | Chat app Vigil re-skin + conversation shell               | jian wei | P1       | 2026-06-15 | 1    | ✅ complete    | #1276   |
-| [feat-202](feat-202-seeker-rag-runtime-hardening.md)       | Seeker RAG runtime hardening                              | jian wei | P2       | 2026-06-18 | 2    | 🔵 not-started | —       |
-| [feat-203](feat-203-chat-sidebar-component-extraction.md)  | Chat sidebar component + behavior extraction              | jian wei | P2       | 2026-07-01 | 2    | 🔵 not-started | —       |
-| [feat-204](feat-204-expose-seeker-mastra-service-route.md) | Expose Seeker agent via internal Mastra SSE service route | jian wei | P2       | 2026-06-24 | 3    | 🔵 not-started | —       |
-| [feat-205](feat-205-chat-wire-seeker-route.md)             | Wire chat app to the Seeker Mastra route                  | jian wei | P1       | 2026-06-27 | 3    | 🔵 not-started | —       |
+| ID                                                           | Feature                                                   | Owner    | Priority | Start      | Days | Status         | Code PR |
+| ------------------------------------------------------------ | --------------------------------------------------------- | -------- | -------- | ---------- | ---- | -------------- | ------- |
+| [feat-198](feat-198-seeker-agent-skeleton.md)                | Seeker Agent Skeleton                                     | jian wei | P2       | 2026-06-09 | 3    | ✅ complete    | #1279   |
+| [feat-199](feat-199-seeker-rag-retrieval-connection.md)      | Seeker Agent RAG Retrieval Connection                     | jian wei | P2       | 2026-06-10 | 3    | ✅ complete    | #1279   |
+| [feat-200](feat-200-chat-app-scaffold.md)                    | Chat app scaffold with stubbed agent                      | jian wei | P1       | 2026-06-10 | 3    | ✅ complete    | #1276   |
+| [feat-201](feat-201-chat-app-vigil-reskin.md)                | Chat app Vigil re-skin + conversation shell               | jian wei | P1       | 2026-06-15 | 1    | ✅ complete    | #1276   |
+| [feat-202](feat-202-seeker-rag-runtime-hardening.md)         | Seeker RAG runtime hardening                              | jian wei | P2       | 2026-06-18 | 2    | 🔵 not-started | —       |
+| [feat-203](feat-203-chat-sidebar-component-extraction.md)    | Chat sidebar component + behavior extraction              | jian wei | P2       | 2026-07-01 | 2    | 🟡 in-progress | —       |
+| [feat-204](feat-204-expose-seeker-mastra-service-route.md)   | Expose Seeker agent via internal Mastra SSE service route | jian wei | P2       | 2026-06-24 | 3    | 🔵 not-started | —       |
+| [feat-205](feat-205-chat-wire-seeker-route.md)               | Wire chat app to the Seeker Mastra route                  | jian wei | P1       | 2026-06-27 | 3    | 🔵 not-started | —       |
+| [feat-206](feat-206-chat-introduce-react-testing-library.md) | Introduce React Testing Library to the chat app           | jian wei | P2       | 2026-07-03 | 2    | 🔵 not-started | —       |

--- a/docs/roadmap/ai-chat/README.md
+++ b/docs/roadmap/ai-chat/README.md
@@ -14,8 +14,8 @@ from the main DS Year 1 roadmap.
 ## Status (June 25, 2026)
 
 - **Total tickets:** 9
-- ✅ **Complete:** 4
-- 🟡 **In progress:** 1
+- ✅ **Complete:** 5
+- 🟡 **In progress:** 0
 - 🔵 **Not started:** 4
 - 🔴 **Blocked:** 0
 
@@ -28,7 +28,7 @@ from the main DS Year 1 roadmap.
 | [feat-200](feat-200-chat-app-scaffold.md)                    | Chat app scaffold with stubbed agent                      | jian wei | P1       | 2026-06-10 | 3    | ✅ complete    | #1276   |
 | [feat-201](feat-201-chat-app-vigil-reskin.md)                | Chat app Vigil re-skin + conversation shell               | jian wei | P1       | 2026-06-15 | 1    | ✅ complete    | #1276   |
 | [feat-202](feat-202-seeker-rag-runtime-hardening.md)         | Seeker RAG runtime hardening                              | jian wei | P2       | 2026-06-18 | 2    | 🔵 not-started | —       |
-| [feat-203](feat-203-chat-sidebar-component-extraction.md)    | Chat sidebar component + behavior extraction              | jian wei | P2       | 2026-07-01 | 2    | 🟡 in-progress | —       |
+| [feat-203](feat-203-chat-sidebar-component-extraction.md)    | Chat sidebar component + behavior extraction              | jian wei | P2       | 2026-07-01 | 2    | ✅ complete    | #1368   |
 | [feat-204](feat-204-expose-seeker-mastra-service-route.md)   | Expose Seeker agent via internal Mastra SSE service route | jian wei | P2       | 2026-06-24 | 3    | 🔵 not-started | —       |
 | [feat-205](feat-205-chat-wire-seeker-route.md)               | Wire chat app to the Seeker Mastra route                  | jian wei | P1       | 2026-06-27 | 3    | 🔵 not-started | —       |
 | [feat-206](feat-206-chat-introduce-react-testing-library.md) | Introduce React Testing Library to the chat app           | jian wei | P2       | 2026-07-03 | 2    | 🔵 not-started | —       |

--- a/docs/roadmap/ai-chat/feat-201-chat-app-vigil-reskin.md
+++ b/docs/roadmap/ai-chat/feat-201-chat-app-vigil-reskin.md
@@ -10,6 +10,7 @@ depends_on:
   - "feat-200"
 blocks:
   - "feat-203"
+  - "feat-206"
 tags: []
 ---
 

--- a/docs/roadmap/ai-chat/feat-203-chat-sidebar-component-extraction.md
+++ b/docs/roadmap/ai-chat/feat-203-chat-sidebar-component-extraction.md
@@ -3,7 +3,7 @@ id: "feat-203"
 title: "Chat sidebar component + behavior extraction"
 owner: "jian wei"
 priority: "P2"
-status: "not-started"
+status: "in-progress"
 start_date: "2026-07-01"
 duration: 2
 depends_on:

--- a/docs/roadmap/ai-chat/feat-203-chat-sidebar-component-extraction.md
+++ b/docs/roadmap/ai-chat/feat-203-chat-sidebar-component-extraction.md
@@ -3,7 +3,7 @@ id: "feat-203"
 title: "Chat sidebar component + behavior extraction"
 owner: "jian wei"
 priority: "P2"
-status: "in-progress"
+status: "complete"
 start_date: "2026-07-01"
 duration: 2
 depends_on:
@@ -12,6 +12,14 @@ blocks: []
 tags:
   - "web"
 ---
+
+## Resolution
+
+**Shipped:** 2026-06-25 via [PR #1368](https://github.com/JesusFilm/forge/pull/1368) (`feat(chat): extract sidebar into hook + sub-components (feat-203)`).
+
+**What landed.** Pure refactor, no behavior change. `sidebar.tsx` (~296 lines) was split into a `useSidebarChrome` hook (the clip-during-collapse state machine + 400ms fallback timer, the Escape-to-close listener, and the mobile-drawer focus trap/restore) plus three presentational sub-components — `SidebarHeader`, `NewConversationButton`, `ConversationList` — with the dispersed `collapsed &&` classes consolidated into a single `collapsedStyles` slot map; the shell now reads ~120 lines. State ownership stayed in `AppShell` per the brief, and the rail was deliberately **not** split by viewport. Added a `useSidebarChrome` unit test plus colocated component and slot-map tests (33 new), keeping the existing `app-shell.test.tsx` behavioral suite green with only import-path changes. Browser-verified in Chromium: desktop collapse/expand (clip reveal + icon rail), mobile drawer open/close, and dialog/focus-trap/focus-restore all behave identically to before.
+
+**Residual risk / follow-ups.** [feat-206](feat-206-chat-introduce-react-testing-library.md) was filed off this work — adopting React Testing Library for `apps/chat` would retire the hand-rolled `react-dom`/`act` plumbing and the `useEffect`-capture hook-test workaround this refactor leaned on. The focus-restore-on-close path stays browser-verified only, since jsdom has no layout (`offsetParent` is always null).
 
 ## Problem
 

--- a/docs/roadmap/ai-chat/feat-203-chat-sidebar-component-extraction.md
+++ b/docs/roadmap/ai-chat/feat-203-chat-sidebar-component-extraction.md
@@ -19,6 +19,8 @@ tags:
 
 **What landed.** Pure refactor, no behavior change. `sidebar.tsx` (~296 lines) was split into a `useSidebarChrome` hook (the clip-during-collapse state machine + 400ms fallback timer, the Escape-to-close listener, and the mobile-drawer focus trap/restore) plus three presentational sub-components — `SidebarHeader`, `NewConversationButton`, `ConversationList` — with the dispersed `collapsed &&` classes consolidated into a single `collapsedStyles` slot map; the shell now reads ~120 lines. State ownership stayed in `AppShell` per the brief, and the rail was deliberately **not** split by viewport. Added a `useSidebarChrome` unit test plus colocated component and slot-map tests (33 new), keeping the existing `app-shell.test.tsx` behavioral suite green with only import-path changes. Browser-verified in Chromium: desktop collapse/expand (clip reveal + icon rail), mobile drawer open/close, and dialog/focus-trap/focus-restore all behave identically to before.
 
+**Compound docs.** [worktree-pnpm-install-8mb-file-truncation](../../solutions/build-errors/worktree-pnpm-install-8mb-file-truncation-20260624.md) — an incident note produced during this work (a fresh-worktree `pnpm install` truncating large `node_modules` files to exactly 8 MiB); tangential to the sidebar feature itself, but written and shipped in the same PR.
+
 **Residual risk / follow-ups.** [feat-206](feat-206-chat-introduce-react-testing-library.md) was filed off this work — adopting React Testing Library for `apps/chat` would retire the hand-rolled `react-dom`/`act` plumbing and the `useEffect`-capture hook-test workaround this refactor leaned on. The focus-restore-on-close path stays browser-verified only, since jsdom has no layout (`offsetParent` is always null).
 
 ## Problem

--- a/docs/roadmap/ai-chat/feat-206-chat-introduce-react-testing-library.md
+++ b/docs/roadmap/ai-chat/feat-206-chat-introduce-react-testing-library.md
@@ -1,0 +1,84 @@
+---
+id: "feat-206"
+title: "Introduce React Testing Library to the chat app"
+owner: "jian wei"
+priority: "P2"
+status: "not-started"
+start_date: "2026-07-03"
+duration: 2
+depends_on:
+  - "feat-201"
+blocks: []
+tags:
+  - "web"
+---
+
+## Problem
+
+`apps/chat` tests use the monorepo's plain `react-dom/client` + `act` +
+`// @vitest-environment jsdom` convention with **no** Testing Library (inherited
+from the `apps/admin` style). For this app that convention has become a tax, and
+chat is **intentionally separate** from `apps/admin`/`apps/web`, so it can adopt
+RTL without forcing a monorepo-wide change:
+
+- The suite is **interaction-heavy** and most of `app-shell.test.tsx` (~586
+  lines) is hand-rolled DOM plumbing that exists only because there is no
+  `user-event`: typing via the `HTMLTextAreaElement.prototype` value-setter,
+  raw `dispatchEvent(new KeyboardEvent(...))` for Enter/Escape, manual
+  `submit` events, and bespoke `buttonByLabel`/`clickButton`/`getTextarea`
+  query helpers re-implemented per file.
+- Hooks need a **workaround**: `use-sidebar-chrome.test.ts` publishes the hook's
+  return through a `useEffect` into a module-level `latest` because there is no
+  `renderHook`.
+- The app is about to become **async**: feat-205 wires the Seeker Mastra route,
+  replacing the synchronous stub with a rejectable, possibly-hanging call plus
+  error/timeout/loading states. `findBy`/`waitFor` + `user-event` are far
+  cleaner there than the current `vi.useFakeTimers()` + manual `act` juggling.
+
+RTL does **not** fix the one jsdom gap we hit (focus-restore-on-close depends on
+`offsetParent`, which jsdom can't represent) — that stays a browser check.
+
+Ideally land this **before** feat-205's async wiring (so those tests are written
+in RTL from the start) and **after** feat-203's sidebar test churn settles (so
+the suite is migrated once). Neither is a hard blocker.
+
+## Entry Points — Read These First
+
+1. `apps/chat/vitest.config.ts` — `environment: "node"` with per-file jsdom opt-in; no `setupFiles`. The place to flip the default env and wire a setup file.
+2. `apps/chat/package.json` — devDeps currently `vitest`, `jsdom`, no `@testing-library/*`. Add the RTL deps here.
+3. `apps/chat/src/components/shell/app-shell.test.tsx` — the 586-line behavioral suite carrying the bulk of the hand-rolled plumbing; the biggest migration win.
+4. `apps/chat/src/components/shell/use-sidebar-chrome.test.ts` — the hook test whose `useEffect`-capture harness `renderHook` replaces outright.
+5. `apps/chat/src/components/shell/sidebar-*.test.tsx` and `src/lib/*.test.ts` — the remaining colocated tests to migrate (or leave: `conversations.test.ts` / `chat-stub.test.ts` are pure-function and need no RTL).
+6. `apps/chat/CLAUDE.md` → "Key Conventions" — currently mandates the no-testing-library style; update it to record the deliberate divergence and the browser-verify caveat.
+
+## Grep These
+
+- `IS_REACT_ACT_ENVIRONMENT` — per-file flag the RTL migration removes.
+- `Object.getOwnPropertyDescriptor(HTMLTextAreaElement` — the value-setter typing hack `user.type` replaces.
+- `dispatchEvent(new KeyboardEvent` / `new Event("submit"` — raw events `user.keyboard`/`user.click` replace.
+- `createRoot(` / `import { act }` — boilerplate RTL `render` + auto-cleanup subsumes.
+- `// @vitest-environment jsdom` — per-file directives droppable once the config default is jsdom.
+
+## What To Build
+
+1. **Add dev deps** pinned for React 19: `@testing-library/react` (v16+), `@testing-library/user-event`, `@testing-library/jest-dom`.
+2. **Add `apps/chat/vitest.setup.ts`**: `import "@testing-library/jest-dom/vitest"` and an `afterEach(cleanup)`; wire it via `setupFiles` in `vitest.config.ts` and set `test.environment: "jsdom"` as the app default (drop per-file directives).
+3. **Migrate the suite** (small — ~1,160 lines across 8 files): replace the hand-rolled helpers with `screen` role/label queries + `user-event`; move `use-sidebar-chrome.test.ts` to `renderHook` (`result.current` + `rerender`); leave pure-function tests as plain vitest.
+4. **Update `apps/chat/CLAUDE.md`**: document that chat deliberately diverges from the `apps/admin`/`apps/web` no-testing-library convention, and keep the note that focus-visibility/layout behavior (e.g. focus-restore-on-close) is browser-verified because jsdom has no layout.
+5. **Confirm the retired convention doc is gone**: the `docs/solutions/best-practices/unit-testing-react-hooks-plain-react-dom-act-*.md` learning existed only to work around the missing `renderHook`; it should not be reintroduced.
+
+## Constraints
+
+- **`apps/chat` only.** Do not touch `apps/admin`/`apps/web` tests or add RTL to the root — this divergence is scoped to chat by design.
+- **No behavior-coverage regression.** Every existing assertion must survive the migration; this is a test-mechanism swap, not a coverage change.
+- **Separate PR from feat-203.** Do not fold the framework swap into the sidebar refactor — it muddies that PR's "no behavior change, tests stay green" story.
+- **RTL does not replace browser checks.** jsdom still can't represent layout/visibility; keep the browser-verified items as such.
+- Avoid a long-lived mixed-style state — migrate the whole (small) suite in one pass rather than leaving half on each convention.
+
+## Verification
+
+- `pnpm --filter @forge/chat test` — all tests pass; count of assertions not reduced.
+- `pnpm --filter @forge/chat lint` and `... typecheck` — clean.
+- Grep is clean of the retired plumbing: no `IS_REACT_ACT_ENVIRONMENT`, no `HTMLTextAreaElement.prototype` value-setter, no raw `KeyboardEvent`/`submit` dispatch, no bare `createRoot`/`act` harness in the migrated component tests.
+- `use-sidebar-chrome.test.ts` uses `renderHook` (no module-level `latest` / `useEffect`-capture harness).
+- `apps/chat/CLAUDE.md` reflects the new convention and the browser-verify caveat.

--- a/docs/solutions/build-errors/worktree-pnpm-install-8mb-file-truncation-20260624.md
+++ b/docs/solutions/build-errors/worktree-pnpm-install-8mb-file-truncation-20260624.md
@@ -1,0 +1,142 @@
+---
+title: "Fresh git worktree: pnpm install truncates large node_modules files at exactly 8MB"
+date: "2026-06-24"
+category: build-errors
+module: git-worktrees
+problem_type: build_error
+component: tooling
+severity: high
+symptoms:
+  - 'esbuild crashes loading any config: "The service was stopped: write EPIPE" (vitest, tsx, anything esbuild-backed)'
+  - 'eslint crashes requiring typescript: "typescript.js:NNNNN SyntaxError: Invalid or unexpected token"'
+  - "pnpm rebuild esbuild fails in postinstall with the same EPIPE — the binary itself is corrupt"
+  - "tsc-based typecheck still passes while vitest and eslint both fail, masking the real cause"
+  - "the broken files are all exactly 8388608 bytes (8 MiB): typescript.js, the turbo binary, the @esbuild platform binary"
+root_cause: incomplete_setup
+resolution_type: environment_setup
+related_components:
+  - development_workflow
+tags:
+  - pnpm
+  - git-worktree
+  - esbuild
+  - typescript
+  - turbo
+  - devcontainer
+  - monorepo
+  - vitest
+---
+
+> **Confidence note.** This was a **single, unreproduced occurrence**. The
+> symptoms, the 8 MiB signature, and both recovery paths below are recorded
+> as observed; the root cause (see "Why This Works") is a **hypothesis**, not a
+> confirmed mechanism. Treat this as an incident note with a working recovery,
+> and rule out the alternative causes listed under Prevention before assuming
+> the filesystem theory. (The `severity: high` in the frontmatter reflects
+> _impact_ — a fully broken test/lint toolchain when it hits — not frequency;
+> this was seen once.)
+
+## Problem
+
+In a freshly-created git worktree, `pnpm install --frozen-lockfile` produced
+node_modules files larger than 8 MiB truncated to exactly 8388608 bytes,
+corrupting the `typescript`, `turbo`, and `esbuild` binaries/bundles. `vitest`
+and `eslint` then crashed with unrelated-looking errors, while `tsc`-based
+typecheck kept passing — masking the real cause.
+
+## Symptoms
+
+- `pnpm --filter <pkg> test` (vitest): `Error: The service was stopped: write EPIPE` thrown from `esbuild/lib/main.js` while loading `vitest.config.ts`.
+- `pnpm --filter <pkg> lint` (eslint): `typescript.js:182489 case 263 /* F  ^^^^  SyntaxError: Invalid or unexpected token` — `@typescript-eslint` `require()`-ing a truncated `typescript.js`.
+- `pnpm rebuild esbuild` re-runs the postinstall and fails the same way — the platform binary is itself truncated, so re-running the install step does not heal it.
+- **Tell-tale signature:** in this occurrence the broken files were all _exactly_ `8388608` bytes (`8 * 1024 * 1024`). `find node_modules -type f -size 8388608c` listed exactly the files that had been larger than 8 MiB. This grep is a strong first signal, not a proof — see the false-positive/negative caveat under Prevention.
+
+## What Didn't Work
+
+- **`pnpm rebuild esbuild`** — re-runs esbuild's postinstall, which itself shells out to the truncated binary and dies with the same EPIPE. Rebuilding does not re-fetch/re-link a clean file.
+- **Trusting typecheck as a health signal** — `tsc --noEmit` passed throughout. In this case the truncation point happened to fall _after_ the entrypoint `tsc` loads, so `tsc` survived while eslint's `require("typescript")` of the truncated `lib/typescript.js` did not. This is content-dependent: a cut at a different offset could break `tsc` too, so a green typecheck is not evidence the toolchain is healthy.
+- **Assuming it was an esbuild-version or config problem** — the EPIPE looks like an esbuild service bug, but the same 8 MiB truncation hit `typescript.js` and the `turbo` binary too. Chasing esbuild alone would have missed the other two.
+
+## Solution
+
+### Default: clean reinstall, then re-smoke immediately
+
+Because the corruption happens _during_ the install, the first move is to redo
+the install and verify before trusting it — this assumes nothing about any
+other checkout:
+
+```bash
+cd <worktree>
+rm -rf node_modules
+pnpm install --frozen-lockfile
+
+# Re-smoke immediately — the install itself is what truncated last time, so a
+# clean reinstall can reproduce it. If the find prints anything, retry the
+# reinstall (or fall back to the copy recipe below).
+find node_modules -type f -size 8388608c   # expect: no output (necessary, not sufficient — the test+lint below is the real check)
+pnpm --filter <pkg> test && pnpm --filter <pkg> lint
+```
+
+### Escape hatch: copy intact files from a known-good checkout
+
+Faster than a full reinstall, but only valid under strict preconditions. Reach
+for this only if the default reinstall's re-smoke still prints truncated files,
+or a reinstall is impractically slow — otherwise stop at the default.
+
+**Preconditions — all three must hold, or you risk silently installing wrong
+bytes (worse than the loud crash you're fixing):**
+
+1. The source checkout is the **same OS + CPU architecture** (the store paths bake in the platform, e.g. `@esbuild+linux-arm64`, `turbo-linux-arm64`).
+2. It pins the **same pnpm version** (`corepack`/`packageManager`) and the **same lockfile** — so the `.pnpm` store layout matches.
+3. Its copy of each file is **itself intact** — the `test`+`lint` smoke below is what actually confirms this; the `8388608c` size re-check only catches a source file truncated to the _same_ 8 MiB, not corruption of another size/shape.
+
+```bash
+cd <worktree>
+SRC=/workspace   # a known-good checkout meeting all three preconditions above
+
+# Drive the copy off the ACTUAL truncated paths — no version guessing. Each
+# discovered path is relative (node_modules/.pnpm/typescript@<real-ver>/...),
+# so it maps 1:1 onto $SRC. If the path doesn't exist under $SRC (e.g. arch
+# mismatch), cp errors loudly instead of silently copying nothing.
+find node_modules -type f -size 8388608c | while read -r f; do
+  cp "$SRC/$f" "$f" || echo "MISSING IN SRC: $f  (arch/version mismatch?)"
+done
+
+# Verify: nothing still 8 MiB (catches a source file that was ALSO truncated),
+# then smoke the toolchain.
+find node_modules -type f -size 8388608c   # expect: no output (necessary, not sufficient — the test+lint below is the real check)
+pnpm --filter <pkg> test && pnpm --filter <pkg> lint
+```
+
+Any `MISSING IN SRC` line means the recovery is incomplete (usually a wrong-arch
+or wrong-version `$SRC`) — fix the source and re-run; don't trust the smoke until
+the copy loop is clean.
+
+After recovery, `vitest`, `eslint`, and `tsc` all run normally in the worktree.
+(Symlinking the worktree's esbuild package dir to the source checkout's also
+works, but a straight `cp` is simpler and avoids cross-tree symlink surprises.)
+
+## Why This Works
+
+The recovery works regardless of root cause: it replaces invalid bytes at the
+exact store paths the resolver already points at, and the re-smoke confirms the
+result. The copy path additionally relies on the source checkout being the same
+OS/arch + pnpm version + lockfile, so its `.pnpm` virtual-store layout is what
+the worktree expects.
+
+**The cause itself is unconfirmed.** The observation is a _write-side_
+truncation during the worktree install — files clipped to exactly 8 MiB, a hard
+power-of-two boundary. That pattern is _consistent with_ an overlay/copy quirk
+in the devcontainer filesystem under concurrent large-file writes, but it was
+seen once and never isolated (no repro, no filesystem/kernel log captured). 8
+MiB is a generic buffer/limit boundary, not a fingerprint unique to any one
+cause — do not let "almost certainly the filesystem" foreclose diagnosis if you
+hit this again.
+
+## Prevention
+
+- **After creating a worktree and running `pnpm install`, smoke the toolchain before trusting it** — run `test` AND `lint`, not just `typecheck` (which can pass over the corruption, as above). As a fast pre-check, `find node_modules -type f -size 8388608c` is a **strong signal worth investigating** — though a file that is legitimately exactly 8 MiB would be a rare false positive, and corruption at a _different_ size or shape would be a false negative. Pair it with the test+lint smoke as the authoritative check, not the grep alone.
+- **Don't reach for `pnpm rebuild`** when a binary is corrupt this way — it re-invokes the broken binary. Use the clean reinstall (default) or the copy escape hatch above.
+- **Before blaming the devcontainer filesystem, rule out other 8 MiB-boundary causes** that produce the same clean truncation: an `RLIMIT_FSIZE` / `ulimit -f` file-size cap on the install process, `ENOSPC` or a disk-quota limit hit mid-write, or an OOM-killed / aborted install. These have different fixes than "retry the install."
+- This is distinct from the two known worktree gotchas already documented: the missing-`lint-staged`-binary husky failure (`.claude/rules/worktree-commit-husky.dev.md`, fixed by `pnpm install`) and `docs/solutions/platform/devcontainer-setup.md` (corepack/pnpm version pinning). Neither heals an 8 MiB truncation — this needs the reinstall or file-replace above.
+- If it recurs, capture evidence before recovering (the exact truncated paths, `ulimit -a`, `df -h`, `dmesg`/OOM logs) so the cause can finally be isolated rather than band-aided again.


### PR DESCRIPTION
## Summary

Three related-but-separable changes, in their own commits:

1. **`feat(chat)` — sidebar refactor (feat-203).** Pure refactor of `apps/chat`'s sidebar, **no behavior change**. Extracts the clip / Escape / focus-trap mechanics into a `useSidebarChrome` hook, splits `SidebarHeader` / `NewConversationButton` / `ConversationList` out of `sidebar.tsx`, and consolidates the dispersed `collapsed &&` classes into a single `collapsedStyles` slot map. `sidebar.tsx` drops from ~296 → ~120 lines. Adds hook + component unit tests.
2. **`docs(solutions)` — worktree 8 MB truncation note.** An incident note for a fresh-worktree `pnpm install` that truncated large `node_modules` files (typescript, turbo, esbuild) to exactly 8 MiB, surfacing as an esbuild EPIPE + a `typescript.js` SyntaxError while typecheck still passed. Records the diagnostic signature and two recovery paths; root cause is explicitly framed as an unconfirmed hypothesis.
3. **`docs(roadmap)` — feat-206 ticket.** Adds feat-206 (introduce React Testing Library to `apps/chat`) to the ai-chat lane with the bidirectional feat-201 link, flips feat-203 to `in-progress`, and updates the hand-maintained lane README.

## Why these are together

They emerged from one working session on feat-203. The solution doc and the roadmap ticket are independent of the refactor; they're bundled here by choice. Reviewers can read commit-by-commit — each commit is self-contained.

## Verification

- `pnpm --filter @forge/chat test` — 63 tests pass (30 pre-existing behavioral + 33 new hook/component/slot-map tests).
- `pnpm --filter @forge/chat lint` and `... typecheck` — clean.
- Browser-verified in headless Chromium: desktop collapse/expand (clip reveal, icon rail), mobile drawer open/close, dialog semantics + focus-trap + focus-restore — all behave identically to before the refactor.
- The refactor is behavior-preserving: the existing `app-shell.test.tsx` suite passes unchanged (only import paths moved).

## Notes

- `feat-203` is marked `in-progress`; flip it to `complete` (with a `## Resolution` block per the ai-chat lane convention) when this merges.
- The 8 MB truncation doc documents a single, unreproduced occurrence — kept deliberately, framed as an incident note rather than a confirmed-cause solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYuMJtM7ev2jybwNUpVATV
