### PR TITLE
perf(search): optimize admin search hot path

### DIFF
--- a/apps/admin/src/services/hybrid-search-health.ts
+++ b/apps/admin/src/services/hybrid-search-health.ts
@@ -1,8 +1,8 @@
 /**
  * Process-local counters and last-error state for query-embedding operations.
  *
- * Used by the search orchestrator to track attempts and failures of the
- * OpenRouter embedding call, and by the health probe endpoint to surface
+ * Used by the search orchestrator to track attempts and failures of actual
+ * OpenRouter embedding calls, and by the health probe endpoint to surface
  * that state to external monitors (Railway healthchecks, uptime tools,
  * curl-based checks) without requiring log tailing.
  *
@@ -33,7 +33,7 @@ export type SearchHealthStats = {
   lastErrorAt: string | null
 }
 
-/** Increment attempts counter. Call before every `embedQuery` invocation. */
+/** Increment attempts counter before each real provider request. */
 export function recordAttempt(): void {
   attempts += 1
 }

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -312,11 +312,15 @@ describe("searchVideoSemantic", () => {
     expect(sql).not.toContain("vsl.locale =")
     expect(sql).toContain("vtc.language =")
     expect(sql).toContain("vt.language =")
+    expect(sql).toContain("query_embedding AS MATERIALIZED")
     expect(sql).toContain("requested_language AS MATERIALIZED")
+    expect(
+      latestRawValues(prisma).filter((value) => value === "[0.1,0.2]"),
+    ).toHaveLength(1)
 
     const transcriptSource = sqlBetween(
       sqlWithFragments,
-      "WITH transcript_source AS",
+      "transcript_source AS",
       "requested_language AS MATERIALIZED",
     )
     const transcriptOrderIndex = transcriptSource.indexOf("ORDER BY")

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -331,7 +331,10 @@ export async function searchVideoSemantic(
     timing,
     "semantic-video.query",
     () => prisma.$queryRaw<VideoSemanticEvidenceRow[]>`
-      WITH transcript_source AS (
+      WITH query_embedding AS MATERIALIZED (
+        SELECT ${queryEmbedding}::vector AS embedding
+      ),
+      transcript_source AS (
         SELECT * FROM (
           SELECT DISTINCT ON (vt.video_id)
             vt.video_id                       AS video_id,
@@ -347,8 +350,9 @@ export async function searchVideoSemantic(
               vtc.text
             )                                 AS scene_description,
             vtc.start_seconds                 AS start_seconds,
-            1 - (vtc.embedding <=> ${queryEmbedding}::vector) AS source_score
+            1 - (vtc.embedding <=> qe.embedding) AS source_score
           FROM video_transcript_chunk vtc
+          CROSS JOIN query_embedding qe
           JOIN video_transcript vt ON vt.id = vtc.transcript_id
             AND vt.language = ${locale}
           JOIN video v ON v.id = vt.video_id
@@ -363,7 +367,7 @@ export async function searchVideoSemantic(
             AND vtc.language = ${locale}
           ORDER BY
             vt.video_id,
-            vtc.embedding <=> ${queryEmbedding}::vector,
+            vtc.embedding <=> qe.embedding,
             vtc.start_seconds ASC NULLS LAST,
             vtc.id ASC
         ) best_transcript_per_video

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -57,6 +57,10 @@ const mockPrisma = {
     // `prisma.video.findMany`) doesn't crash these tests.
     findMany: vi.fn().mockResolvedValue([]),
   },
+  videoLocale: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  $queryRaw: vi.fn().mockResolvedValue([]),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any
 const successEmbedder = (): QueryEmbedder =>
@@ -237,6 +241,8 @@ beforeEach(() => {
   vi.mocked(searchExperienceKeyword).mockResolvedValue([])
   // Restore default hydration stub after clearAllMocks wipes it.
   mockPrisma.video.findMany.mockResolvedValue([])
+  mockPrisma.videoLocale.findMany.mockResolvedValue([])
+  mockPrisma.$queryRaw.mockResolvedValue([])
 })
 
 describe("Bible Project headline (keyword-first mode)", () => {

--- a/apps/admin/src/services/hybrid-search.debug.test.ts
+++ b/apps/admin/src/services/hybrid-search.debug.test.ts
@@ -51,6 +51,10 @@ const mockPrisma = {
     // `prisma.video.findMany`) doesn't crash these tests.
     findMany: vi.fn().mockResolvedValue([]),
   },
+  videoLocale: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  $queryRaw: vi.fn().mockResolvedValue([]),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any
 const successEmbedder = (): QueryEmbedder =>
@@ -61,6 +65,8 @@ beforeEach(() => {
   __resetSearchHealthForTest()
   // Restore default hydration stub after clearAllMocks wipes it.
   mockPrisma.video.findMany.mockResolvedValue([])
+  mockPrisma.videoLocale.findMany.mockResolvedValue([])
+  mockPrisma.$queryRaw.mockResolvedValue([])
   vi.mocked(searchVideoSemantic).mockResolvedValue([])
   vi.mocked(searchExperienceSemantic).mockResolvedValue([])
   vi.mocked(searchExperienceKeyword).mockResolvedValue([])

--- a/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
+++ b/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
@@ -82,6 +82,15 @@ function buildDebugByKey(
   return map
 }
 
+function mockHydrationPrisma() {
+  return {
+    video: { findMany: vi.fn().mockResolvedValue([]) },
+    videoLocale: { findMany: vi.fn().mockResolvedValue([]) },
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
 describe("applyDilutionCap", () => {
   it("does NOT trigger when no exact-title hit covers every query token", () => {
     // Query: "the bible project". Exact-title list has one item but its
@@ -428,8 +437,7 @@ describe("HybridSearchService skips dilution cap when SEARCH_DILUTION_CAP_ENABLE
     process.env.SEARCH_DILUTION_CAP_ENABLED = "false"
 
     const service = new HybridSearchService({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prisma: { video: { findMany: vi.fn().mockResolvedValue([]) } } as any,
+      prisma: mockHydrationPrisma(),
       embedder: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
       logger: { warn: vi.fn(), error: vi.fn() },
     })
@@ -490,8 +498,7 @@ describe("HybridSearchService skips dilution cap when SEARCH_DILUTION_CAP_ENABLE
     delete process.env.SEARCH_DILUTION_CAP_ENABLED
 
     const service = new HybridSearchService({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prisma: { video: { findMany: vi.fn().mockResolvedValue([]) } } as any,
+      prisma: mockHydrationPrisma(),
       embedder: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
       logger: { warn: vi.fn(), error: vi.fn() },
     })

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -56,6 +56,10 @@ const mockPrisma = {
     // `prisma.video.findMany`) doesn't crash these tests.
     findMany: vi.fn().mockResolvedValue([]),
   },
+  videoLocale: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  $queryRaw: vi.fn().mockResolvedValue([]),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any
 
@@ -94,6 +98,8 @@ beforeEach(() => {
   setupAllRetrieversEmpty()
   // Restore default hydration stub after clearAllMocks wipes it.
   mockPrisma.video.findMany.mockResolvedValue([])
+  mockPrisma.videoLocale.findMany.mockResolvedValue([])
+  mockPrisma.$queryRaw.mockResolvedValue([])
 })
 
 describe("HybridSearchService keyword-first branch", () => {

--- a/apps/admin/src/services/hybrid-search.regression.test.ts
+++ b/apps/admin/src/services/hybrid-search.regression.test.ts
@@ -66,6 +66,10 @@ const mockPrisma = {
     // `prisma.video.findMany`) doesn't crash these regression tests.
     findMany: vi.fn().mockResolvedValue([]),
   },
+  videoLocale: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  $queryRaw: vi.fn().mockResolvedValue([]),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any
 
@@ -156,6 +160,8 @@ beforeEach(() => {
   setupRetrieverFixtures()
   // Restore default hydration stub after clearAllMocks wipes it.
   mockPrisma.video.findMany.mockResolvedValue([])
+  mockPrisma.videoLocale.findMany.mockResolvedValue([])
+  mockPrisma.$queryRaw.mockResolvedValue([])
 })
 
 describe("HybridSearchService default-mode regression snapshot", () => {

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -13,6 +13,13 @@ vi.mock("./hybrid-search-retrievers", () => ({
   searchExperienceKeyword: vi.fn(),
 }))
 
+vi.mock("./embeddings.service", () => ({
+  EXPERIENCE_EMBEDDING_DIMENSIONS: 1536,
+  OPENROUTER_EMBEDDING_MODEL: "qwen/qwen3-embedding-8b",
+  generateExperienceEmbedding: vi.fn(),
+}))
+
+import { generateExperienceEmbedding } from "./embeddings.service"
 import {
   searchVideoSemantic,
   searchVideoKeyword,
@@ -23,10 +30,37 @@ import { __resetSearchHealthForTest, getStats } from "./hybrid-search-health"
 import {
   formatSearchTimingLogLine,
   HybridSearchService,
+  __resetQueryEmbeddingCacheForTest,
   normalizeMode,
   sanitizeForLog,
   type QueryEmbedder,
 } from "./hybrid-search.service"
+
+const hydrationRawRows: {
+  images: unknown[]
+  dubs: unknown[]
+  childCounts: unknown[]
+} = {
+  images: [],
+  dubs: [],
+  childCounts: [],
+}
+
+function defaultHydrationRawQuery(
+  strings: TemplateStringsArray,
+): Promise<unknown[]> {
+  const sql = strings.join(" ")
+  if (sql.includes("FROM video_image")) {
+    return Promise.resolve(hydrationRawRows.images)
+  }
+  if (sql.includes("FROM video_dub")) {
+    return Promise.resolve(hydrationRawRows.dubs)
+  }
+  if (sql.includes("FROM video_relation")) {
+    return Promise.resolve(hydrationRawRows.childCounts)
+  }
+  return Promise.resolve([])
+}
 
 const mockPrisma = {
   video: {
@@ -35,6 +69,10 @@ const mockPrisma = {
     // via `mockPrisma.video.findMany.mockResolvedValueOnce(...)`.
     findMany: vi.fn().mockResolvedValue([]),
   },
+  videoLocale: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  $queryRaw: vi.fn(defaultHydrationRawQuery),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any
 const loggerError = vi.fn()
@@ -59,9 +97,20 @@ function setupDefaultRetrievers() {
 beforeEach(() => {
   vi.clearAllMocks()
   __resetSearchHealthForTest()
+  __resetQueryEmbeddingCacheForTest()
   setupDefaultRetrievers()
+  hydrationRawRows.images = []
+  hydrationRawRows.dubs = []
+  hydrationRawRows.childCounts = []
   // Restore default hydration stub after clearAllMocks wipes it.
   mockPrisma.video.findMany.mockResolvedValue([])
+  mockPrisma.videoLocale.findMany.mockResolvedValue([])
+  mockPrisma.$queryRaw.mockImplementation(defaultHydrationRawQuery)
+  vi.mocked(generateExperienceEmbedding).mockResolvedValue({
+    model: "qwen/qwen3-embedding-8b",
+    dimensions: 1536,
+    embedding: [0.1, 0.2, 0.3],
+  })
 })
 
 describe("HybridSearchService", () => {
@@ -260,6 +309,30 @@ describe("HybridSearchService", () => {
       expect.arrayContaining([
         expect.objectContaining({
           label: "hydration.video.findMany",
+          status: "fulfilled",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+        expect.objectContaining({
+          label: "hydration.videoLocale.findMany",
+          status: "fulfilled",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+        expect.objectContaining({
+          label: "hydration.videoImage.query",
+          status: "fulfilled",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+        expect.objectContaining({
+          label: "hydration.videoDub.query",
+          status: "fulfilled",
+          resultCount: 0,
+          elapsedMs: expect.any(Number),
+        }),
+        expect.objectContaining({
+          label: "hydration.videoChildCount.query",
           status: "fulfilled",
           resultCount: 0,
           elapsedMs: expect.any(Number),
@@ -674,31 +747,36 @@ describe("HybridSearchService", () => {
           id: "vid-transcript",
           label: "EPISODE",
           primaryLanguageId: "lang-en",
-          locales: [
-            {
-              description: "A concise public description of the video.",
-              snippet: "A shorter fallback snippet.",
-            },
-          ],
-          images: [
-            {
-              mobileCinematicHigh: "https://cdn.example/cover-high.jpg",
-              mobileCinematicLow: null,
-              videoStill: null,
-              url: null,
-              thumbnail: null,
-            },
-          ],
-          dubs: [
-            {
-              languageId: "lang-en",
-              duration: 70,
-              muxVideo: { playbackId: "mux-hydrated" },
-            },
-          ],
-          _count: { children: 0 },
         },
       ])
+      mockPrisma.videoLocale.findMany.mockResolvedValueOnce([
+        {
+          videoId: "vid-transcript",
+          description: "A concise public description of the video.",
+          snippet: "A shorter fallback snippet.",
+        },
+      ])
+      hydrationRawRows.images = [
+        {
+          videoId: "vid-transcript",
+          mobileCinematicHigh: "https://cdn.example/cover-high.jpg",
+          mobileCinematicLow: null,
+          videoStill: null,
+          url: null,
+          thumbnail: null,
+        },
+      ]
+      hydrationRawRows.dubs = [
+        {
+          videoId: "vid-transcript",
+          languageId: "lang-en",
+          duration: 70,
+          playbackId: "mux-hydrated",
+        },
+      ]
+      hydrationRawRows.childCounts = [
+        { videoId: "vid-transcript", childCount: 0 },
+      ]
 
       const service = new HybridSearchService({
         prisma: mockPrisma,
@@ -754,17 +832,25 @@ describe("HybridSearchService", () => {
           id: "vid-series",
           label: "SERIES",
           primaryLanguageId: "lang-en",
-          dubs: [],
-          _count: { children: 13 },
         },
         {
           id: "vid-clip",
           label: "EPISODE",
           primaryLanguageId: "lang-en",
-          dubs: [{ languageId: "lang-en", duration: 70 }],
-          _count: { children: 0 },
         },
       ])
+      hydrationRawRows.dubs = [
+        {
+          videoId: "vid-clip",
+          languageId: "lang-en",
+          duration: 70,
+          playbackId: null,
+        },
+      ]
+      hydrationRawRows.childCounts = [
+        { videoId: "vid-series", childCount: 13 },
+        { videoId: "vid-clip", childCount: 0 },
+      ]
 
       const service = new HybridSearchService({
         prisma: mockPrisma,
@@ -831,20 +917,37 @@ describe("HybridSearchService", () => {
           id: "vid-primary",
           label: "EPISODE",
           primaryLanguageId: "lang-en",
-          dubs: [
-            { languageId: "lang-fr", duration: 999 },
-            { languageId: "lang-en", duration: 120 },
-          ],
-          _count: { children: 0 },
         },
         {
           id: "vid-fallback",
           label: "EPISODE",
           primaryLanguageId: null,
-          dubs: [{ languageId: "lang-es", duration: 60 }],
-          _count: { children: 0 },
         },
       ])
+      hydrationRawRows.dubs = [
+        {
+          videoId: "vid-primary",
+          languageId: "lang-fr",
+          duration: 999,
+          playbackId: null,
+        },
+        {
+          videoId: "vid-primary",
+          languageId: "lang-en",
+          duration: 120,
+          playbackId: null,
+        },
+        {
+          videoId: "vid-fallback",
+          languageId: "lang-es",
+          duration: 60,
+          playbackId: null,
+        },
+      ]
+      hydrationRawRows.childCounts = [
+        { videoId: "vid-primary", childCount: 0 },
+        { videoId: "vid-fallback", childCount: 0 },
+      ]
 
       const service = new HybridSearchService({
         prisma: mockPrisma,
@@ -859,6 +962,46 @@ describe("HybridSearchService", () => {
       expect(
         result.results.find((r) => r.id === "vid-fallback")!.durationSeconds,
       ).toBe(60)
+    })
+
+    it("keeps pre-hydration video fields when hydration fails", async () => {
+      vi.mocked(searchVideoSemantic).mockResolvedValue([
+        {
+          resultType: "video",
+          resultId: "vid-failure",
+          videoCoreId: "1_failure",
+          videoSlug: "failure",
+          videoTitle: "Failure",
+          imageUrl: "https://cdn.example/original.jpg",
+          sceneDescription: "Evidence text survives.",
+          startSeconds: 12,
+          playbackId: "mux-original",
+          similarity: 0.9,
+          embeddingText: "[]",
+        },
+      ])
+      mockPrisma.video.findMany.mockRejectedValueOnce(new Error("db down"))
+
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: successEmbedder(),
+        logger,
+      })
+
+      const result = await service.search({ query: "x", locale: "en" })
+
+      expect(result.results[0]).toMatchObject({
+        id: "vid-failure",
+        snippet: "Evidence text survives.",
+        imageUrl: "https://cdn.example/original.jpg",
+        playbackId: "mux-original",
+        label: null,
+        durationSeconds: null,
+        childCount: null,
+      })
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining("event=hydration_failed"),
+      )
     })
 
     it("leaves experience rows with null label/duration/childCount and never queries Video", async () => {
@@ -892,6 +1035,87 @@ describe("HybridSearchService", () => {
         childCount: null,
       })
       expect(mockPrisma.video.findMany).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("default query embedding cache", () => {
+    function deferredEmbedding() {
+      let resolve!: (value: {
+        model: string
+        dimensions: number
+        embedding: number[]
+      }) => void
+      let reject!: (error: unknown) => void
+      const promise = new Promise<{
+        model: string
+        dimensions: number
+        embedding: number[]
+      }>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve
+        reject = promiseReject
+      })
+      return { promise, resolve, reject }
+    }
+
+    it("reuses a successful default embedding for identical queries", async () => {
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        logger,
+      })
+
+      await service.search({ query: "jesus", locale: "en" })
+      await service.search({ query: "jesus", locale: "en" })
+
+      expect(generateExperienceEmbedding).toHaveBeenCalledTimes(1)
+      expect(getStats()).toMatchObject({ attempts: 1, failures: 0 })
+      expect(searchVideoSemantic).toHaveBeenCalledTimes(2)
+    })
+
+    it("coalesces concurrent identical default embedding requests", async () => {
+      const embedding = deferredEmbedding()
+      vi.mocked(generateExperienceEmbedding).mockReturnValueOnce(
+        embedding.promise,
+      )
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        logger,
+      })
+
+      const first = service.search({ query: "jesus", locale: "en" })
+      const second = service.search({ query: "jesus", locale: "en" })
+
+      expect(generateExperienceEmbedding).toHaveBeenCalledTimes(1)
+      embedding.resolve({
+        model: "qwen/qwen3-embedding-8b",
+        dimensions: 1536,
+        embedding: [0.3, 0.2, 0.1],
+      })
+      await Promise.all([first, second])
+
+      expect(getStats()).toMatchObject({ attempts: 1, failures: 0 })
+      expect(searchVideoSemantic).toHaveBeenCalledTimes(2)
+    })
+
+    it("does not cache default embedding failures", async () => {
+      vi.mocked(generateExperienceEmbedding)
+        .mockRejectedValueOnce(new Error("provider down"))
+        .mockResolvedValueOnce({
+          model: "qwen/qwen3-embedding-8b",
+          dimensions: 1536,
+          embedding: [0.1, 0.2, 0.3],
+        })
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        logger,
+      })
+
+      const degraded = await service.search({ query: "jesus", locale: "en" })
+      const recovered = await service.search({ query: "jesus", locale: "en" })
+
+      expect(degraded.searchMode).toBe("keyword-only")
+      expect(recovered.searchMode).toBe("hybrid")
+      expect(generateExperienceEmbedding).toHaveBeenCalledTimes(2)
+      expect(getStats()).toMatchObject({ attempts: 2, failures: 1 })
     })
   })
 })

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -17,8 +17,12 @@
  * 5. Paginate with hasMore signal (dedup one extra to detect overflow).
  */
 
-import type { PrismaClient, VideoLabel } from "@prisma/client"
-import { generateExperienceEmbedding } from "./embeddings.service"
+import { Prisma, type PrismaClient, type VideoLabel } from "@prisma/client"
+import {
+  EXPERIENCE_EMBEDDING_DIMENSIONS,
+  OPENROUTER_EMBEDDING_MODEL,
+  generateExperienceEmbedding,
+} from "./embeddings.service"
 import {
   fuseRankedLists,
   deduplicateResults,
@@ -301,9 +305,93 @@ function toPgvectorText(embedding: number[]): string {
  */
 export type QueryEmbedder = (text: string) => Promise<number[]>
 
+const QUERY_EMBEDDING_CACHE_TTL_MS = 10 * 60 * 1000
+const QUERY_EMBEDDING_CACHE_MAX_ENTRIES = 512
+const QUERY_EMBEDDING_PROVIDER = "openrouter"
+
+type CachedQueryEmbedding = {
+  embedding: number[]
+  expiresAt: number
+}
+
+const queryEmbeddingCache = new Map<string, CachedQueryEmbedding>()
+const queryEmbeddingInflight = new Map<string, Promise<number[]>>()
+
+function normalizeEmbeddingCacheText(text: string): string {
+  return text.replace(/\s+/g, " ").trim()
+}
+
+function queryEmbeddingCacheKey(text: string): string {
+  return JSON.stringify({
+    provider: QUERY_EMBEDDING_PROVIDER,
+    model: OPENROUTER_EMBEDDING_MODEL,
+    dimensions: EXPERIENCE_EMBEDDING_DIMENSIONS,
+    text: normalizeEmbeddingCacheText(text),
+  })
+}
+
+function cloneEmbedding(embedding: readonly number[]): number[] {
+  return [...embedding]
+}
+
+function readCachedQueryEmbedding(key: string): number[] | null {
+  const cached = queryEmbeddingCache.get(key)
+  if (cached == null) return null
+
+  if (cached.expiresAt <= Date.now()) {
+    queryEmbeddingCache.delete(key)
+    return null
+  }
+
+  queryEmbeddingCache.delete(key)
+  queryEmbeddingCache.set(key, cached)
+  return cloneEmbedding(cached.embedding)
+}
+
+function rememberQueryEmbedding(key: string, embedding: readonly number[]) {
+  if (queryEmbeddingCache.has(key)) queryEmbeddingCache.delete(key)
+
+  while (queryEmbeddingCache.size >= QUERY_EMBEDDING_CACHE_MAX_ENTRIES) {
+    const oldestKey = queryEmbeddingCache.keys().next().value
+    if (oldestKey == null) break
+    queryEmbeddingCache.delete(oldestKey)
+  }
+
+  queryEmbeddingCache.set(key, {
+    embedding: cloneEmbedding(embedding),
+    expiresAt: Date.now() + QUERY_EMBEDDING_CACHE_TTL_MS,
+  })
+}
+
+export function __resetQueryEmbeddingCacheForTest() {
+  queryEmbeddingCache.clear()
+  queryEmbeddingInflight.clear()
+}
+
 const defaultEmbedder: QueryEmbedder = async (text) => {
-  const result = await generateExperienceEmbedding(text)
-  return result.embedding
+  const key = queryEmbeddingCacheKey(text)
+  const cached = readCachedQueryEmbedding(key)
+  if (cached != null) return cached
+
+  const inflight = queryEmbeddingInflight.get(key)
+  if (inflight != null) return cloneEmbedding(await inflight)
+
+  const request = (async () => {
+    recordAttempt()
+    try {
+      const result = await generateExperienceEmbedding(text)
+      rememberQueryEmbedding(key, result.embedding)
+      return cloneEmbedding(result.embedding)
+    } catch (error) {
+      recordFailure(error)
+      throw error
+    } finally {
+      queryEmbeddingInflight.delete(key)
+    }
+  })()
+  queryEmbeddingInflight.set(key, request)
+
+  return cloneEmbedding(await request)
 }
 
 /**
@@ -363,7 +451,7 @@ function mapToSearchResult(result: FusedResult): SearchResult {
 }
 
 /**
- * Cap on dubs returned per video by the hydration sub-include. The
+ * Cap on dubs returned per video by the hydration dub query. The
  * selector picks one row to compute `durationSeconds`; a small N
  * (primary-language dub + a handful of regional fallbacks) is sufficient
  * and bounds the worst case at 50 videos × 5 dubs = 250 rows per request
@@ -373,9 +461,214 @@ function mapToSearchResult(result: FusedResult): SearchResult {
 const HYDRATION_DUBS_PER_VIDEO = 5
 const HYDRATION_IMAGES_PER_VIDEO = 5
 
+type HydrationBaseRow = {
+  id: string
+  label: VideoLabel | null
+  primaryLanguageId: string | null
+}
+
+type HydrationLocaleRow = {
+  videoId: string
+  description: string | null
+  snippet: string | null
+}
+
+type HydrationImageRow = {
+  videoId: string
+  mobileCinematicHigh: string | null
+  mobileCinematicLow: string | null
+  videoStill: string | null
+  thumbnail: string | null
+  url: string | null
+}
+
+type HydrationDubRow = {
+  videoId: string
+  languageId: string | null
+  duration: number | null
+  playbackId: string | null
+}
+
+type HydrationChildCountRow = {
+  videoId: string
+  childCount: number | bigint | null
+}
+
+type HydrationDataRow = HydrationBaseRow & {
+  locales: HydrationLocaleRow[]
+  images: HydrationImageRow[]
+  dubs: HydrationDubRow[]
+  childCount: number
+}
+
+function groupByVideoId<T extends { videoId: string }>(
+  rows: readonly T[],
+): Map<string, T[]> {
+  const grouped = new Map<string, T[]>()
+  for (const row of rows) {
+    const group = grouped.get(row.videoId)
+    if (group != null) {
+      group.push(row)
+    } else {
+      grouped.set(row.videoId, [row])
+    }
+  }
+  return grouped
+}
+
+function toChildCount(value: number | bigint | null | undefined): number {
+  if (typeof value === "bigint") return Number(value)
+  if (typeof value === "number") return value
+  return 0
+}
+
+async function loadHydrationDataRows(
+  prisma: PrismaClient,
+  videoIds: string[],
+  locale: string,
+  timing?: SearchTimingRecorder,
+): Promise<HydrationDataRow[]> {
+  const [baseRows, localeRows, imageRows, dubRows, childCountRows] =
+    await Promise.all([
+      recordSearchDbTiming(
+        timing,
+        "hydration.video.findMany",
+        () =>
+          prisma.video.findMany({
+            where: { id: { in: videoIds }, deletedAt: null },
+            select: {
+              id: true,
+              label: true,
+              primaryLanguageId: true,
+            },
+          }) as Promise<HydrationBaseRow[]>,
+      ),
+      recordSearchDbTiming(
+        timing,
+        "hydration.videoLocale.findMany",
+        () =>
+          prisma.videoLocale.findMany({
+            where: {
+              videoId: { in: videoIds },
+              locale,
+              status: "PUBLISHED",
+              deletedAt: null,
+            },
+            select: {
+              videoId: true,
+              description: true,
+              snippet: true,
+            },
+          }) as Promise<HydrationLocaleRow[]>,
+      ),
+      recordSearchDbTiming(
+        timing,
+        "hydration.videoImage.query",
+        () =>
+          prisma.$queryRaw<HydrationImageRow[]>`
+        SELECT
+          ranked."videoId",
+          ranked."mobileCinematicHigh",
+          ranked."mobileCinematicLow",
+          ranked."videoStill",
+          ranked.thumbnail,
+          ranked.url
+        FROM (
+          SELECT
+            vi.video_id AS "videoId",
+            vi.mobile_cinematic_high AS "mobileCinematicHigh",
+            vi.mobile_cinematic_low AS "mobileCinematicLow",
+            vi.video_still AS "videoStill",
+            vi.thumbnail,
+            vi.url,
+            row_number() OVER (
+              PARTITION BY vi.video_id
+              ORDER BY vi.created_at ASC
+            ) AS hydration_rank
+          FROM video_image vi
+          WHERE vi.video_id IN (${Prisma.join(videoIds)})
+            AND vi.deleted_at IS NULL
+        ) ranked
+        WHERE ranked.hydration_rank <= ${HYDRATION_IMAGES_PER_VIDEO}
+        ORDER BY ranked."videoId", ranked.hydration_rank
+      `,
+      ),
+      recordSearchDbTiming(
+        timing,
+        "hydration.videoDub.query",
+        () =>
+          prisma.$queryRaw<HydrationDubRow[]>`
+        SELECT
+          ranked."videoId",
+          ranked."languageId",
+          ranked.duration,
+          ranked."playbackId"
+        FROM (
+          SELECT
+            vd.video_id AS "videoId",
+            vd.language_id AS "languageId",
+            vd.duration,
+            mv.playback_id AS "playbackId",
+            row_number() OVER (
+              PARTITION BY vd.video_id
+              ORDER BY vd.duration DESC
+            ) AS hydration_rank
+          FROM video_dub vd
+          LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+          WHERE vd.video_id IN (${Prisma.join(videoIds)})
+            AND vd.published = true
+            AND vd.hls IS NOT NULL
+            AND vd.deleted_at IS NULL
+            AND vd.duration > 0
+        ) ranked
+        WHERE ranked.hydration_rank <= ${HYDRATION_DUBS_PER_VIDEO}
+        ORDER BY ranked."videoId", ranked.hydration_rank
+      `,
+      ),
+      recordSearchDbTiming(
+        timing,
+        "hydration.videoChildCount.query",
+        () =>
+          prisma.$queryRaw<HydrationChildCountRow[]>`
+        SELECT
+          vr.parent_id AS "videoId",
+          COUNT(*)::int AS "childCount"
+        FROM video_relation vr
+        JOIN video child
+          ON child.id = vr.child_id
+          AND child.deleted_at IS NULL
+        WHERE vr.parent_id IN (${Prisma.join(videoIds)})
+          AND EXISTS (
+            SELECT 1
+            FROM video_locale child_locale
+            WHERE child_locale.video_id = child.id
+              AND child_locale.status = 'published'
+              AND child_locale.deleted_at IS NULL
+          )
+        GROUP BY vr.parent_id
+      `,
+      ),
+    ])
+
+  const localesByVideoId = groupByVideoId(localeRows)
+  const imagesByVideoId = groupByVideoId(imageRows)
+  const dubsByVideoId = groupByVideoId(dubRows)
+  const childCountsByVideoId = new Map(
+    childCountRows.map((row) => [row.videoId, toChildCount(row.childCount)]),
+  )
+
+  return baseRows.map((row) => ({
+    ...row,
+    locales: localesByVideoId.get(row.id) ?? [],
+    images: imagesByVideoId.get(row.id) ?? [],
+    dubs: dubsByVideoId.get(row.id) ?? [],
+    childCount: childCountsByVideoId.get(row.id) ?? 0,
+  }))
+}
+
 /**
  * Card display hydration. Given the final page of video-type results,
- * batch-load card metadata in ONE Prisma query and return a new array
+ * batch-load card metadata with bounded, timed reads and return a new array
  * with display fields filled in:
  *
  * - public snippet from VideoLocale description/snippet
@@ -388,10 +681,9 @@ const HYDRATION_IMAGES_PER_VIDEO = 5
  * Why a post-mapping pass instead of fetching the data inline in each
  * retriever: the retrievers project tightly via `$queryRaw` for index
  * use; adding extra display fields per retriever would either duplicate the
- * LATERALs across 4+ SQL paths or force a UNION shape change. A single
- * `findMany({ where: { id: { in: [...] } } })` after pagination is
- * O(page-size) — at most ~50 rows for MAX_LIMIT — and keeps the SQL
- * read paths unchanged.
+ * LATERALs across 4+ SQL paths or force a UNION shape change. A small set
+ * of bounded, parallel reads after pagination is O(page-size) — at most
+ * ~50 rows for MAX_LIMIT — and keeps the retriever SQL read paths unchanged.
  *
  * Returns a NEW array (not mutating the input). Soft-deleted-mid-search
  * rows pass through with null pill fields — they keep title/slug from
@@ -414,94 +706,9 @@ async function hydrateCardDisplayFields(
   // error here must NOT take the search endpoint down. Catch, log, and pass
   // through the pre-hydration array; consumers see a search response with
   // sparse card metadata rather than HTTP 503 for the whole request.
-  let rows
+  let rows: HydrationDataRow[]
   try {
-    rows = await recordSearchDbTiming(timing, "hydration.video.findMany", () =>
-      prisma.video.findMany({
-        where: { id: { in: videoIds }, deletedAt: null },
-        select: {
-          id: true,
-          label: true,
-          primaryLanguageId: true,
-          locales: {
-            where: {
-              locale,
-              status: "PUBLISHED",
-              deletedAt: null,
-            },
-            take: 1,
-            select: {
-              description: true,
-              snippet: true,
-            },
-          },
-          images: {
-            where: { deletedAt: null },
-            orderBy: [{ createdAt: "asc" }],
-            take: HYDRATION_IMAGES_PER_VIDEO,
-            select: {
-              mobileCinematicHigh: true,
-              mobileCinematicLow: true,
-              videoStill: true,
-              thumbnail: true,
-              url: true,
-            },
-          },
-          dubs: {
-            // `duration: { gt: 0 }` excludes sync-glitch rows (Core
-            // occasionally returns a published dub with duration=0; the
-            // pill picker then renders nothing for those rows, leaving an
-            // unexplained gap on the card).
-            where: {
-              published: true,
-              hls: { not: null },
-              deletedAt: null,
-              duration: { gt: 0 },
-            },
-            // `take` bounds the per-video dubs scan. Order by duration
-            // descending so the longest published in-locale dub anchors
-            // the top of the page; the post-query `find` below prefers the
-            // primary-language dub among these top-N rows, falling back to
-            // `dubs[0]` (longest) when the primary dub isn't in the top-N
-            // by duration. On heavily-dubbed videos (200+ dubs) the primary
-            // may rank below position N — accept the fallback rather than
-            // widen `take` (cost is bounded at 50 × N rows per request).
-            orderBy: [{ duration: "desc" }],
-            take: HYDRATION_DUBS_PER_VIDEO,
-            select: {
-              languageId: true,
-              duration: true,
-              muxVideo: { select: { playbackId: true } },
-            },
-          },
-          // `_count.children` mirrors the consumer-facing ABAC at
-          // videoChildrenFilter (apps/admin/src/graphql/types/video.ts):
-          // only count children that have a PUBLISHED locale and aren't
-          // soft-deleted. Without this filter the search-card "{n} episodes"
-          // pill drifts from what the watch page actually renders. Self-
-          // referential rows (parent_id = child_id) — a data-quality issue
-          // seen for `1-jesus-our-loving-pursuer` — can still inflate the
-          // count; web's normalizeAdminVideo filters those client-side, but
-          // the count is computed before that pass. Acceptable today; if
-          // self-ref inflation becomes a UX issue, switch to a raw SQL
-          // count that adds `WHERE child_id <> parent_id`.
-          _count: {
-            select: {
-              children: {
-                where: {
-                  child: {
-                    deletedAt: null,
-                    locales: {
-                      some: { status: "PUBLISHED", deletedAt: null },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      }),
-    )
+    rows = await loadHydrationDataRows(prisma, videoIds, locale, timing)
   } catch (err) {
     const log = logger ?? console
     log.error(
@@ -523,27 +730,27 @@ async function hydrateCardDisplayFields(
   >()
   for (const row of rows) {
     // Pick the primary-language dub when available; otherwise the
-    // longest-duration playable dub (the orderBy in the sub-include
-    // sorted them). `duration` is already in seconds (Int?); the
-    // millisecond column on VideoDub uses BigInt and isn't needed for
-    // pill display where second precision is the right fidelity.
+    // longest-duration playable dub. The hydration query sorts dubs by
+    // duration descending. `duration` is already in seconds (Int?); the
+    // millisecond column on VideoDub uses BigInt and isn't needed for pill
+    // display where second precision is the right fidelity.
     const primaryDub = row.primaryLanguageId
       ? row.dubs.find((d) => d.languageId === row.primaryLanguageId)
       : undefined
     const durationDub = primaryDub ?? row.dubs[0] ?? null
     const playbackDub =
-      (nonEmptyString(primaryDub?.muxVideo?.playbackId) != null
+      (nonEmptyString(primaryDub?.playbackId) != null
         ? primaryDub
         : undefined) ??
-      row.dubs.find((d) => nonEmptyString(d.muxVideo?.playbackId) != null) ??
+      row.dubs.find((d) => nonEmptyString(d.playbackId) != null) ??
       durationDub
     hydration.set(row.id, {
       snippet: pickLocalizedSnippet(row.locales),
       imageUrl: pickImageUrl(row.images),
-      playbackId: nonEmptyString(playbackDub?.muxVideo?.playbackId),
+      playbackId: nonEmptyString(playbackDub?.playbackId),
       label: row.label,
       durationSeconds: durationDub?.duration ?? null,
-      childCount: row._count.children,
+      childCount: row.childCount,
     })
   }
 
@@ -625,6 +832,7 @@ export type HybridSearchServiceDeps = {
 export class HybridSearchService {
   private readonly prisma: PrismaClient
   private readonly embedder: QueryEmbedder
+  private readonly embedderRecordsHealth: boolean
   private readonly logger: {
     error: (message: string) => void
     warn: (message: string) => void
@@ -633,6 +841,7 @@ export class HybridSearchService {
   constructor(deps: HybridSearchServiceDeps) {
     this.prisma = deps.prisma
     this.embedder = deps.embedder ?? defaultEmbedder
+    this.embedderRecordsHealth = deps.embedder == null
     this.logger = deps.logger ?? {
       error: (message: string) => console.error(message),
       warn: (message: string) => console.warn(message),
@@ -795,13 +1004,13 @@ export class HybridSearchService {
     let embeddingFailed = false
     let embeddingMs = 0
     const embeddingStartedAt = nowMs()
-    recordAttempt()
+    if (!this.embedderRecordsHealth) recordAttempt()
     try {
       const vector = await this.embedder(query)
       queryEmbeddingText = toPgvectorText(vector)
     } catch (error) {
       embeddingFailed = true
-      recordFailure(error)
+      if (!this.embedderRecordsHealth) recordFailure(error)
       const errorClass =
         error instanceof Error ? error.constructor.name : "UnknownError"
       const message = error instanceof Error ? error.message : String(error)

--- a/apps/admin/src/services/transcript-embedding-ingest.contract.test.ts
+++ b/apps/admin/src/services/transcript-embedding-ingest.contract.test.ts
@@ -151,7 +151,7 @@ function buildContractPrisma() {
       return [...transcripts.values()]
     }
 
-    if (sql.includes("WITH transcript_source AS")) {
+    if (sql.includes("transcript_source AS")) {
       return chunks.map((chunk) => {
         const transcript = transcripts.get(chunk.transcriptId)!
         return {

--- a/docs/plans/2026-06-25-001-perf-admin-search-hydration-semantic-cache-plan.md
+++ b/docs/plans/2026-06-25-001-perf-admin-search-hydration-semantic-cache-plan.md
@@ -1,0 +1,224 @@
+---
+title: "perf: Optimize Admin search hydration, semantic SQL, and query embeddings"
+type: "perf"
+date: "2026-06-25"
+execution: "code"
+---
+
+# perf: Optimize Admin search hydration, semantic SQL, and query embeddings
+
+## Summary
+
+Reduce Admin search latency on the same production path measured for `feat-175` by optimizing the slow database and embedding layers while preserving current search results. This plan covers hydration query optimization, semantic-video SQL tuning, and a query embedding cache; trace-write offloading remains deferred.
+
+---
+
+## Problem Frame
+
+Production timing after the keyword-first overlap PR did not show a reliable improvement. The remaining visible costs are dominated by `semantic-video.query` and card hydration, with query embedding still paid on every repeated request. The user wants query optimization first, with the specific constraint that result quality and result shape must not change.
+
+The roadmap ticket already frames this as latency recovery rather than timeout masking. The safe path is to reduce database work and avoid repeat provider calls without changing retriever labels, RRF list order, dedupe, dilution-cap behavior, public response fields, or trace-write behavior.
+
+---
+
+## Requirements
+
+### Result Preservation
+
+- R1. Hydration optimization must preserve result IDs, order, scores, `hasMore`, `searchMode`, `query`, and every public display field for equivalent database rows.
+- R2. Semantic-video SQL optimization must keep the `semantic-video` retriever label and current best-transcript-evidence-per-video semantics.
+- R3. No optimization may drop semantic retrieval, narrow candidate recall, change RRF list order, or solve latency by returning degraded keyword-only results.
+
+### Latency And Observability
+
+- R4. Hydration database work must be split or narrowed so logs expose which hydration sub-layer is slow.
+- R5. Semantic-video database timing must remain visible under a stable comparable label, with any added labels treated as more granular DB-layer diagnostics.
+- R6. Repeated identical query embedding requests should avoid repeat provider calls within a bounded process-local cache.
+
+### Scope Control
+
+- R7. Trace-write behavior stays unchanged in this pass.
+- R8. Public REST and GraphQL search response contracts remain unchanged.
+- R9. Existing keyword-first, hybrid, semantic-only, and degraded keyword-only behavior remains covered by tests.
+
+---
+
+## Key Technical Decisions
+
+- **Optimize projection, not ranking:** Hydration may change how display data is loaded, but not what final search results contain. Semantic SQL may reduce repeated work inside the same logical candidate semantics, but not introduce HNSW-first windows or recall-reducing prefilters in this pass.
+- **Keep the orchestrator contract:** `HybridSearchService.searchWithTrace` remains the single orchestrator for pipeline mode, embedding degradation, fusion, dedupe, mapping, hydration, and private timings.
+- **Split hydration with explicit DB labels:** Replace the single broad nested Prisma hydration query with narrow batch reads for base video metadata, localized snippets, images, dubs, and child counts. Preserve the fallback behavior where hydration failure logs and returns pre-hydration results.
+- **Semantic SQL tuning stays equivalence-bound:** Prefer query-shape changes that compute the query vector once, remove redundant casts or joins, and preserve the current ordering tie-breakers. Defer HNSW-first transcript windows until there is a separate recall/diversity proof.
+- **Byte-identical public response oracle:** For selected fixtures and representative queries, preservation means byte-identical public JSON after excluding timing/log side effects. Result IDs, order, scores, display fields, `hasMore`, `query`, and `searchMode` are all part of the oracle.
+- **Process-local embedding cache only:** Cache successful query embeddings by normalized query text, provider, model, and dimensions for a short TTL with in-flight dedupe. Do not cache failures, and do not introduce shared infrastructure or persistent query storage.
+- **Provider health counters remain provider-call counters:** Cache hits are search successes, but should not be counted as fresh provider attempts. Failures on cache misses still flow through the existing degradation and health-counter path.
+- **Plain-string timing logs remain the observability surface:** New timing labels must continue through the existing `[search] event=... key=value` formatter. Do not add JSON-shaped runtime logs for Railway production timing.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Search request"] --> B["Query embedding"]
+  B --> C["Semantic and lexical retrievers"]
+  C --> D["Fusion, dilution cap, dedupe"]
+  D --> E["Map public result contract"]
+  E --> F["Hydration batch"]
+  F --> G["Response"]
+
+  B -. "Track C: cache successful embeddings" .-> B
+  C -. "Track B: equivalent semantic-video SQL tuning" .-> C
+  F -. "Track A: split/narrow DB hydration reads" .-> F
+```
+
+---
+
+## Implementation Units
+
+### U1. Add Result-Equivalence Characterization For Search Cards
+
+- **Goal:** Lock the current response contract before changing hydration or semantic SQL.
+- **Requirements:** R1, R2, R3, R8, R9
+- **Dependencies:** none
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+  - `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+  - `apps/admin/src/services/hybrid-search.keyword-first.test.ts`
+- **Approach:** Add focused characterization around hydration overlay rules, semantic-video SQL shape, and mode-specific dispatch. The tests should assert final public response equality for the hydration cases that matter: localized description/snippet precedence, image priority, playback fallback, primary-dub duration preference, child count, missing hydration rows, and hydration failure pass-through.
+- **Technical design:** Public response comparison ignores timings, logs, and private trace summaries. It does not ignore any field returned through REST or GraphQL search results.
+- **Execution note:** Start this unit before changing query shape so the tests prove preservation rather than the rewritten implementation.
+- **Patterns to follow:** Existing card-pill hydration tests in `apps/admin/src/services/hybrid-search.service.test.ts`; SQL-shape tests in `apps/admin/src/services/hybrid-search-retrievers.test.ts`.
+- **Patterns to follow:** Existing card-pill hydration tests in `apps/admin/src/services/hybrid-search.service.test.ts`; SQL-shape tests in `apps/admin/src/services/hybrid-search-retrievers.test.ts`; `docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md`; `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`.
+- **Test scenarios:**
+  - A video with semantic evidence keeps its ID, score, start seconds, and order while localized description/image/playback/label/duration/child count are hydrated.
+  - Empty-string retriever image and playback fields use hydrated fallbacks; non-empty retriever values remain authoritative.
+  - A primary-language playable dub is preferred for duration; otherwise the first duration-ordered playable dub is used.
+  - Missing hydration rows pass through with pre-hydration fields.
+  - Hydration query failure logs once and returns the original result array.
+  - Semantic-video SQL still selects transcript evidence only, preserves locale/provenance/visibility gates, and keeps final hydration outside the transcript-source candidate collapse.
+- **Verification:** Focused tests fail if public result fields, semantic SQL invariants, or mode dispatch behavior drift.
+
+### U2. Optimize Hydration Query Shape Without Changing Results
+
+- **Goal:** Reduce hydration latency and expose per-layer DB timings while preserving final card output.
+- **Requirements:** R1, R4, R8
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+  - `apps/admin/src/services/hybrid-search-timing.test.ts`
+- **Approach:** Replace the broad nested `video.findMany` hydration read with narrow batch reads keyed by the final page of video IDs. Keep the same selection semantics for localized snippets, image priority, playable dubs, and published child counts. Record separate DB timings for each hydration sub-layer while retaining aggregate `hydrationMs`.
+- **Patterns to follow:** `recordSearchDbTiming` in `apps/admin/src/services/hybrid-search-timing.ts`; existing display-only hydration fallback in `apps/admin/src/services/hybrid-search.service.ts`; `docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md`.
+- **Test scenarios:**
+  - Final response for the characterized hydration fixtures remains identical after the query rewrite.
+  - Each hydration sub-query records a DB timing label with status and result count.
+  - Experience-only searches do not run video hydration queries.
+  - A rejected hydration sub-query logs `event=hydration_failed` and leaves the response unchanged.
+  - Hydration still sends only the final page video IDs, not overfetch candidates.
+- **Verification:** Service tests demonstrate response equivalence and the timing log formatter includes the new hydration DB labels.
+
+### U3. Tune Semantic-Video SQL Within Current Candidate Semantics
+
+- **Goal:** Reduce redundant SQL work in `semantic-video.query` without changing semantic-video result semantics.
+- **Requirements:** R2, R3, R5, R8, R9
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search-retrievers.ts`
+  - `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+  - `apps/admin/src/services/transcript-embedding-ingest.contract.test.ts`
+- **Approach:** Keep transcript-only retrieval and per-video best evidence semantics. Apply only equivalence-preserving query-shape changes, such as binding the query vector once in a CTE and reusing it for score and ordering, or removing redundant final joins when selected evidence data is already available. Keep the stable `semantic-video.query` DB timing label for comparison.
+- **Technical design:** HNSW-first nearest-neighbor windows are out of scope for this PR because they can alter distinct-video recall before per-video collapse.
+- **Patterns to follow:** `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`; `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md`; `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`; `docs/solutions/database-issues/set-local-requires-transaction-for-pgvector-search.md`; `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`.
+- **Test scenarios:**
+  - SQL still contains transcript evidence only and no scene source.
+  - Locale, published visibility, non-null embedding, and Qwen-compatible provenance gates remain present.
+  - Candidate limit remains after per-video evidence collapse.
+  - Tie-break ordering remains score, timecode, and stable evidence ID as before.
+  - Mapping still returns the same `VideoSemanticResult` fields from mocked rows.
+- **Verification:** Existing retriever tests and contract tests pass, and any SQL-shape change is readable enough for production `EXPLAIN` follow-up.
+
+### U4. Add Bounded Query Embedding Cache
+
+- **Goal:** Avoid repeated embedding-provider latency for identical live search queries while keeping embedding semantics unchanged.
+- **Requirements:** R3, R6, R8, R9
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+  - `apps/admin/src/services/embeddings.service.test.ts`
+- **Approach:** Wrap the default live-query embedder with a small process-local TTL cache and in-flight promise dedupe. Key by normalized query text plus the current provider/model/dimension contract available in the service layer. Cache only fulfilled vectors; failures must continue to trigger the existing degradation path and health counters.
+- **Patterns to follow:** `docs/solutions/best-practices/batched-provider-input-position-stable-contract-20260505.md` for preserving the singular `generateExperienceEmbedding` contract; `docs/solutions/best-practices/openrouter-only-embedding-provider-contract.md` for provider/model provenance; existing embedding failure health tests in `apps/admin/src/services/hybrid-search.service.test.ts`.
+- **Test scenarios:**
+  - Two identical default-embedder searches within the TTL call the provider once and return the same results.
+  - Concurrent identical requests share one in-flight embedding promise.
+  - Different normalized query keys call the provider separately.
+  - Provider failures are not cached; the next request retries and health counters still record the failed attempt.
+  - Cache hits do not increment provider-attempt counters if the counter remains scoped to real provider calls.
+  - Injected test embedders remain injectable and deterministic.
+- **Verification:** Unit tests prove cache hits reduce provider calls without changing search response fields or degradation behavior.
+
+### U5. Validate And Compare Timings
+
+- **Goal:** Prove the PR is safe locally and ready for production timing comparison after merge.
+- **Requirements:** R1, R3, R4, R5, R7, R8, R9
+- **Dependencies:** U2, U3, U4
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+  - `docs/solutions/performance-issues/`
+- **Approach:** Run focused Admin search tests, typecheck, and lint for touched files. After deployment, run the same production canaries used for the previous comparison: `the bible project`, `jesus`, and `hope when life is hard` across keyword-first, hybrid, and semantic-only where applicable. Compare service timings, client timings, top-N video IDs, evidence/snippet parity, image/playback null-rate deltas, and the new DB-layer hydration labels.
+- **Patterns to follow:** `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`; `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`.
+- **Test scenarios:** Test expectation: none -- this unit is validation and measurement, not new runtime behavior.
+- **Verification:** The report names whether hydration, semantic SQL, embedding, or trace write remains the dominant bottleneck. It includes cold/warm timing samples, response `searchMode`, top-N IDs, evidence/snippet parity, and image/playback null-rate deltas. Trace write is measured but not optimized in this pass.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Optimize hydration queries while preserving the final public response exactly.
+- Apply equivalence-preserving semantic-video SQL tuning.
+- Add a bounded process-local query embedding cache for successful embeddings.
+- Keep and improve DB-layer timing visibility for the touched search layers.
+
+### Deferred to Follow-Up Work
+
+- Move trace writes off the request path or into post-response execution.
+- Prototype HNSW-first transcript candidate windows.
+- Add or change pgvector indexes based on production `EXPLAIN`.
+- Change ranking, RRF weights, dilution-cap rules, dedupe semantics, or semantic evidence source mix.
+
+---
+
+## Risks & Dependencies
+
+- **Hidden hydration behavior drift:** Splitting one nested Prisma query into multiple reads can accidentally change row ordering or null fallback. Characterization tests must land before the rewrite.
+- **Semantic recall regression:** An apparently faster vector query can degrade quality if it bounds candidates before per-video collapse. This pass must avoid HNSW-first windows unless separate eval proof exists.
+- **Cache staleness:** Query embeddings should be stable for short periods, but a long cache TTL could obscure provider-contract changes. Keep TTL short and process-local.
+- **Production variance:** Cold and warm database/cache states vary. Compare multiple runs and look at per-layer timings rather than one total duration.
+- **Trace-write temptation:** Trace write may still be visible in logs after these changes, but it stays deliberately untouched until the first three optimizations are measured.
+
+---
+
+## Open Questions
+
+- OQ1. Production `EXPLAIN` proof may be needed after deployment if semantic SQL remains dominant. This is deferred to measurement unless the implementation changes candidate-window semantics, which this plan forbids.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-24-001-perf-admin-search-parallel-keyword-plan.md`
+- `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
+- `docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md`
+- `docs/solutions/platform/admin-hybrid-search-keyword-first-r4-extension-pattern.md`
+- `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `docs/solutions/database-issues/set-local-requires-transaction-for-pgvector-search.md`
+- `docs/solutions/best-practices/openrouter-only-embedding-provider-contract.md`
+- `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`
+- `docs/solutions/runtime-errors/railway-logsv2-silences-nextjs-stdout-runtime-20260518.md`
+- `apps/admin/AGENTS.md`
+- `CONCEPTS.md`

--- a/docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md
+++ b/docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md
@@ -1,0 +1,140 @@
+---
+title: "Admin search result-preserving latency optimization"
+date: "2026-06-25"
+category: "performance-issues"
+module: "apps/admin"
+problem_type: "performance_issue"
+component: "database"
+symptoms:
+  - "Production Watch search spends several seconds inside Admin search"
+  - "Search timings show hydration and semantic SQL can dominate user-visible latency"
+  - "The optimization must not change top result IDs, ordering, or public response fields"
+root_cause: "wrong_api"
+resolution_type: "code_fix"
+severity: "high"
+tags:
+  - "admin"
+  - "search"
+  - "latency"
+  - "hydration"
+  - "pgvector"
+  - "embeddings"
+  - "cache"
+---
+
+# Admin Search Result-Preserving Latency Optimization
+
+## Problem
+
+Admin Watch search needed latency reductions without degrading semantic quality
+or changing the public search contract. The dangerous shortcut was to shrink or
+timeout retrievers and return faster but different results; the safe path was to
+optimize query shape, hydration shape, and repeated query embedding work while
+proving the response stayed stable.
+
+## Symptoms
+
+- Keyword-first and hybrid searches can spend 4-8 seconds in production, with
+  occasional slower calls.
+- Search timings identify multiple possible hot spots: live query embedding,
+  `semantic-video` SQL, card hydration reads, and trace writes.
+- Top-N result identity, order, score shape, display metadata, `searchMode`,
+  and `hasMore` must remain stable while optimizing.
+
+## What Didn't Work
+
+- **Optimizing by changing retrieval semantics.** HNSW-first row windows,
+  retriever timeouts, lower candidate limits, or semantic-list removal may
+  reduce latency but can silently reduce recall or diversity.
+- **Treating hydration as ranking work.** Display metadata belongs after fusion
+  and pagination; adding broad image/dub joins to every retriever expands the
+  hot SQL path.
+- **Relying on route timing alone.** A single request duration cannot separate
+  embedding provider time from PostgreSQL time, hydration time, and trace-write
+  overhead.
+
+## Solution
+
+Use a result-preserving optimization ladder:
+
+1. Keep a byte-equivalent public response oracle in tests before changing query
+   shape. Compare IDs, order, scores, display fields, `searchMode`, `query`,
+   and `hasMore`; exclude private timing/log data from the oracle.
+2. Split post-fusion video card hydration into bounded, timed reads for the
+   final page only:
+   - base video fields via `hydration.video.findMany`;
+   - locale display copy via `hydration.videoLocale.findMany`;
+   - image variants via a per-video `row_number()` window over `video_image`;
+   - playable dubs via a per-video `row_number()` window over `video_dub`;
+   - child counts via grouped raw SQL with the same published-child gate.
+3. Preserve overlay semantics exactly. Hydrated display fields fill public card
+   metadata, but existing semantic evidence still owns `startSeconds` and any
+   non-empty retriever `playbackId` / `imageUrl` fallback.
+4. In pgvector semantic SQL, avoid duplicate query-vector binding/casting
+   without changing ranking:
+
+   ```sql
+   WITH query_embedding AS MATERIALIZED (
+     SELECT ${queryEmbedding}::vector AS embedding
+   ),
+   transcript_source AS (
+     SELECT
+       1 - (vtc.embedding <=> qe.embedding) AS source_score
+     FROM video_transcript_chunk vtc
+     CROSS JOIN query_embedding qe
+     ORDER BY vtc.embedding <=> qe.embedding
+   )
+   ```
+
+   The key invariant is that `DISTINCT ON`, visibility filters, provenance
+   filters, candidate limits, and final ordering remain unchanged.
+
+5. Add a process-local query embedding cache only around the default live-search
+   embedder:
+   - key by normalized query text plus provider/model/dimensions;
+   - bound with TTL and max entries;
+   - coalesce concurrent identical misses with an in-flight promise map;
+   - cache fulfilled embeddings only, never failures;
+   - count health attempts/failures for real provider calls, not cache hits.
+6. Leave trace-write behavior alone until timings prove it is still a bottleneck.
+   Optimizing trace persistence too early removes observability that may be
+   needed for the next production comparison.
+
+## Why This Works
+
+The retrievers still generate the same ranked candidates, and RRF still sees the
+same list labels and list order. The semantic SQL computes the same distance
+expression against the same rows; it simply binds the query vector once and
+reuses the CTE alias.
+
+Hydration stays display-only and bounded by the final page size. Window queries
+preserve the old per-video `take` behavior for image and dub relations, so one
+popular video with hundreds of dubs cannot balloon hydration rows for the whole
+page.
+
+The query embedding cache targets the most repeatable provider cost without
+changing relevance. Identical normalized text under the same provider/model
+contract receives the same vector the provider would have returned on the first
+call, while failures still degrade to keyword-only and remain observable.
+
+## Prevention
+
+- Do not merge a search-latency optimization unless result-stability tests cover
+  the public response shape and semantic evidence/display metadata boundaries.
+- Treat HNSW-first or candidate-window rewrites as a separate relevance change
+  that needs recall/diversity proof, production-shaped `EXPLAIN`, and eval
+  coverage.
+- Add a DB timing label for every new search SQL shape. If a query is worth
+  optimizing, it is worth timing independently.
+- Keep query embedding caches provider-bound. Include provider, model, and
+  dimensions in the cache key so model upgrades cannot reuse stale vectors.
+- Keep health counters and health probes honest: cache hits are not provider
+  attempts, and `/api/search/health` should still call the provider directly.
+
+## Related Issues
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
+- `docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `docs/solutions/best-practices/openrouter-only-embedding-provider-contract.md`


### PR DESCRIPTION
## Summary

Optimize Admin search latency without changing public search results. This keeps trace-write behavior unchanged and focuses on the first three safe slices:

- split final-page video card hydration into bounded, timed DB reads
- bind/cast the semantic-video query vector once via a materialized CTE
- add a bounded process-local query embedding cache with in-flight dedupe

## Work Loop

- [x] `ce:plan` done
- [x] `ce:work` done
- [x] `ce:review` done
- [x] `ce:compound` done

## Validation

- `pnpm --filter @forge/admin lint`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin test -- src/services/hybrid-search.service.test.ts src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search.keyword-first.test.ts src/services/hybrid-search.regression.test.ts src/services/hybrid-search-timing.test.ts src/services/transcript-embedding-ingest.contract.test.ts src/services/hybrid-search.debug.test.ts src/services/hybrid-search.bible-project.test.ts src/services/hybrid-search.dilution-cap.test.ts src/services/hybrid-search-health.test.ts`

## Notes

- Plan: `docs/plans/2026-06-25-001-perf-admin-search-hydration-semantic-cache-plan.md`
- Learning: `docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`
- Trace write intentionally remains unchanged for this slice.
