### PR TITLE
fix(search): stabilize hydrated dub selection

### DIFF
--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -62,6 +62,17 @@ function defaultHydrationRawQuery(
   return Promise.resolve([])
 }
 
+function latestHydrationRawSqlContaining(pattern: string): string {
+  const calls = mockPrisma.$queryRaw.mock.calls as Array<
+    [TemplateStringsArray, ...unknown[]]
+  >
+  const call = calls.find((rawCall) => {
+    const strings = rawCall[0]
+    return strings?.join(" ").includes(pattern)
+  })
+  return call?.[0].join(" ") ?? ""
+}
+
 const mockPrisma = {
   video: {
     // Default to empty hydration so paginated tests don't need to seed
@@ -962,6 +973,51 @@ describe("HybridSearchService", () => {
       expect(
         result.results.find((r) => r.id === "vid-fallback")!.durationSeconds,
       ).toBe(60)
+    })
+
+    it("uses a stable tie-breaker for equal-duration hydration dubs", async () => {
+      vi.mocked(searchVideoSemantic).mockResolvedValue([
+        {
+          resultType: "video",
+          resultId: "vid-tied-dubs",
+          videoCoreId: "1_tied",
+          videoSlug: "tied",
+          videoTitle: "Tied",
+          imageUrl: null,
+          sceneDescription: "",
+          startSeconds: 0,
+          playbackId: null,
+          similarity: 0.9,
+          embeddingText: "[]",
+        },
+      ])
+      mockPrisma.video.findMany.mockResolvedValueOnce([
+        {
+          id: "vid-tied-dubs",
+          label: "EPISODE",
+          primaryLanguageId: null,
+        },
+      ])
+      hydrationRawRows.dubs = [
+        {
+          videoId: "vid-tied-dubs",
+          languageId: "lang-a",
+          duration: 120,
+          playbackId: "mux-a",
+        },
+      ]
+
+      const service = new HybridSearchService({
+        prisma: mockPrisma,
+        embedder: successEmbedder(),
+        logger,
+      })
+
+      await service.search({ query: "x", locale: "en" })
+
+      expect(latestHydrationRawSqlContaining("FROM video_dub")).toContain(
+        "ORDER BY vd.duration DESC, vd.id ASC",
+      )
     })
 
     it("keeps pre-hydration video fields when hydration fails", async () => {

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -62,7 +62,7 @@ function defaultHydrationRawQuery(
   return Promise.resolve([])
 }
 
-function latestHydrationRawSqlContaining(pattern: string): string {
+function hydrationRawSqlContaining(pattern: string): string {
   const calls = mockPrisma.$queryRaw.mock.calls as Array<
     [TemplateStringsArray, ...unknown[]]
   >
@@ -70,7 +70,8 @@ function latestHydrationRawSqlContaining(pattern: string): string {
     const strings = rawCall[0]
     return strings?.join(" ").includes(pattern)
   })
-  return call?.[0].join(" ") ?? ""
+  expect(call, `Expected hydration SQL containing ${pattern}`).toBeDefined()
+  return call![0].join(" ")
 }
 
 const mockPrisma = {
@@ -975,7 +976,7 @@ describe("HybridSearchService", () => {
       ).toBe(60)
     })
 
-    it("uses a stable tie-breaker for equal-duration hydration dubs", async () => {
+    it("orders hydration dub ranking with a stable tie-breaker", async () => {
       vi.mocked(searchVideoSemantic).mockResolvedValue([
         {
           resultType: "video",
@@ -1015,8 +1016,8 @@ describe("HybridSearchService", () => {
 
       await service.search({ query: "x", locale: "en" })
 
-      expect(latestHydrationRawSqlContaining("FROM video_dub")).toContain(
-        "ORDER BY vd.duration DESC, vd.id ASC",
+      expect(hydrationRawSqlContaining("FROM video_dub")).toMatch(
+        /row_number\(\)\s+OVER\s*\(\s*PARTITION BY vd\.video_id\s+ORDER BY vd\.duration DESC,\s*vd\.id ASC\s*\)\s+AS hydration_rank/,
       )
     })
 

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -611,7 +611,7 @@ async function loadHydrationDataRows(
             mv.playback_id AS "playbackId",
             row_number() OVER (
               PARTITION BY vd.video_id
-              ORDER BY vd.duration DESC
+              ORDER BY vd.duration DESC, vd.id ASC
             ) AS hydration_rank
           FROM video_dub vd
           LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
@@ -731,9 +731,10 @@ async function hydrateCardDisplayFields(
   for (const row of rows) {
     // Pick the primary-language dub when available; otherwise the
     // longest-duration playable dub. The hydration query sorts dubs by
-    // duration descending. `duration` is already in seconds (Int?); the
-    // millisecond column on VideoDub uses BigInt and isn't needed for pill
-    // display where second precision is the right fidelity.
+    // duration descending with a stable ID tie-breaker. `duration` is
+    // already in seconds (Int?); the millisecond column on VideoDub uses
+    // BigInt and isn't needed for pill display where second precision is
+    // the right fidelity.
     const primaryDub = row.primaryLanguageId
       ? row.dubs.find((d) => d.languageId === row.primaryLanguageId)
       : undefined

--- a/docs/plans/2026-06-25-002-fix-search-stable-dub-hydration-plan.md
+++ b/docs/plans/2026-06-25-002-fix-search-stable-dub-hydration-plan.md
@@ -1,0 +1,111 @@
+---
+title: "fix: Stabilize search hydrated dub selection"
+type: "fix"
+date: "2026-06-25"
+execution: "code"
+---
+
+# fix: Stabilize search hydrated dub selection
+
+## Summary
+
+Stabilize Admin search card hydration so repeated identical searches return the
+same fallback `playbackId` when multiple playable dubs share the same duration.
+The fix keeps the existing ranking, score, and hydration semantics while making
+the SQL row choice deterministic.
+
+## Problem Frame
+
+The result-preservation check for the Admin search latency PR showed stable
+result IDs, order, and scores, but `jesus` returned different hydrated
+`playbackId` values across repeated identical requests. The optimized hydration
+query ordered playable dubs by duration only; equal-duration rows could be
+returned in different orders by Postgres.
+
+## Requirements
+
+- R1. Repeated identical search requests return stable hydrated fallback
+  `playbackId` values for equal-duration dubs.
+- R2. Search result ranking, result IDs, scores, snippets, and existing
+  primary-language dub preference remain unchanged.
+- R3. The fix stays scoped to search hydration and does not alter retrievers,
+  fusion, trace writes, or query embedding caching.
+- R4. Regression coverage guards the deterministic ordering contract.
+
+## Key Technical Decisions
+
+- **Add a deterministic tie-breaker:** Keep duration-descending dub selection
+  and add a stable `video_dub` ID tie-breaker so equal-duration rows do not
+  depend on executor order.
+- **Preserve hydration semantics:** Continue selecting primary-language dubs
+  first when present, otherwise fall back to the first playable dub from the
+  bounded hydration window.
+- **Test the SQL contract directly:** Assert the hydration SQL's
+  `row_number() OVER (...)` window contains the tie-breaker because the
+  nondeterminism comes from rank ordering, not service mapping logic.
+
+## Implementation Units
+
+### U1. Stabilize Hydration Dub Ordering
+
+- **Goal:** Make the playable-dub hydration window deterministic for
+  equal-duration rows.
+- **Requirements:** R1, R2, R3
+- **Dependencies:** none
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+- **Approach:** Extend the `hydration.videoDub.query` window ordering from
+  duration-only to duration plus a stable row identifier. Keep the existing
+  per-video row cap and downstream primary-language/fallback selection.
+- **Patterns to follow:** Existing hydration query labels and display-only
+  fallback behavior in `apps/admin/src/services/hybrid-search.service.ts`.
+- **Test scenarios:**
+  - Equal-duration playable dubs are ordered with a stable tie-breaker.
+  - Primary-language dub preference remains the selected duration source when
+    available.
+- **Verification:** Repeated prod searches should keep the same result IDs,
+  order, scores, and hydrated fallback playback IDs.
+
+### U2. Add Regression Coverage
+
+- **Goal:** Prevent the hydration dub query from drifting back to nondeterminism.
+- **Requirements:** R4
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+- **Approach:** Add a focused service test that executes card hydration and
+  inspects the generated raw SQL for deterministic duration-plus-ID ordering
+  inside the `video_dub` `row_number() OVER (...)` hydration window.
+- **Patterns to follow:** Existing card-pill hydration tests in
+  `apps/admin/src/services/hybrid-search.service.test.ts`.
+- **Test scenarios:**
+  - The hydration SQL for `video_dub` orders the `row_number() OVER (...)`
+    hydration window by `vd.duration DESC, vd.id ASC`.
+  - Existing card-pill hydration tests continue to prove duration, child count,
+    playback fallback, and hydration failure behavior.
+- **Verification:** Focused Admin search tests, typecheck, lint, and CI remain
+  green.
+
+## Scope Boundaries
+
+- In scope: deterministic ordering for hydrated playable dubs used by search
+  card display fields.
+- Out of scope: search ranking changes, retriever SQL changes, trace-write
+  offloading, query embedding cache changes, and broader playback-language
+  product decisions.
+
+## Risks & Dependencies
+
+- **Data tie behavior:** The fix assumes `video_dub.id` is stable and unique,
+  which matches the Prisma model and Postgres primary-key contract.
+- **Prod parity proof:** A full old-code-vs-new-code prod DB comparison is not
+  available from the local shell because Railway exposes only private internal
+  database hosts to `railway run`.
+
+## Sources & Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-25-001-perf-admin-search-hydration-semantic-cache-plan.md`
+- `docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/services/hybrid-search.service.test.ts`

--- a/docs/solutions/database-issues/stable-admin-search-dub-hydration-ordering.md
+++ b/docs/solutions/database-issues/stable-admin-search-dub-hydration-ordering.md
@@ -1,0 +1,121 @@
+---
+title: "Stable Admin search dub hydration ordering"
+date: "2026-06-25"
+category: "database-issues"
+module: "Admin search"
+problem_type: "database_issue"
+component: "database"
+severity: "medium"
+symptoms:
+  - "Repeated identical Admin search checks sometimes returned different hydrated fallback playbackId values for jesus"
+  - "Result IDs, order, and scores stayed stable while fallback dub hydration varied"
+root_cause: "logic_error"
+resolution_type: "code_fix"
+related_components:
+  - "service_object"
+  - "testing_framework"
+tags:
+  - "admin-search"
+  - "hybrid-search"
+  - "hydration"
+  - "video-dub"
+  - "postgres-ordering"
+  - "result-parity"
+  - "deterministic-sql"
+---
+
+# Stable Admin Search Dub Hydration Ordering
+
+## Problem
+
+Repeated identical Admin search requests produced stable result IDs, order, and
+scores, but some hydrated fallback `playbackId` values varied for `jesus`
+results. The ranking pipeline was stable; the nondeterminism came from fallback
+dub hydration.
+
+## Symptoms
+
+- Same query returned the same ranked videos with the same scores.
+- Some results showed different fallback `playbackId` values across runs.
+- The instability appeared only during optimized hydration of playable
+  `video_dub` rows.
+- Primary search behavior, scoring, and semantic evidence were unchanged.
+
+## What Didn't Work
+
+- **Changing retrievers, RRF/fusion, or scoring.** Those layers already produced
+  stable ranked results, so changing them would risk search quality without
+  addressing the display-field drift.
+- **Changing query embedding cache or trace writes.** Those are timing and
+  observability concerns, not public response row-selection logic.
+- **Testing TypeScript mapping only.** The bug lived in raw SQL row ordering
+  before the mapping layer received hydrated rows.
+
+## Solution
+
+Add a deterministic tie-breaker to the `video_dub` hydration window.
+
+Before:
+
+```sql
+row_number() OVER (
+  PARTITION BY vd.video_id
+  ORDER BY vd.duration DESC
+) AS hydration_rank
+```
+
+After:
+
+```sql
+row_number() OVER (
+  PARTITION BY vd.video_id
+  ORDER BY vd.duration DESC, vd.id ASC
+) AS hydration_rank
+```
+
+The TypeScript hydration layer still preserves the product contract: prefer the
+primary-language Dub when one is available, otherwise use the first playable Dub
+from the bounded hydration window.
+
+The regression test asserts the SQL shape inside the `video_dub`
+`row_number() OVER (...)` window:
+
+```ts
+expect(hydrationRawSqlContaining("FROM video_dub")).toMatch(
+  /row_number\(\)\s+OVER\s*\(\s*PARTITION BY vd\.video_id\s+ORDER BY vd\.duration DESC,\s*vd\.id ASC\s*\)\s+AS hydration_rank/,
+)
+```
+
+## Why This Works
+
+Postgres does not guarantee a stable order for rows that compare equal on every
+`ORDER BY` expression. When multiple playable dubs for the same Video had equal
+duration, either row could receive `hydration_rank = 1`, producing different
+fallback `playbackId` values.
+
+Adding `vd.id ASC` gives the window a stable final sort key. It preserves search
+result quality because it does not alter retrievers, RRF/fusion, scoring, trace
+writes, query embedding cache behavior, or semantic evidence. It only makes the
+display hydration choice deterministic when otherwise-equivalent dub candidates
+tie.
+
+## Prevention
+
+- Include a unique, stable tie-breaker in SQL windows that select one hydrated
+  row from multiple candidates.
+- Keep SQL-shape tests for raw query behavior when the risk is database
+  ordering, not service mapping.
+- Prefer focused assertions around `row_number() OVER (...) ORDER BY ...` for
+  hydration queries that use fallback selection.
+- Preserve ranking and evidence layers when fixing hydration-only
+  nondeterminism.
+
+## Related Issues
+
+- PR #1370: `fix(search): stabilize hydrated dub selection`
+- `docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`
+- `docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md`
+- `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`
+- `docs/solutions/platform/admin-hybrid-search-r4-pattern.md`
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/services/hybrid-search.service.test.ts`

--- a/docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md
+++ b/docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md
@@ -67,6 +67,9 @@ Use a result-preserving optimization ladder:
    - image variants via a per-video `row_number()` window over `video_image`;
    - playable dubs via a per-video `row_number()` window over `video_dub`;
    - child counts via grouped raw SQL with the same published-child gate.
+     Any window that picks one hydrated row from otherwise-equivalent candidates
+     needs a stable final tie-breaker, such as `video_dub.id`, so result-preserving
+     optimizations do not create nondeterministic display fields.
 3. Preserve overlay semantics exactly. Hydrated display fields fill public card
    metadata, but existing semantic evidence still owns `startSeconds` and any
    non-empty retriever `playbackId` / `imageUrl` fallback.
@@ -130,10 +133,14 @@ call, while failures still degrade to keyword-only and remain observable.
   dimensions in the cache key so model upgrades cannot reuse stale vectors.
 - Keep health counters and health probes honest: cache hits are not provider
   attempts, and `/api/search/health` should still call the provider directly.
+- Treat deterministic hydration ordering as part of result preservation. When a
+  hydration window orders by a non-unique display attribute, add a stable
+  tie-breaker and assert it in the raw SQL shape.
 
 ## Related Issues
 
 - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/solutions/database-issues/stable-admin-search-dub-hydration-ordering.md`
 - `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
 - `docs/solutions/integration-issues/semantic-search-video-card-display-metadata-hydration.md`
 - `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`


### PR DESCRIPTION
## Summary

Repeated identical Admin search requests can now return the same hydrated fallback `playbackId` when multiple playable dubs share the same duration. Ranking, result IDs, scores, snippets, primary-language preference, retrievers, RRF/fusion, trace writes, and query embedding cache behavior are unchanged; this only stabilizes the display hydration row choice.

## What Changed

- Adds `vd.id ASC` as the stable tie-breaker inside the `video_dub` `row_number() OVER (...)` hydration window.
- Tightens the regression test so it asserts the tie-breaker is inside the hydration ranking window, not merely present somewhere in the SQL.
- Adds the formal CE plan and compounds the database-ordering lesson for future Admin search work.

## Formal CE Artifacts

- Plan: `docs/plans/2026-06-25-002-fix-search-stable-dub-hydration-plan.md`
- Review: `/tmp/compound-engineering/ce-code-review/20260625-034359-1492897f/report.md` (no actionable findings)
- Learning: `docs/solutions/database-issues/stable-admin-search-dub-hydration-ordering.md`

## Verification

- `pnpm --filter @forge/admin test -- src/services/hybrid-search.service.test.ts src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search.keyword-first.test.ts src/services/hybrid-search.regression.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`
- `pnpm exec prettier --check apps/admin/src/services/hybrid-search.service.test.ts docs/plans/2026-06-25-002-fix-search-stable-dub-hydration-plan.md docs/solutions/database-issues/stable-admin-search-dub-hydration-ordering.md docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`
- `python3 .../ce-compound/scripts/validate-frontmatter.py docs/solutions/database-issues/stable-admin-search-dub-hydration-ordering.md`
- `python3 .../ce-compound/scripts/validate-frontmatter.py docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`

## Post-Deploy Monitoring & Validation

- Run repeated production `keyword-first` Admin searches for `jesus`, `the bible project`, and `hope when life is hard` after deployment.
- Expected healthy signal: same query returns stable top result IDs, order, scores, snippets, and hydrated fallback `playbackId` values across repeated runs.
- Watch search timing logs for `hydration.videoDub.query`; expected healthy signal is no material latency regression versus the current hydration timing range.
- Failure signal: same result ID receives different fallback `playbackId` values across repeated identical requests, or `hydration.videoDub.query` shows a new sustained timing spike/error rate.
- Rollback/mitigation trigger: revert this PR if playback IDs remain unstable or hydration DB timings materially regress after deployment validation.
- Validation window/owner: first production deployment window; PR owner to run the repeated-query comparison.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
