### PR TITLE
feat(chat): adopt React Testing Library for the test suite (feat-206)

### DIFF
--- a/apps/chat/CLAUDE.md
+++ b/apps/chat/CLAUDE.md
@@ -156,12 +156,25 @@ roadmap ticket that settles the integration path (above) as explicit
   `apps/web` (the CI-proven template).
 - Tailwind v4, CSS-first (`@import "tailwindcss"` in `src/app/globals.css`;
   no tailwind.config file). Design tokens live in the `@theme` block there.
-- Tests colocated (`*.test.ts(x)`); component tests use plain
-  `react-dom/client` + `act` with per-file `// @vitest-environment jsdom`
-  (the `apps/admin` style — no testing-library). The behavioral suite lives in
-  `components/shell/app-shell.test.tsx` (AppShell owns the state); the extracted
-  `use-sidebar-chrome` hook has its own colocated unit test for its state machine
-  in isolation.
+- Tests colocated (`*.test.ts(x)`). Component tests use **React Testing
+  Library** (`render` / `screen` / `within` + `@testing-library/user-event`,
+  with `@testing-library/jest-dom` matchers); the hook test uses `renderHook`.
+  jsdom is the app-wide test env (`vitest.config.ts` `environment: "jsdom"` +
+  `vitest.setup.ts`), so there are no per-file `// @vitest-environment`
+  directives. This is a **deliberate divergence** from the `apps/admin` /
+  `apps/web` no-testing-library convention (plain `react-dom/client` + `act`),
+  scoped to chat by design — it does not change those apps. Pure-function tests
+  (`lib/conversations.test.ts`, `lib/chat-stub.test.ts`,
+  `shell/sidebar-collapsed-styles.test.ts`) stay plain vitest. The behavioral
+  suite lives in `components/shell/app-shell.test.tsx` (AppShell owns the
+  state); the extracted `use-sidebar-chrome` hook has its own colocated
+  `renderHook` unit test for its state machine in isolation. Note for the
+  behavioral suite: the reply lands via `setTimeout`, so it runs on fake timers
+  with `userEvent.setup({ advanceTimers, ... })` under
+  `vi.useFakeTimers({ shouldAdvanceTime: true })` — a plain fake clock hangs
+  user-event's awaited interactions. Layout/visibility behavior jsdom can't
+  represent (e.g. focus-restore-on-close, which depends on `offsetParent`) stays
+  **browser-verified**, not asserted in jsdom.
 - Runs on port **3200**.
 
 ### Comments

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -18,6 +18,10 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.9.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9.0.0",

--- a/apps/chat/src/components/shell/app-shell.test.tsx
+++ b/apps/chat/src/components/shell/app-shell.test.tsx
@@ -1,97 +1,79 @@
-// @vitest-environment jsdom
-
-import { act } from "react"
-import { createRoot, type Root } from "react-dom/client"
+import { act, fireEvent, render, screen, within } from "@testing-library/react"
+import userEvent, { type UserEvent } from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import * as chatStub from "@/lib/chat-stub"
 import { buildStubReply, STUB_REPLY_DELAY_MS } from "@/lib/chat-stub"
 import { deriveTitle } from "@/lib/conversations"
+
 import { AppShell } from "./app-shell"
 
-// Quiet React's "not configured to support act" warnings (same flag the
-// admin experience-editor tests set).
-;(
-  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
-).IS_REACT_ACT_ENVIRONMENT = true
-
-let container: HTMLDivElement
-let root: Root
+let user: UserEvent
+let view: ReturnType<typeof render>
+let container: HTMLElement
 
 beforeEach(() => {
-  vi.useFakeTimers()
-  container = document.createElement("div")
-  document.body.appendChild(container)
-  root = createRoot(container)
-  act(() => {
-    root.render(<AppShell />)
-  })
+  // shouldAdvanceTime lets user-event's awaited interactions resolve (a plain
+  // fake clock hangs them); awaitReply() still jumps the 800ms reply timer
+  // deterministically. cleanup() (vitest.setup.ts) unmounts after each test.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+  view = render(<AppShell />)
+  container = view.container
 })
 
 afterEach(() => {
-  act(() => {
-    root.unmount()
-  })
-  container.remove()
   vi.useRealTimers()
 })
 
 function getTextarea(): HTMLTextAreaElement {
-  const el = container.querySelector("textarea")
-  if (!el) throw new Error("textarea not found")
-  return el
+  return screen.getByRole<HTMLTextAreaElement>("textbox", { name: "Message" })
 }
 
 function getSendButton(): HTMLButtonElement {
-  const el = container.querySelector<HTMLButtonElement>('button[type="submit"]')
-  if (!el) throw new Error("send button not found")
-  return el
+  return screen.getByRole<HTMLButtonElement>("button", { name: "Send" })
 }
 
 function getLog(): HTMLElement {
-  const el = container.querySelector<HTMLElement>('[role="log"]')
-  if (!el) throw new Error("log container not found")
-  return el
+  return screen.getByRole("log", { name: "Conversation" })
 }
 
-function typeDraft(value: string) {
-  act(() => {
-    const el = getTextarea()
-    // React tracks the value through its own setter; use the native
-    // prototype setter so the dispatched input event carries the change.
-    const setter = Object.getOwnPropertyDescriptor(
-      HTMLTextAreaElement.prototype,
-      "value",
-    )?.set
-    setter?.call(el, value)
-    el.dispatchEvent(new Event("input", { bubbles: true }))
-  })
+function getConversationNav(): HTMLElement {
+  return screen.getByRole("navigation", { name: "Conversations" })
 }
 
-function pressEnter(options: { shiftKey?: boolean } = {}) {
-  act(() => {
-    getTextarea().dispatchEvent(
-      new KeyboardEvent("keydown", {
-        key: "Enter",
-        bubbles: true,
-        cancelable: true,
-        shiftKey: options.shiftKey ?? false,
-      }),
-    )
-  })
+// Scope message reads to the conversation log so sidebar rows (also listitems)
+// never leak in. The pending turn is a listitem too (as the old querySelectorAll
+// "li" was), so exact-count assertions run after awaitReply(), never mid-pending.
+function messageTexts(): string[] {
+  return within(getLog())
+    .queryAllByRole("listitem")
+    .map((li) => li.textContent ?? "")
 }
 
-function submitForm() {
-  act(() => {
-    const form = container.querySelector("form")
-    if (!form) throw new Error("form not found")
-    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
-  })
+function isPending(): boolean {
+  return getLog().querySelector("[data-pending]") !== null
 }
 
-function sendMessage(text: string) {
-  typeDraft(text)
-  submitForm()
+// The "New conversation" action and a default-titled conversation row share the
+// same accessible name; the action is the one outside the conversation nav.
+function getNewConversationAction(): HTMLButtonElement {
+  const nav = getConversationNav()
+  const action = screen
+    .getAllByRole("button", { name: "New conversation" })
+    .find((b) => !nav.contains(b))
+  if (!action) throw new Error("New conversation action button not found")
+  return action as HTMLButtonElement
+}
+
+// How many sidebar rows show the per-conversation "replying" pulse.
+function sidebarReplyingCount(): number {
+  return getConversationNav().querySelectorAll("[data-replying]").length
+}
+
+async function sendMessage(text: string) {
+  await user.type(getTextarea(), text)
+  await user.click(getSendButton())
 }
 
 function awaitReply() {
@@ -100,182 +82,118 @@ function awaitReply() {
   })
 }
 
-// Scope message reads to the conversation log so sidebar list items (also <li>)
-// never leak into the counts.
-function messageTexts(): string[] {
-  return Array.from(getLog().querySelectorAll("li")).map(
-    (li) => li.textContent ?? "",
+async function clickNewConversation() {
+  await user.click(getNewConversationAction())
+}
+
+// Click a conversation in the rail by its visible title. Scoped to the nav so
+// the "New conversation" action is never matched.
+async function selectSidebarConversation(title: string) {
+  await user.click(
+    within(getConversationNav()).getByRole("button", { name: title }),
   )
-}
-
-function isPending(): boolean {
-  return getLog().querySelector("[data-pending]") !== null
-}
-
-function getConversationNav(): HTMLElement {
-  const el = container.querySelector<HTMLElement>(
-    'nav[aria-label="Conversations"]',
-  )
-  if (!el) throw new Error("conversation nav not found")
-  return el
-}
-
-function clickNewConversation() {
-  act(() => {
-    const newButton = Array.from(
-      container.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
-    ).find((b) => b.textContent?.includes("New conversation"))
-    if (!newButton) throw new Error("New conversation button not found")
-    newButton.click()
-  })
-}
-
-// Click a conversation in the sidebar rail by its visible title. Scoped to the
-// nav so the "New conversation" action is never matched.
-function selectSidebarConversation(title: string) {
-  act(() => {
-    const btn = Array.from(
-      getConversationNav().querySelectorAll<HTMLButtonElement>("button"),
-    ).find((b) => b.textContent?.includes(title))
-    if (!btn) throw new Error(`sidebar conversation "${title}" not found`)
-    btn.click()
-  })
-}
-
-// How many sidebar rows show the per-conversation "replying" pulse.
-function sidebarReplyingCount(): number {
-  return getConversationNav().querySelectorAll("[data-replying]").length
 }
 
 describe("AppShell", () => {
   it("renders the empty-state prompt and stub note when no messages exist", () => {
-    expect(container.textContent).toContain("What would you like to ask?")
-    expect(container.textContent).toContain("no agent is connected yet")
+    expect(container).toHaveTextContent("What would you like to ask?")
+    expect(container).toHaveTextContent("no agent is connected yet")
   })
 
-  it("removes the empty state after the first send, before the reply arrives", () => {
-    sendMessage("hello")
-    expect(container.textContent).not.toContain("What would you like to ask?")
+  it("removes the empty state after the first send, before the reply arrives", async () => {
+    await sendMessage("hello")
+    expect(container).not.toHaveTextContent("What would you like to ask?")
   })
 
-  it("appends the user message, shows pending, disables controls, then replies and re-enables", () => {
-    sendMessage("hello")
+  it("appends the user message, shows pending, disables controls, then replies and re-enables", async () => {
+    await sendMessage("hello")
 
     expect(messageTexts()).toContain("hello")
     expect(isPending()).toBe(true)
-    expect(getTextarea().disabled).toBe(true)
-    expect(getSendButton().disabled).toBe(true)
+    expect(getTextarea()).toBeDisabled()
+    expect(getSendButton()).toBeDisabled()
 
     awaitReply()
 
     expect(isPending()).toBe(false)
-    expect(getTextarea().disabled).toBe(false)
+    expect(getTextarea()).toBeEnabled()
     expect(messageTexts()).toHaveLength(2)
   })
 
-  it("replies with exactly buildStubReply of the sent text", () => {
-    sendMessage("what is this?")
+  it("replies with exactly buildStubReply of the sent text", async () => {
+    await sendMessage("what is this?")
     awaitReply()
     expect(messageTexts()[1]).toBe(buildStubReply("what is this?"))
   })
 
-  it("disables the send button on empty or whitespace-only input while idle", () => {
-    expect(getSendButton().disabled).toBe(true)
-    typeDraft("   ")
-    expect(getSendButton().disabled).toBe(true)
-    typeDraft("hi")
-    expect(getSendButton().disabled).toBe(false)
+  it("disables the send button on empty or whitespace-only input while idle", async () => {
+    expect(getSendButton()).toBeDisabled()
+    await user.type(getTextarea(), "   ")
+    expect(getSendButton()).toBeDisabled()
+    await user.type(getTextarea(), "hi")
+    expect(getSendButton()).toBeEnabled()
   })
 
-  it("treats whitespace-only submit as a no-op", () => {
-    typeDraft("   ")
-    submitForm()
+  it("treats whitespace-only submit as a no-op", async () => {
+    await user.type(getTextarea(), "   ")
+    // Enter bypasses the disabled send button, so this exercises the hook's
+    // whitespace guard rather than the button's disabled state.
+    await user.keyboard("{Enter}")
     expect(messageTexts()).toHaveLength(0)
-    expect(container.textContent).toContain("What would you like to ask?")
+    expect(container).toHaveTextContent("What would you like to ask?")
   })
 
-  it("ignores a rapid double-submit before re-render", () => {
-    typeDraft("once")
-    act(() => {
-      const form = container.querySelector("form")
-      if (!form) throw new Error("form not found")
-      const submit = () =>
-        form.dispatchEvent(
-          new Event("submit", { bubbles: true, cancelable: true }),
-        )
-      submit()
-      submit()
-    })
+  it("ignores a rapid double-submit before re-render", async () => {
+    await user.type(getTextarea(), "once")
+    // Two synchronous submits in one render cycle — the double-send guard must
+    // collapse them to one message (awaited user.click would re-render between and
+    // dissolve the test). The form has no role/name, so query it from container.
+    const form = container.querySelector("form")
+    if (!form) throw new Error("form not found")
+    fireEvent.submit(form)
+    fireEvent.submit(form)
     awaitReply()
     expect(messageTexts()).toHaveLength(2)
   })
 
-  it("sends on Enter; Shift+Enter does not send", () => {
-    // Note: jsdom does not simulate native textarea newline insertion on
-    // keydown, so this pins only the no-send half of the Shift+Enter
-    // contract. The newline-insertion behavior is a manual smoke check.
-    typeDraft("enter sends")
-    pressEnter()
+  it("sends on Enter; Shift+Enter does not send", async () => {
+    await user.type(getTextarea(), "enter sends{Enter}")
     expect(messageTexts()).toContain("enter sends")
 
     awaitReply()
 
-    typeDraft("no send")
-    pressEnter({ shiftKey: true })
+    // Shift+Enter inserts a newline instead of sending — user-event simulates
+    // the native newline the old synthetic dispatch could not, so the retained
+    // draft now carries the "\n".
+    await user.type(getTextarea(), "no send")
+    await user.keyboard("{Shift>}{Enter}{/Shift}")
     expect(messageTexts()).not.toContain("no send")
-    expect(getTextarea().value).toBe("no send")
+    expect(getTextarea()).toHaveValue("no send\n")
   })
 
-  it("clears the input on send", () => {
-    sendMessage("clear me")
-    expect(getTextarea().value).toBe("")
+  it("clears the input on send", async () => {
+    await sendMessage("clear me")
+    expect(getTextarea()).toHaveValue("")
   })
 
-  it("cleans up the pending timer on unmount without state-update warnings", () => {
-    // Own isolated root/container so unmounting here doesn't collide with
-    // the shared root that afterEach tears down.
-    const localContainer = document.createElement("div")
-    document.body.appendChild(localContainer)
-    const localRoot = createRoot(localContainer)
-    act(() => {
-      localRoot.render(<AppShell />)
-    })
-
+  it("cleans up the pending timer on unmount without state-update warnings", async () => {
     const errorSpy = vi.spyOn(console, "error")
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(
-        HTMLTextAreaElement.prototype,
-        "value",
-      )?.set
-      const el = localContainer.querySelector("textarea")
-      if (!el) throw new Error("textarea not found")
-      setter?.call(el, "unmount race")
-      el.dispatchEvent(new Event("input", { bubbles: true }))
-    })
-    act(() => {
-      const form = localContainer.querySelector("form")
-      if (!form) throw new Error("form not found")
-      form.dispatchEvent(
-        new Event("submit", { bubbles: true, cancelable: true }),
-      )
-    })
 
-    act(() => {
-      localRoot.unmount()
-    })
+    await sendMessage("unmount race")
+    view.unmount()
     act(() => {
       vi.runAllTimers()
     })
+
     expect(vi.getTimerCount()).toBe(0)
     expect(errorSpy).not.toHaveBeenCalled()
     errorSpy.mockRestore()
-    localContainer.remove()
   })
 
-  it("keeps history append-only with alternating roles across exchanges", () => {
-    sendMessage("first")
+  it("keeps history append-only with alternating roles across exchanges", async () => {
+    await sendMessage("first")
     awaitReply()
-    sendMessage("second")
+    await sendMessage("second")
     awaitReply()
 
     const texts = messageTexts()
@@ -287,41 +205,35 @@ describe("AppShell", () => {
     expect(isPending()).toBe(false)
   })
 
-  it("exposes the conversation as a labeled log with the pending turn inside it", () => {
+  it("exposes the conversation as a labeled log with the pending turn inside it", async () => {
     const log = getLog()
-    expect(log.getAttribute("aria-label")).toBe("Conversation")
-    expect(getTextarea().getAttribute("aria-label")).toBe("Message")
+    expect(log).toHaveAttribute("aria-label", "Conversation")
+    expect(getTextarea()).toHaveAttribute("aria-label", "Message")
 
-    sendMessage("a11y")
-    expect(log.querySelector("[data-pending]")).not.toBeNull()
+    await sendMessage("a11y")
+    expect(getLog().querySelector("[data-pending]")).not.toBeNull()
   })
 
-  it("starts a fresh empty conversation from the New conversation action", () => {
-    sendMessage("keep me")
+  it("starts a fresh empty conversation from the New conversation action", async () => {
+    await sendMessage("keep me")
     awaitReply()
     expect(messageTexts()).toHaveLength(2)
 
-    act(() => {
-      const newButton = Array.from(
-        container.querySelectorAll<HTMLButtonElement>('button[type="button"]'),
-      ).find((b) => b.textContent?.includes("New conversation"))
-      if (!newButton) throw new Error("New conversation button not found")
-      newButton.click()
-    })
+    await clickNewConversation()
 
     // New active conversation is empty again; the old one still lives in the rail.
     expect(messageTexts()).toHaveLength(0)
-    expect(container.textContent).toContain("What would you like to ask?")
-    expect(container.textContent).toContain("keep me")
+    expect(container).toHaveTextContent("What would you like to ask?")
+    expect(container).toHaveTextContent("keep me")
   })
 
-  it("auto-titles the prior conversation in the rail from its first message", () => {
-    sendMessage("keep me titled")
+  it("auto-titles the prior conversation in the rail from its first message", async () => {
+    await sendMessage("keep me titled")
     awaitReply()
 
-    const titles = Array.from(
-      getConversationNav().querySelectorAll<HTMLButtonElement>("button"),
-    ).map((b) => b.textContent ?? "")
+    const titles = within(getConversationNav())
+      .getAllByRole("button")
+      .map((b) => b.textContent ?? "")
     // Explicit: the rail row shows the derived title, not the default
     // "New conversation" placeholder (the message-list text is excluded
     // because we only read the sidebar nav).
@@ -329,34 +241,34 @@ describe("AppShell", () => {
     expect(titles).not.toContain("New conversation")
   })
 
-  it("keeps a reply routed to its originating conversation when the user switches mid-reply", () => {
-    sendMessage("question in A")
+  it("keeps a reply routed to its originating conversation when the user switches mid-reply", async () => {
+    await sendMessage("question in A")
     // Switch to a fresh conversation before A's stub reply fires.
-    clickNewConversation()
+    await clickNewConversation()
 
     // The new conversation is genuinely idle: empty, not pending, composer live.
     expect(messageTexts()).toHaveLength(0)
     expect(isPending()).toBe(false)
-    expect(getTextarea().disabled).toBe(false)
+    expect(getTextarea()).toBeEnabled()
 
     awaitReply()
 
     // The reply landed in A, not the conversation that was active when it fired.
-    selectSidebarConversation(deriveTitle("question in A"))
+    await selectSidebarConversation(deriveTitle("question in A"))
     const texts = messageTexts()
     expect(texts).toHaveLength(2)
     expect(texts[0]).toBe("question in A")
     expect(texts[1]).toBe(buildStubReply("question in A"))
   })
 
-  it("attaches the pending pulse to the awaiting conversation, not whichever is active", () => {
-    sendMessage("first")
+  it("attaches the pending pulse to the awaiting conversation, not whichever is active", async () => {
+    await sendMessage("first")
     expect(sidebarReplyingCount()).toBe(1)
 
-    clickNewConversation()
+    await clickNewConversation()
     // Active pane (the new, empty conversation) shows no pending cursor...
     expect(isPending()).toBe(false)
-    expect(getTextarea().disabled).toBe(false)
+    expect(getTextarea()).toBeEnabled()
     // ...but the rail still marks the original conversation as replying.
     expect(sidebarReplyingCount()).toBe(1)
 
@@ -364,11 +276,11 @@ describe("AppShell", () => {
     expect(sidebarReplyingCount()).toBe(0)
   })
 
-  it("allows sending in a second conversation while the first is still pending", () => {
-    sendMessage("alpha")
-    clickNewConversation()
+  it("allows sending in a second conversation while the first is still pending", async () => {
+    await sendMessage("alpha")
+    await clickNewConversation()
     // This send must NOT be swallowed by a cross-conversation lock.
-    sendMessage("beta")
+    await sendMessage("beta")
 
     expect(messageTexts()).toContain("beta")
     expect(sidebarReplyingCount()).toBe(2)
@@ -378,22 +290,22 @@ describe("AppShell", () => {
 
     // Each reply landed in its own conversation.
     expect(messageTexts()).toEqual(["beta", buildStubReply("beta")])
-    selectSidebarConversation(deriveTitle("alpha"))
+    await selectSidebarConversation(deriveTitle("alpha"))
     expect(messageTexts()).toEqual(["alpha", buildStubReply("alpha")])
   })
 
-  it("restores a prior conversation's messages when reselected from the rail", () => {
-    sendMessage("conv one")
+  it("restores a prior conversation's messages when reselected from the rail", async () => {
+    await sendMessage("conv one")
     awaitReply()
-    clickNewConversation()
-    sendMessage("conv two")
+    await clickNewConversation()
+    await sendMessage("conv two")
     awaitReply()
 
-    selectSidebarConversation(deriveTitle("conv one"))
+    await selectSidebarConversation(deriveTitle("conv one"))
     expect(messageTexts()).toEqual(["conv one", buildStubReply("conv one")])
   })
 
-  it("releases the pending slot when reply generation throws, so the conversation can send again", () => {
+  it("releases the pending slot when reply generation throws, so the conversation can send again", async () => {
     // Latent with the pure stub, but this is the slot-leak guard that matters
     // once the real (rejectable) Mastra call replaces buildStubReply: the
     // finally must clear the timer/pending slot even on a throw.
@@ -403,29 +315,34 @@ describe("AppShell", () => {
         throw new Error("reply boom")
       })
 
-    sendMessage("trigger throw")
+    await sendMessage("trigger throw")
     expect(isPending()).toBe(true)
 
     // The thrown reply propagates out of the timer, but the finally already
     // ran clearTimer, freeing the per-conversation slot.
     expect(() => awaitReply()).toThrow("reply boom")
 
+    // The throw escaped before React committed the slot-release re-render;
+    // flush it so the composer reflects the cleared (enabled) state.
+    act(() => {})
+    expect(getTextarea()).toBeEnabled()
+
     // Proof the slot was released: a fresh send is accepted (not swallowed by
     // the double-send guard) and resolves cleanly, leaving the pane idle.
     spy.mockRestore()
-    sendMessage("after throw")
+    await sendMessage("after throw")
     expect(messageTexts()).toContain("after throw")
     awaitReply()
     expect(isPending()).toBe(false)
-    expect(getTextarea().disabled).toBe(false)
+    expect(getTextarea()).toBeEnabled()
   })
 
-  it("treats reselecting the active conversation as a no-op and keeps the draft", () => {
+  it("treats reselecting the active conversation as a no-op and keeps the draft", async () => {
     // The sole conversation starts active with the default title. Reselecting
     // it must hit the early-return guard (no draft reset).
-    typeDraft("draft in progress")
-    selectSidebarConversation("New conversation")
-    expect(getTextarea().value).toBe("draft in progress")
+    await user.type(getTextarea(), "draft in progress")
+    await selectSidebarConversation("New conversation")
+    expect(getTextarea()).toHaveValue("draft in progress")
   })
 })
 
@@ -444,21 +361,6 @@ function getMain(): HTMLElement {
   return el
 }
 
-// Find a button by accessible label, scoped so the desktop expand toggle and
-// the mobile menu trigger don't collide across responsive contexts.
-function buttonByLabel(label: string, scope: ParentNode = container) {
-  return Array.from(scope.querySelectorAll<HTMLButtonElement>("button")).find(
-    (b) => b.getAttribute("aria-label") === label,
-  )
-}
-
-function clickButton(el: HTMLButtonElement | undefined) {
-  if (!el) throw new Error("button to click not found")
-  act(() => {
-    el.click()
-  })
-}
-
 function drawerOpen(): boolean {
   return getAside().getAttribute("data-open") === "true"
 }
@@ -466,56 +368,79 @@ function drawerOpen(): boolean {
 describe("Sidebar shell", () => {
   it("starts expanded: wordmark, collapse toggle, and the conversation list are present", () => {
     const aside = getAside()
-    expect(aside.textContent).toContain("jesusfilm.ai")
-    expect(buttonByLabel("Collapse sidebar", aside)).toBeTruthy()
-    expect(buttonByLabel("Open sidebar", aside)).toBeFalsy()
+    expect(aside).toHaveTextContent("jesusfilm.ai")
     expect(
-      aside.querySelector('nav[aria-label="Conversations"]'),
-    ).not.toBeNull()
+      within(aside).getByRole("button", { name: "Collapse sidebar" }),
+    ).toBeInTheDocument()
+    expect(
+      within(aside).queryByRole("button", { name: "Open sidebar" }),
+    ).toBeNull()
+    expect(
+      within(aside).getByRole("navigation", { name: "Conversations" }),
+    ).toBeInTheDocument()
   })
 
-  it("collapses and re-expands the desktop rail via the toggle", () => {
+  it("collapses and re-expands the desktop rail via the toggle", async () => {
     const aside = getAside()
-    clickButton(buttonByLabel("Collapse sidebar", aside))
+    await user.click(
+      within(aside).getByRole("button", { name: "Collapse sidebar" }),
+    )
     // Collapsed: the in-rail expand affordance appears; collapse toggle is gone.
-    expect(buttonByLabel("Open sidebar", aside)).toBeTruthy()
-    expect(buttonByLabel("Collapse sidebar", aside)).toBeFalsy()
+    expect(
+      within(aside).getByRole("button", { name: "Open sidebar" }),
+    ).toBeInTheDocument()
+    expect(
+      within(aside).queryByRole("button", { name: "Collapse sidebar" }),
+    ).toBeNull()
 
-    clickButton(buttonByLabel("Open sidebar", aside))
-    expect(buttonByLabel("Collapse sidebar", aside)).toBeTruthy()
-    expect(buttonByLabel("Open sidebar", aside)).toBeFalsy()
+    await user.click(
+      within(aside).getByRole("button", { name: "Open sidebar" }),
+    )
+    expect(
+      within(aside).getByRole("button", { name: "Collapse sidebar" }),
+    ).toBeInTheDocument()
+    expect(
+      within(aside).queryByRole("button", { name: "Open sidebar" }),
+    ).toBeNull()
   })
 
-  it("opens the mobile drawer from the menu trigger and closes it via the X, toggling aria-expanded", () => {
-    const trigger = buttonByLabel("Open menu", getMain())
+  it("opens the mobile drawer from the menu trigger and closes it via the X, toggling aria-expanded", async () => {
     expect(drawerOpen()).toBe(false)
-    expect(trigger?.getAttribute("aria-expanded")).toBe("false")
+    expect(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    ).toHaveAttribute("aria-expanded", "false")
 
-    clickButton(trigger)
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    )
     expect(drawerOpen()).toBe(true)
     expect(
-      buttonByLabel("Open menu", getMain())?.getAttribute("aria-expanded"),
-    ).toBe("true")
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    ).toHaveAttribute("aria-expanded", "true")
     // Open drawer carries dialog semantics; the desktop rail does not.
-    expect(getAside().getAttribute("role")).toBe("dialog")
+    expect(getAside()).toHaveAttribute("role", "dialog")
 
-    clickButton(buttonByLabel("Close sidebar", getAside()))
+    await user.click(
+      within(getAside()).getByRole("button", { name: "Close sidebar" }),
+    )
     expect(drawerOpen()).toBe(false)
-    expect(getAside().getAttribute("role")).toBeNull()
+    expect(getAside()).not.toHaveAttribute("role")
   })
 
-  it("closes the mobile drawer on Escape", () => {
-    clickButton(buttonByLabel("Open menu", getMain()))
+  it("closes the mobile drawer on Escape", async () => {
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    )
     expect(drawerOpen()).toBe(true)
 
-    act(() => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
-    })
+    await user.keyboard("{Escape}")
     expect(drawerOpen()).toBe(false)
   })
 
-  it("closes the mobile drawer when the scrim is clicked", () => {
-    clickButton(buttonByLabel("Open menu", getMain()))
+  it("closes the mobile drawer when the scrim is clicked", async () => {
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    )
     expect(drawerOpen()).toBe(true)
 
     // The scrim is the aria-hidden sibling of the aside carrying onCloseMobile.
@@ -523,31 +448,33 @@ describe("Sidebar shell", () => {
       'div[aria-hidden="true"]',
     )
     if (!scrim) throw new Error("scrim not found")
-    act(() => {
-      scrim.click()
-    })
+    await user.click(scrim)
     expect(drawerOpen()).toBe(false)
   })
 
-  it("closes the mobile drawer when New conversation is tapped", () => {
-    clickButton(buttonByLabel("Open menu", getMain()))
+  it("closes the mobile drawer when New conversation is tapped", async () => {
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    )
     expect(drawerOpen()).toBe(true)
 
-    clickNewConversation()
+    await clickNewConversation()
     expect(drawerOpen()).toBe(false)
   })
 
-  it("navigates and closes the drawer when a non-active conversation is selected", () => {
+  it("navigates and closes the drawer when a non-active conversation is selected", async () => {
     // Two conversations so the selection actually changes the active one
     // (clicking the already-active row early-returns and proves nothing).
-    sendMessage("first conversation")
+    await sendMessage("first conversation")
     awaitReply()
-    clickNewConversation()
+    await clickNewConversation()
 
-    clickButton(buttonByLabel("Open menu", getMain()))
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    )
     expect(drawerOpen()).toBe(true)
 
-    selectSidebarConversation(deriveTitle("first conversation"))
+    await selectSidebarConversation(deriveTitle("first conversation"))
     expect(drawerOpen()).toBe(false)
     expect(messageTexts()).toEqual([
       "first conversation",
@@ -555,32 +482,42 @@ describe("Sidebar shell", () => {
     ])
   })
 
-  it("marks <main> inert only while the mobile drawer is open (focus trap)", () => {
-    expect(getMain().hasAttribute("inert")).toBe(false)
+  it("marks <main> inert only while the mobile drawer is open (focus trap)", async () => {
+    expect(getMain()).not.toHaveAttribute("inert")
 
-    clickButton(buttonByLabel("Open menu", getMain()))
-    expect(getMain().hasAttribute("inert")).toBe(true)
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    )
+    expect(getMain()).toHaveAttribute("inert")
 
-    clickButton(buttonByLabel("Close sidebar", getAside()))
-    expect(getMain().hasAttribute("inert")).toBe(false)
+    await user.click(
+      within(getAside()).getByRole("button", { name: "Close sidebar" }),
+    )
+    expect(getMain()).not.toHaveAttribute("inert")
   })
 
-  it("locks body scroll while the mobile drawer is open and restores it on close", () => {
+  it("locks body scroll while the mobile drawer is open and restores it on close", async () => {
     expect(document.body.style.overflow).toBe("")
 
-    clickButton(buttonByLabel("Open menu", getMain()))
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
+    )
     expect(document.body.style.overflow).toBe("hidden")
 
-    clickButton(buttonByLabel("Close sidebar", getAside()))
+    await user.click(
+      within(getAside()).getByRole("button", { name: "Close sidebar" }),
+    )
     expect(document.body.style.overflow).toBe("")
   })
 
-  it("moves focus to the close button when the mobile drawer opens", () => {
+  it("moves focus to the close button when the mobile drawer opens", async () => {
     // Open direction is jsdom-testable; focus *restore* on close depends on a
     // visibility guard jsdom can't represent (no layout), so it's browser-verified.
-    clickButton(buttonByLabel("Open menu", getMain()))
-    expect(document.activeElement).toBe(
-      buttonByLabel("Close sidebar", getAside()),
+    await user.click(
+      within(getMain()).getByRole("button", { name: "Open menu" }),
     )
+    expect(
+      within(getAside()).getByRole("button", { name: "Close sidebar" }),
+    ).toHaveFocus()
   })
 })

--- a/apps/chat/src/components/shell/sidebar-conversation-list.test.tsx
+++ b/apps/chat/src/components/shell/sidebar-conversation-list.test.tsx
@@ -1,31 +1,17 @@
-// @vitest-environment jsdom
-
-import { act } from "react"
-import { createRoot, type Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import userEvent, { type UserEvent } from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { type Conversation } from "@/lib/conversations"
 
 import { collapsedStyles } from "./sidebar-collapsed-styles"
 import { ConversationList } from "./sidebar-conversation-list"
-;(
-  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
-).IS_REACT_ACT_ENVIRONMENT = true
 
-let container: HTMLDivElement
-let root: Root
-
+// Built per test (not at module load) so the instance never predates a future
+// fake-timer install in this file — matches app-shell.test.tsx.
+let user: UserEvent
 beforeEach(() => {
-  container = document.createElement("div")
-  document.body.appendChild(container)
-  root = createRoot(container)
-})
-
-afterEach(() => {
-  act(() => {
-    root.unmount()
-  })
-  container.remove()
+  user = userEvent.setup()
 })
 
 const conversations: Conversation[] = [
@@ -41,8 +27,8 @@ type Overrides = {
   onCloseMobile?: () => void
 }
 
-function render(overrides: Overrides = {}) {
-  const props = {
+function buildProps(overrides: Overrides = {}) {
+  return {
     conversations: overrides.conversations ?? conversations,
     activeId: overrides.activeId ?? "a",
     pendingIds: overrides.pendingIds ?? new Set<string>(),
@@ -50,28 +36,27 @@ function render(overrides: Overrides = {}) {
     onSelect: overrides.onSelect ?? (() => {}),
     onCloseMobile: overrides.onCloseMobile ?? (() => {}),
   }
-  act(() => {
-    root.render(<ConversationList {...props} />)
-  })
 }
 
-function rowByTitle(title: string): HTMLButtonElement {
-  const btn = Array.from(
-    container.querySelectorAll<HTMLButtonElement>("nav button"),
-  ).find((b) => b.textContent?.includes(title))
-  if (!btn) throw new Error(`row "${title}" not found`)
-  return btn
+function renderList(overrides: Overrides = {}) {
+  return render(<ConversationList {...buildProps(overrides)} />)
+}
+
+// Match by substring (regex) so a replying row — whose accessible name gains an
+// sr-only "Replying" — still resolves by its title alone.
+function rowByTitle(title: string): HTMLElement {
+  return within(
+    screen.getByRole("navigation", { name: "Conversations" }),
+  ).getByRole("button", { name: new RegExp(title) })
 }
 
 describe("ConversationList", () => {
-  it("selects a conversation and closes the mobile drawer on row click", () => {
+  it("selects a conversation and closes the mobile drawer on row click", async () => {
     const onSelect = vi.fn()
     const onCloseMobile = vi.fn()
-    render({ onSelect, onCloseMobile })
+    renderList({ onSelect, onCloseMobile })
 
-    act(() => {
-      rowByTitle("Second chat").click()
-    })
+    await user.click(rowByTitle("Second chat"))
 
     // Both fire on a single click — selecting also dismisses the drawer.
     expect(onSelect).toHaveBeenCalledTimes(1)
@@ -80,13 +65,13 @@ describe("ConversationList", () => {
   })
 
   it("marks only the active row with aria-current", () => {
-    render({ activeId: "b" })
-    expect(rowByTitle("Second chat").getAttribute("aria-current")).toBe("true")
-    expect(rowByTitle("First chat").getAttribute("aria-current")).toBeNull()
+    renderList({ activeId: "b" })
+    expect(rowByTitle("Second chat")).toHaveAttribute("aria-current", "true")
+    expect(rowByTitle("First chat")).not.toHaveAttribute("aria-current")
   })
 
   it("renders the replying pulse only on conversations awaiting a reply", () => {
-    render({ pendingIds: new Set(["a"]) })
+    renderList({ pendingIds: new Set(["a"]) })
     expect(
       rowByTitle("First chat").querySelector("[data-replying]"),
     ).not.toBeNull()
@@ -94,13 +79,13 @@ describe("ConversationList", () => {
       rowByTitle("Second chat").querySelector("[data-replying]"),
     ).toBeNull()
     // The pulse carries an sr-only label so it is announced, not silent.
-    expect(rowByTitle("First chat").textContent).toContain("Replying")
+    expect(rowByTitle("First chat")).toHaveTextContent("Replying")
   })
 
   it("renders the labeled nav with no rows when there are no conversations", () => {
-    render({ conversations: [], activeId: "" })
-    const nav = container.querySelector('nav[aria-label="Conversations"]')
-    expect(nav).not.toBeNull()
-    expect(nav?.querySelectorAll("li")).toHaveLength(0)
+    renderList({ conversations: [], activeId: "" })
+    const nav = screen.getByRole("navigation", { name: "Conversations" })
+    expect(nav).toBeInTheDocument()
+    expect(within(nav).queryAllByRole("listitem")).toHaveLength(0)
   })
 })

--- a/apps/chat/src/components/shell/sidebar-header.test.tsx
+++ b/apps/chat/src/components/shell/sidebar-header.test.tsx
@@ -1,29 +1,16 @@
-// @vitest-environment jsdom
-
-import { act, createRef } from "react"
-import { createRoot, type Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent, { type UserEvent } from "@testing-library/user-event"
+import { createRef } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { collapsedStyles } from "./sidebar-collapsed-styles"
 import { SidebarHeader } from "./sidebar-header"
-;(
-  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
-).IS_REACT_ACT_ENVIRONMENT = true
 
-let container: HTMLDivElement
-let root: Root
-
+// Built per test (not at module load) so the instance never predates a future
+// fake-timer install in this file — matches app-shell.test.tsx.
+let user: UserEvent
 beforeEach(() => {
-  container = document.createElement("div")
-  document.body.appendChild(container)
-  root = createRoot(container)
-})
-
-afterEach(() => {
-  act(() => {
-    root.unmount()
-  })
-  container.remove()
+  user = userEvent.setup()
 })
 
 type Overrides = {
@@ -33,82 +20,79 @@ type Overrides = {
   onCloseMobile?: () => void
 }
 
-function render(overrides: Overrides = {}) {
-  const props = {
+function buildProps(overrides: Overrides = {}) {
+  return {
     collapsed: overrides.collapsed ?? false,
     styles: collapsedStyles(overrides.collapsed ?? false),
     closeRef: overrides.closeRef ?? createRef<HTMLButtonElement>(),
     onToggleCollapsed: overrides.onToggleCollapsed ?? (() => {}),
     onCloseMobile: overrides.onCloseMobile ?? (() => {}),
   }
-  act(() => {
-    root.render(<SidebarHeader {...props} />)
-  })
 }
 
-function buttonByLabel(label: string): HTMLButtonElement | undefined {
-  return Array.from(
-    container.querySelectorAll<HTMLButtonElement>("button"),
-  ).find((b) => b.getAttribute("aria-label") === label)
-}
-
-// Throws a descriptive error (not a bare undefined deref) if the button is
-// absent — mirrors app-shell.test.tsx's clickButton guard.
-function clickByLabel(label: string) {
-  const button = buttonByLabel(label)
-  if (!button) throw new Error(`button "${label}" not found`)
-  act(() => {
-    button.click()
-  })
+function renderHeader(overrides: Overrides = {}) {
+  return render(<SidebarHeader {...buildProps(overrides)} />)
 }
 
 describe("SidebarHeader", () => {
   it("shows the collapse toggle (not the expand affordance) when expanded", () => {
-    render({ collapsed: false })
-    expect(buttonByLabel("Collapse sidebar")).toBeTruthy()
-    expect(buttonByLabel("Open sidebar")).toBeFalsy()
-    expect(container.textContent).toContain("jesusfilm.ai")
+    const { container } = renderHeader({ collapsed: false })
+    expect(
+      screen.getByRole("button", { name: "Collapse sidebar" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Open sidebar" })).toBeNull()
+    expect(container).toHaveTextContent("jesusfilm.ai")
   })
 
   it("shows the expand affordance (not the collapse toggle) when collapsed", () => {
-    render({ collapsed: true })
-    expect(buttonByLabel("Open sidebar")).toBeTruthy()
-    expect(buttonByLabel("Collapse sidebar")).toBeFalsy()
+    renderHeader({ collapsed: true })
+    expect(
+      screen.getByRole("button", { name: "Open sidebar" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Collapse sidebar" }),
+    ).toBeNull()
   })
 
-  it("fires onToggleCollapsed from the collapse toggle when expanded", () => {
+  it("fires onToggleCollapsed from the collapse toggle when expanded", async () => {
     const onToggleCollapsed = vi.fn()
-    render({ collapsed: false, onToggleCollapsed })
-    clickByLabel("Collapse sidebar")
+    renderHeader({ collapsed: false, onToggleCollapsed })
+    await user.click(screen.getByRole("button", { name: "Collapse sidebar" }))
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1)
   })
 
-  it("fires onToggleCollapsed from the expand affordance when collapsed", () => {
+  it("fires onToggleCollapsed from the expand affordance when collapsed", async () => {
     const onToggleCollapsed = vi.fn()
-    render({ collapsed: true, onToggleCollapsed })
-    clickByLabel("Open sidebar")
+    renderHeader({ collapsed: true, onToggleCollapsed })
+    await user.click(screen.getByRole("button", { name: "Open sidebar" }))
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1)
   })
 
   it("renders the mobile close button in both collapsed states", () => {
     // The X lives in the drawer regardless of the desktop collapse flag, so it
     // must render whether expanded or collapsed.
-    render({ collapsed: false })
-    expect(buttonByLabel("Close sidebar")).toBeTruthy()
-    render({ collapsed: true })
-    expect(buttonByLabel("Close sidebar")).toBeTruthy()
+    const { rerender } = renderHeader({ collapsed: false })
+    expect(
+      screen.getByRole("button", { name: "Close sidebar" }),
+    ).toBeInTheDocument()
+    rerender(<SidebarHeader {...buildProps({ collapsed: true })} />)
+    expect(
+      screen.getByRole("button", { name: "Close sidebar" }),
+    ).toBeInTheDocument()
   })
 
-  it("fires onCloseMobile from the mobile close button", () => {
+  it("fires onCloseMobile from the mobile close button", async () => {
     const onCloseMobile = vi.fn()
-    render({ onCloseMobile })
-    clickByLabel("Close sidebar")
+    renderHeader({ onCloseMobile })
+    await user.click(screen.getByRole("button", { name: "Close sidebar" }))
     expect(onCloseMobile).toHaveBeenCalledTimes(1)
   })
 
   it("forwards closeRef to the mobile close button so the drawer can focus it", () => {
     const closeRef = createRef<HTMLButtonElement>()
-    render({ closeRef })
-    expect(closeRef.current).toBe(buttonByLabel("Close sidebar"))
+    renderHeader({ closeRef })
+    expect(closeRef.current).toBe(
+      screen.getByRole("button", { name: "Close sidebar" }),
+    )
   })
 })

--- a/apps/chat/src/components/shell/sidebar-new-conversation.test.tsx
+++ b/apps/chat/src/components/shell/sidebar-new-conversation.test.tsx
@@ -1,62 +1,44 @@
-// @vitest-environment jsdom
-
-import { act } from "react"
-import { createRoot, type Root } from "react-dom/client"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent, { type UserEvent } from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { collapsedStyles } from "./sidebar-collapsed-styles"
 import { NewConversationButton } from "./sidebar-new-conversation"
-;(
-  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
-).IS_REACT_ACT_ENVIRONMENT = true
 
-let container: HTMLDivElement
-let root: Root
-
+// Built per test (not at module load) so the instance never predates a future
+// fake-timer install in this file — matches app-shell.test.tsx.
+let user: UserEvent
 beforeEach(() => {
-  container = document.createElement("div")
-  document.body.appendChild(container)
-  root = createRoot(container)
+  user = userEvent.setup()
 })
 
-afterEach(() => {
-  act(() => {
-    root.unmount()
-  })
-  container.remove()
-})
-
-function render(onNew: () => void, onCloseMobile: () => void) {
-  act(() => {
-    root.render(
-      <NewConversationButton
-        styles={collapsedStyles(false)}
-        onNew={onNew}
-        onCloseMobile={onCloseMobile}
-      />,
-    )
-  })
+function renderButton(onNew: () => void, onCloseMobile: () => void) {
+  render(
+    <NewConversationButton
+      styles={collapsedStyles(false)}
+      onNew={onNew}
+      onCloseMobile={onCloseMobile}
+    />,
+  )
 }
 
 describe("NewConversationButton", () => {
   it("renders the labeled action", () => {
-    render(
+    renderButton(
       () => {},
       () => {},
     )
-    expect(container.textContent).toContain("New conversation")
+    expect(
+      screen.getByRole("button", { name: "New conversation" }),
+    ).toBeInTheDocument()
   })
 
-  it("starts a new conversation and closes the mobile drawer on click", () => {
+  it("starts a new conversation and closes the mobile drawer on click", async () => {
     const onNew = vi.fn()
     const onCloseMobile = vi.fn()
-    render(onNew, onCloseMobile)
+    renderButton(onNew, onCloseMobile)
 
-    const button = container.querySelector("button")
-    if (!button) throw new Error("New conversation button not found")
-    act(() => {
-      button.click()
-    })
+    await user.click(screen.getByRole("button", { name: "New conversation" }))
 
     // Both fire on a single click — a new chat also dismisses the drawer.
     expect(onNew).toHaveBeenCalledTimes(1)

--- a/apps/chat/src/components/shell/use-sidebar-chrome.test.ts
+++ b/apps/chat/src/components/shell/use-sidebar-chrome.test.ts
@@ -1,41 +1,10 @@
-// @vitest-environment jsdom
-
-import { act, createElement, type ReactNode, useEffect } from "react"
-import { createRoot, type Root } from "react-dom/client"
+import { act, fireEvent, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSidebarChrome } from "./use-sidebar-chrome"
-;(
-  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
-).IS_REACT_ACT_ENVIRONMENT = true
 
 type HookProps = Parameters<typeof useSidebarChrome>[0]
 type Chrome = ReturnType<typeof useSidebarChrome>
-
-let container: HTMLDivElement
-let root: Root
-let latest: Chrome
-
-// Thin harness: calls the hook, publishes its return via `latest` from an effect
-// (act() flushes it, so `latest` is current after render()), and renders the
-// close button with the hook's ref so the focus-trap effect has a real target.
-function Harness(props: HookProps): ReactNode {
-  const chrome = useSidebarChrome(props)
-  useEffect(() => {
-    latest = chrome
-  })
-  return createElement("button", {
-    type: "button",
-    ref: chrome.closeRef,
-    "aria-label": "Close sidebar",
-  })
-}
-
-function render(props: HookProps) {
-  act(() => {
-    root.render(createElement(Harness, props))
-  })
-}
 
 const base: HookProps = {
   collapsed: false,
@@ -46,121 +15,124 @@ const base: HookProps = {
 
 beforeEach(() => {
   vi.useFakeTimers()
-  container = document.createElement("div")
-  document.body.appendChild(container)
-  root = createRoot(container)
 })
 
 afterEach(() => {
-  act(() => {
-    root.unmount()
-  })
-  container.remove()
   vi.useRealTimers()
 })
 
+function setup(initialProps: HookProps = base) {
+  return renderHook((props: HookProps) => useSidebarChrome(props), {
+    initialProps,
+  })
+}
+
 describe("useSidebarChrome", () => {
   it("clips while expanded and stops clipping once a collapsed rail has settled", () => {
-    render({ ...base, collapsed: false })
-    expect(latest.clip).toBe(true)
+    const { result, rerender } = setup({ ...base, collapsed: false })
+    expect(result.current.clip).toBe(true)
 
     // Collapse with no animation flag set yet: a settled collapsed rail does
     // not clip (so its tooltip can overflow).
-    render({ ...base, collapsed: true })
-    expect(latest.clip).toBe(false)
+    rerender({ ...base, collapsed: true })
+    expect(result.current.clip).toBe(false)
   })
 
   it("clips through the collapse animation until the width transition ends", () => {
     const onToggleCollapsed = vi.fn()
-    render({ ...base, collapsed: false, onToggleCollapsed })
+    const { result, rerender } = setup({
+      ...base,
+      collapsed: false,
+      onToggleCollapsed,
+    })
 
     // Initiating a toggle sets the animating flag immediately.
     act(() => {
-      latest.handleToggleCollapsed()
+      result.current.handleToggleCollapsed()
     })
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1)
 
     // Parent flips collapsed → true; clip stays true because we're animating.
-    render({ ...base, collapsed: true, onToggleCollapsed })
-    expect(latest.clip).toBe(true)
+    rerender({ ...base, collapsed: true, onToggleCollapsed })
+    expect(result.current.clip).toBe(true)
 
     // The width transition ending clears the animating flag.
     act(() => {
-      latest.handleTransitionEnd({
+      result.current.handleTransitionEnd({
         propertyName: "width",
       } as Parameters<Chrome["handleTransitionEnd"]>[0])
     })
-    expect(latest.clip).toBe(false)
+    expect(result.current.clip).toBe(false)
   })
 
   it("ignores non-width transitions when clearing the animating flag", () => {
-    render({ ...base, collapsed: false })
+    const { result, rerender } = setup({ ...base, collapsed: false })
     act(() => {
-      latest.handleToggleCollapsed()
+      result.current.handleToggleCollapsed()
     })
-    render({ ...base, collapsed: true })
+    rerender({ ...base, collapsed: true })
 
     act(() => {
-      latest.handleTransitionEnd({
+      result.current.handleTransitionEnd({
         propertyName: "opacity",
       } as Parameters<Chrome["handleTransitionEnd"]>[0])
     })
     // Still animating — an unrelated transition must not drop the clip.
-    expect(latest.clip).toBe(true)
+    expect(result.current.clip).toBe(true)
   })
 
   it("falls back to clearing the animating flag after 400ms if transitionend never fires", () => {
-    render({ ...base, collapsed: false })
+    const { result, rerender } = setup({ ...base, collapsed: false })
     act(() => {
-      latest.handleToggleCollapsed()
+      result.current.handleToggleCollapsed()
     })
-    render({ ...base, collapsed: true })
-    expect(latest.clip).toBe(true)
+    rerender({ ...base, collapsed: true })
+    expect(result.current.clip).toBe(true)
 
     act(() => {
       vi.advanceTimersByTime(400)
     })
-    expect(latest.clip).toBe(false)
+    expect(result.current.clip).toBe(false)
   })
 
   it("closes the mobile drawer on Escape only while open", () => {
     const onCloseMobile = vi.fn()
-    render({ ...base, mobileOpen: false, onCloseMobile })
+    const { rerender } = setup({ ...base, mobileOpen: false, onCloseMobile })
 
-    act(() => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
-    })
+    fireEvent.keyDown(document, { key: "Escape" })
     expect(onCloseMobile).not.toHaveBeenCalled()
 
-    render({ ...base, mobileOpen: true, onCloseMobile })
-    act(() => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
-    })
+    rerender({ ...base, mobileOpen: true, onCloseMobile })
+    fireEvent.keyDown(document, { key: "Escape" })
     expect(onCloseMobile).toHaveBeenCalledTimes(1)
 
     // Other keys are ignored.
-    act(() => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }))
-    })
+    fireEvent.keyDown(document, { key: "Enter" })
     expect(onCloseMobile).toHaveBeenCalledTimes(1)
   })
 
   it("focuses the close button when the mobile drawer opens", () => {
-    render({ ...base, mobileOpen: false })
-    render({ ...base, mobileOpen: true })
-    expect(document.activeElement).toBe(
-      container.querySelector('button[aria-label="Close sidebar"]'),
-    )
+    const { result, rerender } = setup({ ...base, mobileOpen: false })
+
+    // The focus-trap effect targets closeRef.current; renderHook renders no DOM
+    // of its own, so give the ref a real, focusable node in the document.
+    const closeButton = document.createElement("button")
+    closeButton.setAttribute("aria-label", "Close sidebar")
+    document.body.appendChild(closeButton)
+    result.current.closeRef.current = closeButton
+
+    rerender({ ...base, mobileOpen: true })
+    expect(document.activeElement).toBe(closeButton)
+
+    closeButton.remove()
   })
 
   it("removes the Escape listener when the drawer closes", () => {
     const onCloseMobile = vi.fn()
-    render({ ...base, mobileOpen: true, onCloseMobile })
-    render({ ...base, mobileOpen: false, onCloseMobile })
+    const { rerender } = setup({ ...base, mobileOpen: true, onCloseMobile })
+    rerender({ ...base, mobileOpen: false, onCloseMobile })
 
-    act(() => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
-    })
+    fireEvent.keyDown(document, { key: "Escape" })
     expect(onCloseMobile).not.toHaveBeenCalled()
   })
 })

--- a/apps/chat/src/vitest.d.ts
+++ b/apps/chat/src/vitest.d.ts
@@ -1,0 +1,3 @@
+// Brings @testing-library/jest-dom's matcher augmentation of vitest's Assertion
+// into the tsc program (vitest.setup.ts lives outside the `src` include).
+import "@testing-library/jest-dom/vitest"

--- a/apps/chat/vitest.config.ts
+++ b/apps/chat/vitest.config.ts
@@ -8,9 +8,10 @@ export default defineConfig({
     },
   },
   test: {
-    // Default environment is `node`; DOM tests opt in per-file with
-    // `// @vitest-environment jsdom` (matches apps/web and apps/admin).
-    environment: "node",
+    // jsdom is the app default: chat tests use React Testing Library (a
+    // deliberate divergence from apps/web and apps/admin — see CLAUDE.md).
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 })

--- a/apps/chat/vitest.setup.ts
+++ b/apps/chat/vitest.setup.ts
@@ -1,0 +1,10 @@
+import { cleanup } from "@testing-library/react"
+import { afterEach } from "vitest"
+
+// jest-dom matchers (toBeDisabled, toHaveValue, toBeInTheDocument, …) and
+// auto-unmount between tests. jsdom is the app-wide test env (vitest.config.ts).
+import "@testing-library/jest-dom/vitest"
+
+afterEach(() => {
+  cleanup()
+})

--- a/docs/plans/2026-06-25-001-feat-chat-react-testing-library-plan.md
+++ b/docs/plans/2026-06-25-001-feat-chat-react-testing-library-plan.md
@@ -1,0 +1,574 @@
+---
+title: "feat: Introduce React Testing Library to apps/chat"
+date: 2026-06-25
+type: feat
+status: ready
+origin: docs/roadmap/ai-chat/feat-206-chat-introduce-react-testing-library.md
+plan_depth: standard
+---
+
+# feat: Introduce React Testing Library to apps/chat
+
+## Summary
+
+Adopt React Testing Library (RTL) + `user-event` + `jest-dom` in `apps/chat`
+**only**, and migrate its five DOM-touching test files off the hand-rolled
+`react-dom/client` + `act` plumbing the monorepo inherited from `apps/admin`.
+This is a **test-mechanism swap, not a coverage change**: every existing
+assertion survives, the suite stays green, and no production code under
+`apps/chat/src/components` or `apps/chat/src/lib` changes. `apps/admin` and
+`apps/web` keep their plain-`react-dom` convention untouched — this divergence
+is scoped to chat by design (origin ticket Constraints).
+
+The suite today is 8 test files / 63 tests. Five are DOM tests that migrate;
+three are pure-function tests (`lib/conversations.test.ts`,
+`lib/chat-stub.test.ts`, `components/shell/sidebar-collapsed-styles.test.ts`)
+that stay plain vitest and are **not** touched beyond inheriting the new default
+jsdom env.
+
+---
+
+## Problem Frame
+
+`apps/chat` tests carry mechanism cost that RTL removes (origin Problem):
+
+- `app-shell.test.tsx` (~586 lines) is mostly hand-rolled DOM plumbing that
+  exists only because there is no `user-event`: typing via the
+  `HTMLTextAreaElement.prototype` value-setter, raw
+  `dispatchEvent(new KeyboardEvent(...))` for Enter/Escape, manual `submit`
+  events, and bespoke `buttonByLabel` / `clickButton` / `getTextarea` query
+  helpers re-implemented per file.
+- `use-sidebar-chrome.test.ts` needs a workaround: it publishes the hook's
+  return through a `useEffect` into a module-level `latest` because there is no
+  `renderHook`.
+- The app is about to become async (feat-205 wires the Seeker Mastra route).
+  `findBy` / `waitFor` + `user-event` are far cleaner for the rejectable,
+  possibly-hanging call than the current `vi.useFakeTimers()` + manual `act`
+  juggling. Landing RTL **before** that async wiring means those tests are
+  written in RTL from the start.
+
+RTL does **not** fix the one jsdom gap the suite hits: focus-restore-on-close
+depends on `offsetParent`, which jsdom can't represent. That stays a
+browser-verified check, and the CLAUDE.md note recording it must survive.
+
+---
+
+## Requirements
+
+Traced from the origin ticket's "What To Build" and "Verification":
+
+- **R1** — Add RTL dev deps pinned for React 19: `@testing-library/react` (v16+),
+  `@testing-library/user-event`, `@testing-library/jest-dom`, and the explicit
+  `@testing-library/dom` peer (RTL v16 does not bundle it).
+- **R2** — Add `apps/chat/vitest.setup.ts` (`import "@testing-library/jest-dom/vitest"`
+  - `afterEach(cleanup)`); wire it via `setupFiles` and flip
+    `test.environment` to `jsdom` as the app default; drop per-file
+    `// @vitest-environment jsdom` directives.
+- **R3** — Migrate the five DOM test files to `screen` role/label queries +
+  `user-event`; move `use-sidebar-chrome.test.ts` to `renderHook`
+  (`result.current` + `rerender`); leave the three pure-function tests as plain
+  vitest.
+- **R4** — Update `apps/chat/CLAUDE.md`: record the deliberate divergence from
+  the `apps/admin`/`apps/web` no-testing-library convention and keep the
+  browser-verify caveat for focus-restore/layout behavior.
+- **R5** — No behavior-coverage regression: every existing assertion survives;
+  assertion count is not reduced. The grep-clean and "tests pass" checks in
+  Verification all pass.
+- **R6** (origin "Confirm"): the retired
+  `docs/solutions/best-practices/unit-testing-react-hooks-plain-react-dom-act-*.md`
+  learning is **not** reintroduced. _(Already absent on `main` — verified during
+  planning. This is a guard, not work.)_
+
+---
+
+## Key Technical Decisions
+
+### KTD1 — `user-event` must be configured for fake timers
+
+`app-shell.test.tsx` relies on `vi.useFakeTimers()` because the stub reply fires
+through `setTimeout(STUB_REPLY_DELAY_MS)` in `use-conversations.ts` (timing lives
+in the hook, not the stub — see chat CLAUDE.md "stub seam"). `user-event` v14
+defaults to _real_ timers for its inter-event delay; under fake timers an
+un-configured `await user.click(...)` **hangs**. Every file that calls
+`vi.useFakeTimers()` must create its user instance with:
+
+```ts
+// directional — exact call site is the implementer's
+const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+```
+
+Files with no timers (`sidebar-header`, `sidebar-new-conversation`,
+`sidebar-conversation-list`) use a plain `userEvent.setup()`.
+
+### KTD2 — Keep `act(() => vi.advanceTimersByTime(...))` for the reply delay; use RTL's `act`
+
+The stub reply is a `setTimeout`, not an awaitable promise, so `findBy`/`waitFor`
+cannot drive it forward under fake timers. The reply-advance helper stays an
+explicit timer advance, but imported from `@testing-library/react`
+(`act`) rather than `react`. This is **not** the retired harness — the grep
+target the ticket retires is the `createRoot` + `act`-render _setup harness_ in
+`beforeEach`, not RTL's `act` used to flush a timer tick. Code review should read
+the Verification grep accordingly (KTD acknowledged so it isn't mis-flagged).
+
+### KTD3 — The double-submit test keeps a synchronous `fireEvent`, not `user.click`
+
+The "ignores a rapid double-submit before re-render" assertion depends on two
+submits landing **within the same render cycle** (the double-send guard's
+window). `await user.click()` flushes React between clicks, dissolving the
+condition under test. Use RTL's `fireEvent.submit(form)` twice synchronously for
+this one case. `fireEvent` is first-class RTL — it is **not** the retired
+`form.dispatchEvent(new Event("submit"))` plumbing, and does not match the
+Verification grep patterns. Preserve the assertion: a rapid double-submit yields
+2 messages, not 4.
+
+### KTD4 — `renderHook` covers the state machine; the focus test needs a real DOM target
+
+Five of the seven `use-sidebar-chrome` tests are pure state-machine assertions
+(clip lifecycle, width-vs-opacity `transitionEnd`, 400ms fallback, Escape-only-
+while-open, listener cleanup) and convert cleanly to `renderHook` →
+`result.current` + `rerender(newProps)`. Two tests need a DOM node bound to the
+hook's `closeRef` (the focus-trap effect calls `.focus()` on `closeRef.current`):
+
+- **Primary approach:** stay in `renderHook` — create a `<button>`, append it to
+  `document.body`, assign it to `result.current.closeRef.current`, then
+  `rerender({ ...base, mobileOpen: true })` so the effect focuses it. Assert
+  `document.activeElement`.
+- **Acceptable fallback:** render a 3-line local component with RTL `render` that
+  calls the hook and attaches `chrome.closeRef` to a labeled button, then assert
+  on `screen.getByLabelText("Close sidebar")`.
+
+Either way the **module-level `latest` + `useEffect`-capture harness is deleted**
+— that is the origin's hard requirement for this file. Implementer picks the
+cleaner of the two at `ce-work` time.
+
+### KTD5 — `jsdom` becomes the app-wide default env; pure tests inherit it harmlessly
+
+Flipping `test.environment` to `jsdom` applies it to all eight files, including
+the three pure-function ones. jsdom is a superset of the node env for those
+(they touch no DOM), so they keep passing; the per-file directives are dropped
+everywhere. This matches the origin's "set `test.environment: jsdom` as the app
+default" instruction.
+
+### KTD6 — Version pinning
+
+No `@testing-library/*` exists anywhere in the monorepo and there is no pnpm
+catalog entry, so chat pins its own caret ranges in `apps/chat/package.json`
+(current published, React-19-compatible): `@testing-library/react ^16.3.x`,
+`@testing-library/dom ^10.4.x`, `@testing-library/user-event ^14.6.x`,
+`@testing-library/jest-dom ^6.9.x`. Exact patch resolved by `pnpm add` at
+implementation time; the lockfile is committed.
+
+---
+
+## Implementation Units
+
+### U1. Add RTL dev dependencies to apps/chat
+
+**Goal:** `apps/chat` can import `@testing-library/react`, `/user-event`,
+`/jest-dom`, and the `@testing-library/dom` peer.
+
+**Requirements:** R1.
+
+**Dependencies:** none.
+
+**Files:**
+
+- `apps/chat/package.json` (add four `devDependencies`)
+- `pnpm-lock.yaml` (regenerated)
+
+**Approach:** Add the four packages as devDeps via `pnpm add -D --filter @forge/chat`
+so the lockfile updates correctly. Include `@testing-library/dom` explicitly —
+RTL v16 lists it as a _peer_, not a bundled, dependency. Confirm versions match
+KTD6 ranges. No root-level or other-app manifest changes (origin Constraint:
+"do not add RTL to the root").
+
+**Patterns to follow:** existing `devDependencies` block in `apps/chat/package.json`
+(caret ranges, alphabetical-ish grouping).
+
+**Test scenarios:** Test expectation: none — dependency manifest change.
+Verified transitively by U2–U5 importing the packages and the suite running.
+
+**Verification:** `pnpm --filter @forge/chat install` resolves; the four
+packages appear under `devDependencies`; no change to `dependencies` or to any
+other package's manifest.
+
+---
+
+### U2. Add the vitest setup file and flip the default env to jsdom
+
+**Goal:** jest-dom matchers are globally available, RTL auto-cleans between
+tests, and jsdom is the app default so per-file env directives become redundant.
+
+**Requirements:** R2.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- `apps/chat/vitest.setup.ts` (new)
+- `apps/chat/vitest.config.ts` (modify)
+
+**Approach:**
+
+- `vitest.setup.ts`: `import "@testing-library/jest-dom/vitest"` and register
+  `afterEach(() => cleanup())` (import `cleanup` from `@testing-library/react`,
+  `afterEach` from `vitest`). Explicit cleanup per origin instruction — do not
+  rely on implicit auto-cleanup detection.
+- `vitest.config.ts`: set `test.environment: "jsdom"`, add
+  `test.setupFiles: ["./vitest.setup.ts"]`, keep the existing `include` globs
+  and the `@` alias. Replace the "DOM tests opt in per-file" comment with one
+  noting jsdom is now the app default (3-line cap, per chat CLAUDE.md).
+
+**Patterns to follow:** existing `defineConfig` shape in
+`apps/chat/vitest.config.ts`; the comment-style cap in `apps/chat/CLAUDE.md`.
+
+**Test scenarios:** Test expectation: none — test-harness config. Proven by the
+migrated suites (U3–U5) running green under the new default without per-file
+directives.
+
+**Verification:** with directives still present (transitional), `pnpm --filter
+@forge/chat test` stays green; jest-dom matchers (e.g. `toBeDisabled`) resolve
+type-wise under `tsc --noEmit`.
+
+---
+
+### U3. Migrate app-shell.test.tsx to RTL + user-event
+
+**Goal:** the 586-line behavioral suite uses `render` / `screen` /
+`user-event`, with the hand-rolled harness and helpers gone — every one of its
+30 assertions preserved.
+
+**Requirements:** R3, R5.
+
+**Dependencies:** U2.
+
+**Files:**
+
+- `apps/chat/src/components/shell/app-shell.test.tsx` (rewrite)
+
+**Approach:** Replace the `beforeEach` `createRoot`/`act` harness with RTL
+`render(<AppShell />)`. Keep `vi.useFakeTimers()` in `beforeEach` /
+`vi.useRealTimers()` in `afterEach` (RTL `cleanup` handles unmount via U2's
+setup). Replace helpers:
+
+- `getTextarea` → `screen.getByRole("textbox", { name: "Message" })` (or
+  `getByLabelText("Message")`).
+- `getSendButton` → `screen.getByRole("button", { name: /send/i })` /
+  `screen.getByRole("button", { name: ... })` matching the submit control; if it
+  has no accessible name, query by `getByRole("button")` scoped to the form.
+  Resolve the exact accessible name by reading `chat/composer.tsx` at impl time.
+- `getLog` → `screen.getByRole("log", { name: "Conversation" })`.
+- `getConversationNav` → `screen.getByRole("navigation", { name: "Conversations" })`.
+- `typeDraft` / `pressEnter` / `submitForm` / `sendMessage` → `user.type`,
+  `user.keyboard("{Enter}")` / `user.type(textarea, "...{Enter}")`,
+  `user.type(textarea, "{Shift>}{Enter}{/Shift}")`, `user.click(sendButton)`.
+- `clickNewConversation` / `selectSidebarConversation` →
+  `user.click(screen.getByRole("button", { name: /new conversation/i }))` and
+  `within(nav).getByRole("button", { name: title })`.
+- `messageTexts` / `isPending` / `sidebarReplyingCount` → keep as small reads
+  but source from `screen`/`within` queries (e.g. `within(getLog()).getAllByRole("listitem")`).
+  The pending turn renders as a `<li data-pending>` inside the same log list, so
+  `getAllByRole("listitem")` counts it — exactly as today's `querySelectorAll("li")`
+  does. The exact-count assertions (`toHaveLength(2)` / `(4)`) are therefore
+  timing-load-bearing: they run _after_ `awaitReply()` when no pending `<li>`
+  exists. Preserve that sequencing; don't read counts mid-pending.
+  Where they read non-semantic markers (`[data-pending]`, `[data-replying]`),
+  keep the attribute query via `within(...).container`-style scoping or
+  `screen.getByRole(...).querySelector` — these are structural signals jsdom
+  exposes and there is no ARIA role for them.
+- Assertions: prefer jest-dom (`toBeDisabled`, `toHaveValue("")`,
+  `toBeInTheDocument`) over `.disabled` / `.value` reads where it reads cleaner;
+  keep semantics identical.
+- `awaitReply` → `act(() => vi.advanceTimersByTime(STUB_REPLY_DELAY_MS))` with
+  `act` from `@testing-library/react` (KTD2).
+- **Double-submit test** → `fireEvent.submit(form)` twice synchronously (KTD3).
+  The `<form>` in `composer.tsx` has no role/accessible name, so `screen` can't
+  reach it — obtain it from the `container` returned by `render()`
+  (`container.querySelector("form")`), the one place this file uses `container`.
+- **Throw test** → keep `expect(() => act(() => vi.advanceTimersByTime(...)))
+.toThrow("reply boom")`; the synchronous throw propagates out of the timer
+  callback exactly as today. Re-verify it still throws under RTL's `act`.
+- **Unmount-race test** → use the `unmount` returned by `render` instead of a
+  bespoke local root; keep the `console.error` spy and `vi.getTimerCount()`
+  assertions.
+- The "jsdom does not simulate native textarea newline on keydown" comment and
+  the Shift+Enter no-send-half note survive (still true under user-event).
+
+**Patterns to follow:** RTL `screen` + `within` + `user-event` idioms; preserve
+the existing `describe` blocks ("AppShell", "Sidebar shell") and test titles.
+
+**Execution note:** migrate test-by-test, running `pnpm --filter @forge/chat
+test app-shell` after each cluster, so a green→green diff is verifiable per
+assertion rather than as one big-bang rewrite.
+
+**Test scenarios:** this _is_ a test file — no new behavior. The bar is
+preservation. Each of the 30 existing cases must keep its assertion semantics:
+
+- Empty-state present → gone after first send (before reply).
+- Append user message; pending shown; textarea + send disabled; reply arrives;
+  re-enabled; exactly 2 messages.
+- Reply equals `buildStubReply(text)`.
+- Send disabled on empty/whitespace; enabled on real text; whitespace submit is
+  a no-op leaving empty state.
+- Rapid double-submit → 2 messages not 4 (KTD3).
+- Enter sends; Shift+Enter does not (value retained).
+- Input clears on send.
+- Pending timer cleaned on unmount, no `console.error`, timer count 0.
+- History append-only, alternating roles across two exchanges.
+- Conversation exposed as labeled `log` with the pending turn inside it; textarea
+  labeled "Message".
+- New-conversation action starts a fresh empty conversation; prior one persists
+  in the rail with its derived title (not the "New conversation" placeholder).
+- Reply routed to its originating conversation across a mid-reply switch.
+- Pending pulse attaches to the awaiting conversation, not the active one.
+- Second conversation can send while the first is pending; each reply lands in
+  its own conversation.
+- Prior conversation's messages restored on reselect.
+- Reply-generation throw releases the pending slot (slot-leak guard) and a fresh
+  send afterward resolves cleanly.
+- Reselecting the active conversation is a no-op that keeps the draft.
+- Sidebar: starts expanded (wordmark, collapse toggle, conversation list);
+  collapse/re-expand toggle swap; mobile drawer open via menu / close via X with
+  `aria-expanded` + `role="dialog"` toggle; Escape closes; scrim click closes;
+  New conversation closes drawer; selecting a non-active conversation navigates
+  - closes; `<main>` `inert` only while open; body scroll lock + restore; focus
+    moves to the close button on open.
+
+**Verification:** `pnpm --filter @forge/chat test app-shell` green with the same
+test count (30). No `createRoot`, no `IS_REACT_ACT_ENVIRONMENT`, no
+value-setter, no raw `KeyboardEvent`/`dispatchEvent(new Event("submit"`) remain
+in the file.
+
+---
+
+### U4. Migrate use-sidebar-chrome.test.ts to renderHook
+
+**Goal:** the hook's seven tests run through `renderHook` (`result.current` +
+`rerender`), with the module-level `latest` + `useEffect`-capture `Harness`
+deleted.
+
+**Requirements:** R3, R5.
+
+**Dependencies:** U2.
+
+**Files:**
+
+- `apps/chat/src/components/shell/use-sidebar-chrome.test.ts` (rewrite)
+
+**Approach:** Use `renderHook((props) => useSidebarChrome(props), { initialProps:
+base })`; read `result.current.clip` / `.handleToggleCollapsed()` /
+`.handleTransitionEnd(...)`; drive prop changes with `rerender(newProps)`. Keep
+`vi.useFakeTimers()` for the 400ms-fallback test. Wrap state-mutating calls
+(`handleToggleCollapsed`, `handleTransitionEnd`, timer advances, document keydown
+dispatch) in `act` from `@testing-library/react`. For the two focus-target tests,
+follow KTD4 (primary: append a button to `document.body`, assign
+`result.current.closeRef.current`, `rerender({ mobileOpen: true })`; fallback:
+a 3-line RTL-rendered component). Delete `Harness`, `latest`, and the manual
+`createRoot`/`container` scaffolding.
+
+**Patterns to follow:** `renderHook` from `@testing-library/react`; existing test
+titles and `base` props object.
+
+**Test scenarios (preserve all seven):**
+
+- Clips while expanded; a settled collapsed rail does not clip.
+- Clips through the collapse animation until the width `transitionend`.
+- Ignores non-width (`opacity`) transitions when clearing the animating flag.
+- Falls back to clearing the animating flag after 400ms if `transitionend` never
+  fires.
+- Closes the mobile drawer on Escape only while open; other keys ignored.
+- Focuses the close button when the drawer opens (DOM target per KTD4).
+- Removes the Escape listener when the drawer closes.
+
+**Verification:** `pnpm --filter @forge/chat test use-sidebar-chrome` green, 7
+tests. No `latest`, no `useEffect`-capture `Harness`, no `createRoot` in the
+file.
+
+---
+
+### U5. Migrate the three sidebar component test files to RTL
+
+**Goal:** `sidebar-header.test.tsx`, `sidebar-conversation-list.test.tsx`, and
+`sidebar-new-conversation.test.tsx` use `render` / `screen` / `user-event`, with
+their per-file `createRoot`/`act` harnesses and `buttonByLabel`/`clickByLabel`
+helpers gone.
+
+**Requirements:** R3, R5.
+
+**Dependencies:** U2.
+
+**Files:**
+
+- `apps/chat/src/components/shell/sidebar-header.test.tsx` (rewrite)
+- `apps/chat/src/components/shell/sidebar-conversation-list.test.tsx` (rewrite)
+- `apps/chat/src/components/shell/sidebar-new-conversation.test.tsx` (rewrite)
+
+**Approach:** Keep each file's local `render(overrides)` prop-defaulting wrapper
+(it's a useful per-component fixture, not the retired DOM harness) but have it
+call RTL `render(...)` instead of `createRoot`/`act`. Replace `buttonByLabel` →
+`screen.getByRole("button", { name })` / `queryByRole` for absence;
+`clickByLabel` → `await user.click(...)`; raw `.click()` → `user.click`. Keep
+`createRef` usage for the `forwards closeRef` test (asserting `closeRef.current`
+equals the close button — that's a ref-forwarding contract, query the button via
+`screen`). Drop `IS_REACT_ACT_ENVIRONMENT` and the `container`/`root`
+scaffolding.
+
+**Patterns to follow:** the same `screen`/`user-event`/`within` idioms as U3;
+preserve each file's `describe`/`it` titles and the `collapsedStyles(...)` /
+`Conversation[]` fixtures.
+
+**Test scenarios (preserve all):**
+
+- _sidebar-header (7):_ collapse toggle shown (expand hidden) when expanded +
+  wordmark present; expand affordance shown (collapse hidden) when collapsed;
+  `onToggleCollapsed` fires from each control; mobile close button renders in
+  both collapsed states; `onCloseMobile` fires from it; `closeRef` forwarded to
+  the close button.
+- _sidebar-conversation-list (4):_ row click fires `onSelect(id)` +
+  `onCloseMobile` once each; only the active row has `aria-current="true"`;
+  replying pulse + "Replying" sr-only label only on pending conversations;
+  labeled nav with zero rows when empty.
+- _sidebar-new-conversation (2):_ renders the labeled action; click fires `onNew`
+  - `onCloseMobile` once each.
+
+**Verification:** `pnpm --filter @forge/chat test sidebar-header
+sidebar-conversation-list sidebar-new-conversation` green with the same counts
+(7 / 4 / 2). Grep-clean of the retired plumbing in all three.
+
+---
+
+### U6. Update apps/chat/CLAUDE.md and run the full verification sweep
+
+**Goal:** the chat conventions record the deliberate RTL divergence and the
+browser-verify caveat; the whole suite + lint + typecheck pass; the grep
+verification is clean.
+
+**Requirements:** R4, R5, R6.
+
+**Dependencies:** U3, U4, U5.
+
+**Files:**
+
+- `apps/chat/CLAUDE.md` (modify "Key Conventions" → the testing bullet)
+
+**Approach:** Rewrite the testing-convention bullet that currently mandates
+"plain `react-dom/client` + `act` with per-file `// @vitest-environment jsdom`
+(the `apps/admin` style — no testing-library)". Replace with: chat uses RTL +
+`user-event` + `jest-dom` (jsdom is the app default via `vitest.config.ts` +
+`vitest.setup.ts`); the hook test uses `renderHook`; pure-function tests stay
+plain vitest. State explicitly that this is a **deliberate divergence** from the
+`apps/admin`/`apps/web` no-testing-library convention, scoped to chat. Keep the
+existing note that focus-restore-on-close / layout-visibility behavior is
+**browser-verified** because jsdom has no layout. Respect the 3-line inline
+comment / concise-prose conventions of that file.
+
+**Patterns to follow:** the existing "Key Conventions" bullet style and the
+"Comments" cap in the same file.
+
+**Test scenarios:** Test expectation: none — docs. Behavior coverage is verified
+by the full-suite run below.
+
+**Verification (the origin ticket's full checklist):**
+
+- `pnpm --filter @forge/chat test` — all 8 files / 63 tests pass; assertion
+  count not reduced.
+- `pnpm --filter @forge/chat lint` and `pnpm --filter @forge/chat typecheck` —
+  clean.
+- Grep clean across `apps/chat/src`: no `IS_REACT_ACT_ENVIRONMENT`, no
+  `Object.getOwnPropertyDescriptor(HTMLTextAreaElement`, no
+  `dispatchEvent(new KeyboardEvent`, no `dispatchEvent(new Event("submit"`, no
+  `createRoot(`, no bare `import { act } from "react"` harness in the migrated
+  component tests. (RTL `act`/`fireEvent` per KTD2/KTD3 are expected and allowed.)
+- No `// @vitest-environment jsdom` directives remain.
+- `use-sidebar-chrome.test.ts` uses `renderHook`, no module-level `latest`.
+- `apps/chat/CLAUDE.md` reflects the new convention + browser-verify caveat.
+- `docs/solutions/best-practices/unit-testing-react-hooks-plain-react-dom-act-*.md`
+  remains absent (R6 — already confirmed gone).
+
+---
+
+## Scope Boundaries
+
+**In scope:** `apps/chat` test mechanism only — deps, vitest config/setup, the
+five DOM test files, and `apps/chat/CLAUDE.md`.
+
+**Out of scope (origin Constraints):**
+
+- `apps/admin` and `apps/web` tests, and any root-level RTL addition — the
+  divergence is chat-only by design.
+- The feat-205 async Mastra wiring. This plan lands RTL _before_ it so those
+  tests start in RTL, but does not touch reply timing, `chat-stub.ts`, or
+  `use-conversations.ts`. The synchronous-stub timer/throw assertions are
+  migrated **as-is** (KTD2), not reshaped for async.
+- Folding into the feat-203 sidebar PR — this is a separate PR (origin
+  Constraint).
+- Any production-code change under `apps/chat/src/components` or `src/lib`.
+
+### Deferred to Follow-Up Work
+
+- None. If U3's `screen.getByRole(...)` queries reveal a missing accessible name
+  on the send button (composer), prefer fixing the query within this PR over a
+  production a11y change; only if a real a11y gap surfaces, file a follow-up
+  rather than expanding scope here.
+
+---
+
+## Risks & Mitigations
+
+- **`user-event` hangs under fake timers.** Highest-likelihood failure. Mitigated
+  by KTD1 (`advanceTimers: vi.advanceTimersByTime`). If a test mysteriously times
+  out, this is the first suspect.
+- **Accessible-name drift.** Role/name queries assume the components expose the
+  accessible names the current attribute queries rely on (`aria-label="Message"`,
+  `role="log"` name "Conversation", nav name "Conversations", button labels
+  "Collapse sidebar"/"Open sidebar"/"Close sidebar"/"Open menu"). These are all
+  present in the current tests' attribute reads, so the names exist — but the
+  send button's accessible name must be confirmed against `composer.tsx` at impl
+  time (U3 approach note).
+- **Over-zealous grep cleanup.** RTL's `act` and `fireEvent` legitimately remain
+  (KTD2/KTD3). Mitigated by spelling the allowed survivors into U6's grep
+  verification so code review doesn't flag them as incomplete migration.
+- **The throw test under RTL `act`.** `act` rethrows, so the synchronous
+  `toThrow("reply boom")` should hold, but verify explicitly (U3) — `act`'s error
+  handling differs subtly from a bare timer advance.
+- **Worktree install truncation (environmental).** A fresh-worktree `pnpm install`
+  has been seen to truncate large `node_modules` files to 8 MiB (esbuild EPIPE /
+  `typescript.js` SyntaxError). Baseline suite already ran green in this worktree,
+  so the risk is low, but a re-install after U1 could re-trigger it — see
+  `docs/solutions/build-errors/worktree-pnpm-install-8mb-file-truncation-20260624.md`
+  if test/lint suddenly crash.
+
+---
+
+## Verification (rollup)
+
+The whole change is done when, from the worktree:
+
+1. `pnpm --filter @forge/chat test` → 8 files, 63 tests, all green.
+2. `pnpm --filter @forge/chat lint` → clean.
+3. `pnpm --filter @forge/chat typecheck` → clean.
+4. The grep sweep in U6 returns no retired-plumbing hits and no
+   `@vitest-environment` directives.
+5. `git diff --stat` touches only: `apps/chat/package.json`, `pnpm-lock.yaml`,
+   `apps/chat/vitest.config.ts`, `apps/chat/vitest.setup.ts`, the five
+   `apps/chat/src/components/shell/*.test.ts(x)` files, `apps/chat/CLAUDE.md`,
+   and this plan doc — nothing under `apps/admin`, `apps/web`, the repo root, or
+   `apps/chat/src` production files.
+
+---
+
+## Sources & Research
+
+- Origin ticket: `docs/roadmap/ai-chat/feat-206-chat-introduce-react-testing-library.md`.
+- Lane conventions: `docs/roadmap/ai-chat/CLAUDE.md` (status/README upkeep on
+  completion — a `## Resolution` section + README row update are part of "done"
+  when the code PR merges; tracked for the close-out, not this plan's code).
+- App conventions: `apps/chat/CLAUDE.md` ("Key Conventions", "Comments", stub
+  seam ownership of reply timing).
+- Current published, React-19-compatible versions (looked up during planning):
+  `@testing-library/react` 16.3.2, `@testing-library/dom` 10.4.1,
+  `@testing-library/user-event` 14.6.1, `@testing-library/jest-dom` 6.9.1.
+- Baseline confirmed during planning: 8 files / 63 tests green; five files carry
+  `@vitest-environment jsdom` + `IS_REACT_ACT_ENVIRONMENT` + `react-dom/client`;
+  the three pure-function files do not; the retired solutions doc is already
+  absent on `main`.

--- a/docs/roadmap/ai-chat/README.md
+++ b/docs/roadmap/ai-chat/README.md
@@ -14,9 +14,9 @@ from the main DS Year 1 roadmap.
 ## Status (June 25, 2026)
 
 - **Total tickets:** 9
-- ✅ **Complete:** 5
+- ✅ **Complete:** 6
 - 🟡 **In progress:** 0
-- 🔵 **Not started:** 4
+- 🔵 **Not started:** 3
 - 🔴 **Blocked:** 0
 
 ## Feature Index
@@ -31,4 +31,4 @@ from the main DS Year 1 roadmap.
 | [feat-203](feat-203-chat-sidebar-component-extraction.md)    | Chat sidebar component + behavior extraction              | jian wei | P2       | 2026-07-01 | 2    | ✅ complete    | #1368   |
 | [feat-204](feat-204-expose-seeker-mastra-service-route.md)   | Expose Seeker agent via internal Mastra SSE service route | jian wei | P2       | 2026-06-24 | 3    | 🔵 not-started | —       |
 | [feat-205](feat-205-chat-wire-seeker-route.md)               | Wire chat app to the Seeker Mastra route                  | jian wei | P1       | 2026-06-27 | 3    | 🔵 not-started | —       |
-| [feat-206](feat-206-chat-introduce-react-testing-library.md) | Introduce React Testing Library to the chat app           | jian wei | P2       | 2026-07-03 | 2    | 🔵 not-started | —       |
+| [feat-206](feat-206-chat-introduce-react-testing-library.md) | Introduce React Testing Library to the chat app           | jian wei | P2       | 2026-07-03 | 2    | ✅ complete    | #1372   |

--- a/docs/roadmap/ai-chat/feat-206-chat-introduce-react-testing-library.md
+++ b/docs/roadmap/ai-chat/feat-206-chat-introduce-react-testing-library.md
@@ -3,7 +3,7 @@ id: "feat-206"
 title: "Introduce React Testing Library to the chat app"
 owner: "jian wei"
 priority: "P2"
-status: "not-started"
+status: "complete"
 start_date: "2026-07-03"
 duration: 2
 depends_on:
@@ -12,6 +12,16 @@ blocks: []
 tags:
   - "web"
 ---
+
+## Resolution
+
+**Shipped:** 2026-06-25 via [PR #1372](https://github.com/JesusFilm/forge/pull/1372) (`feat(chat): adopt React Testing Library for the test suite (feat-206)`).
+
+**What landed.** Migrated the five DOM test files in `apps/chat` to React Testing Library + `user-event` + `renderHook`, flipped the Vitest default env to `jsdom` via a new `vitest.setup.ts`, and deleted the hand-rolled plumbing (value-setter typing, raw `KeyboardEvent`/`submit` dispatch, the `useEffect`-capture hook harness). All 63 tests still pass — a pure mechanism swap, with two assertions deliberately _strengthened_ because `user-event` is more faithful than the old synthetic dispatch: Shift+Enter now proves the real newline (`"no send\n"`), and the error-throw test gained an explicit `act(() => {})` flush + `toBeEnabled()` recovery check (user-event refuses to type into a still-disabled composer). The three pure-function tests stayed plain vitest by design. Two things `git log` won't tell a future reader: the working fake-timer config is `vi.useFakeTimers({ shouldAdvanceTime: true })` (the documented `advanceTimers`-only pattern _hangs_ user-event under Vitest 3), and jest-dom matcher types needed a `src/vitest.d.ts` re-export because `vitest.setup.ts` sits outside the tsconfig `include`. This is a deliberate **chat-only** divergence — `apps/admin`/`apps/web` keep plain `react-dom/client` + `act`.
+
+**Compound docs.** [`docs/solutions/best-practices/rtl-user-event-vitest-fake-timers-migration-20260625.md`](../../solutions/best-practices/rtl-user-event-vitest-fake-timers-migration-20260625.md).
+
+**Residual risk / follow-ups.** None blocking. focus-restore-on-close stays browser-verified (depends on `offsetParent`, which jsdom can't represent). feat-205's async Mastra wiring can now be written in RTL from the start — the motivation for landing this first.
 
 ## Problem
 

--- a/docs/solutions/best-practices/rtl-user-event-vitest-fake-timers-migration-20260625.md
+++ b/docs/solutions/best-practices/rtl-user-event-vitest-fake-timers-migration-20260625.md
@@ -1,0 +1,186 @@
+---
+title: "Migrating a Vitest suite to React Testing Library + user-event (fake-timer hang, realism-revealed assertions, jest-dom types)"
+date: 2026-06-25
+category: best-practices
+module: apps/chat
+problem_type: best_practice
+component: testing_framework
+severity: medium
+applies_when:
+  - "Adopting @testing-library/react + @testing-library/user-event in a Vitest project that uses vi.useFakeTimers()"
+  - "Migrating tests off plain react-dom/client + act onto RTL"
+  - "jest-dom matchers (toBeDisabled, toHaveValue, toBeInTheDocument) fail to typecheck under tsc --noEmit"
+tags:
+  - react-testing-library
+  - user-event
+  - vitest
+  - fake-timers
+  - jsdom
+  - jest-dom
+  - testing
+---
+
+# Migrating a Vitest suite to React Testing Library + user-event
+
+Three non-obvious traps surfaced migrating `apps/chat`'s test suite from the
+monorepo's plain `react-dom/client` + `act` convention onto React Testing
+Library + `user-event` + `renderHook` (forge#1372, roadmap feat-206). Each cost
+a debug cycle; all three are mechanical once known.
+
+> Scope note: this is a **chat-only** convention. `apps/admin` and `apps/web`
+> deliberately stay on plain `react-dom/client` + `act` (no testing-library).
+> See `apps/chat/CLAUDE.md` "Key Conventions".
+
+## Context
+
+The suite was interaction-heavy (typing, Enter/Escape, clicks, a reply that
+lands via `setTimeout`) and had been written with hand-rolled DOM plumbing
+because there was no `user-event`: a `HTMLTextAreaElement.prototype` value-setter
+to type, raw `dispatchEvent(new KeyboardEvent(...))`, and a `useEffect`-into-a-
+module-level-`latest` harness to read a hook's return. RTL removes all of that —
+but the migration is not a pure find-and-replace. The three traps below are what
+review and the test run actually caught.
+
+## Guidance
+
+### 1. user-event + Vitest fake timers: the documented config HANGS — use `shouldAdvanceTime: true`
+
+When a test installs `vi.useFakeTimers()` (here: because the stub reply fires
+through `setTimeout`), every `await user.click(...)` / `user.type(...)` **hangs
+to the 5s test timeout**. The widely-documented fix —
+
+```ts
+// HANGS under Vitest 3: user-event's awaited interactions never resolve
+vi.useFakeTimers()
+const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+```
+
+— was **not** sufficient in this project (Vitest 3.2 / user-event 14.6). Adding
+`delay: null` did not help either. The config that works:
+
+```ts
+beforeEach(() => {
+  // shouldAdvanceTime lets user-event's awaited interactions resolve; the
+  // reply setTimeout is still advanced deterministically by an explicit
+  // act(() => vi.advanceTimersByTime(DELAY)).
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+})
+```
+
+`shouldAdvanceTime` makes the fake clock auto-advance with real wall-time, so
+user-event's internal awaits settle, while you still control the domain timer
+(an 800ms reply here) by jumping it explicitly. The auto-advance does **not**
+fire the domain timer early — tests don't spend the domain delay (800ms) inside
+an `await`, so the explicit jump remains the only thing that fires it. Caveat
+when porting this elsewhere: that guarantee holds only while awaited
+interactions stay short. If a test awaits a genuinely slow interaction (a very
+long `user.type`, a real delay) for more wall-time than the domain delay between
+the action and the explicit jump, auto-advance can cross the boundary and fire
+the timer early — keep awaited interactions short or jump the timer right after
+the action. Diagnosis tell: nearly all interaction tests time out at exactly
+5000ms while the no-interaction tests pass.
+
+### 2. user-event is more faithful than synthetic dispatch — it reveals assertions that only passed before because the old events under-simulated reality
+
+Synthetic `dispatchEvent` / prototype value-setters skip browser behaviors that
+`user-event` reproduces. A mechanism migration is therefore **not always
+assertion-preserving by accident** — two assertions legitimately changed, each
+strengthening the test:
+
+- **Shift+Enter inserts a real newline.** The old raw `KeyboardEvent` could not
+  insert text, so the test asserted the draft was unchanged (`"no send"`).
+  `user.keyboard("{Shift>}{Enter}{/Shift}")` performs the real default action,
+  so the retained draft is now `"no send\n"`. Assert the newline — it proves
+  more than the original did.
+
+- **user-event refuses to act on disabled elements.** The old tests bypassed
+  `disabled` by forcing the value through the prototype setter and dispatching
+  `submit` directly. `user.type` / `user.click` correctly no-op on a disabled
+  control. So a test that sends, triggers an error, and then expects the
+  composer to accept a fresh send must first **flush the React state update that
+  re-enables it**. When an error escapes a `setTimeout` callback, React may not
+  have committed the slot-release re-render before the throw propagated:
+
+  ```ts
+  expect(() => act(() => vi.advanceTimersByTime(DELAY))).toThrow("boom")
+  act(() => {}) // flush the deferred slot-release render
+  expect(getTextarea()).toBeEnabled() // make the recovery observable
+  await sendMessage("after throw") // now user-event will actually type
+  ```
+
+Corollary for queries: prefer role/name (`getByRole("button", { name: "Send" })`).
+Where two controls share an accessible name (here a "New conversation" _action_
+and a default-titled conversation _row_), disambiguate by container scope
+(`within(nav)` / `!nav.contains(el)`), not by DOM order. Keep `querySelector`
+only for elements whose role legitimately changes — e.g. an `<aside>` that is
+`role="dialog"` when open and a complementary rail otherwise; `getByRole`
+against it breaks across states.
+
+### 3. jest-dom matcher types need a `src`-included reference when the setup file lives outside tsconfig `include`
+
+`vitest.setup.ts` at the app root imports `@testing-library/jest-dom/vitest`
+(which augments Vitest's `Assertion` interface at runtime). But if tsconfig's
+`include` is `src/**/*` and the setup file lives at the app root, **tsc never
+sees the augmentation** — `toBeDisabled`, `toHaveValue`, `toBeInTheDocument`,
+etc. fail `tsc --noEmit` with `Property '...' does not exist on type
+'Assertion<HTMLElement>'`, even though the tests run green.
+
+Fix: add a one-line declaration file _inside_ the `include` glob:
+
+```ts
+// apps/chat/src/vitest.d.ts
+import "@testing-library/jest-dom/vitest"
+```
+
+Do **not** reach for `compilerOptions.types: ["@testing-library/jest-dom"]` —
+that narrows the global types array and can drop other auto-included `@types`.
+
+Also pin `@testing-library/dom` explicitly: RTL v16 lists it as a **peer**, not
+a bundled dependency.
+
+## Why This Matters
+
+A test-mechanism migration is sold as "no behavior change, tests stay green," so
+the failure modes are easy to mis-read: the fake-timer hang looks like a broken
+test rather than a config gap; the realism-revealed assertion changes look like
+regressions rather than strengthenings; and the jest-dom type errors look like a
+missing dependency rather than a tsconfig-scope gap. Knowing all three up front
+turns a multi-cycle debug into mechanical edits, and keeps the "every assertion
+survives" guarantee honest (you can explain exactly why the two that changed are
+stronger, not weaker).
+
+## When to Apply
+
+- Installing RTL + user-event in any Vitest project that already uses
+  `vi.useFakeTimers()` for domain timers.
+- Migrating an existing `react-dom/client` + `act` suite to RTL — budget for
+  per-assertion review, not a blind sweep.
+- Seeing jest-dom matchers fail typecheck while passing at runtime.
+
+## Examples
+
+Hook tests migrate to `renderHook` cleanly, but an effect that focuses a
+`ref`-bound node needs a real DOM target (renderHook renders no DOM of its own):
+
+```ts
+const { result, rerender } = renderHook((p) => useSidebarChrome(p), {
+  initialProps: { ...base, mobileOpen: false },
+})
+const btn = document.createElement("button")
+document.body.appendChild(btn)
+result.current.closeRef.current = btn // give the focus effect a target
+rerender({ ...base, mobileOpen: true })
+expect(document.activeElement).toBe(btn)
+```
+
+This replaces the old "publish the hook's return through a `useEffect` into a
+module-level `latest`" harness entirely.
+
+## Related
+
+- Plan: `docs/plans/2026-06-25-001-feat-chat-react-testing-library-plan.md`
+- Convention: `apps/chat/CLAUDE.md` "Key Conventions" (the deliberate chat-only
+  RTL divergence + the browser-verify caveat for focus-restore-on-close, which
+  depends on `offsetParent` and so cannot be asserted in jsdom)
+- PR: forge#1372 (roadmap feat-206)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,18 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.2.4
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.9.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.0
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.1.17
@@ -1287,6 +1299,9 @@ packages:
         optional: true
       express:
         optional: true
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@ai-sdk/gateway@3.0.114':
     resolution: {integrity: sha512-MqkZ5sd+qiq6RgIxELkoFQXg2/JwK+WCMaot7U+rtrZpWJl3fSyYvc28SC03b256o4F7OXjQtdjTqs81B2w+dA==}
@@ -5601,6 +5616,35 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -5617,6 +5661,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -6502,6 +6549,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -7406,6 +7456,9 @@ packages:
       webpack:
         optional: true
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -7639,6 +7692,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-walk@0.1.2:
     resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
@@ -9856,6 +9915,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -10079,6 +10139,10 @@ packages:
     resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   m3u8-parser@7.2.0:
     resolution: {integrity: sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==}
@@ -10545,6 +10609,10 @@ packages:
 
   min-document@2.19.2:
     resolution: {integrity: sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -11319,6 +11387,10 @@ packages:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -11503,6 +11575,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
@@ -11681,6 +11756,10 @@ packages:
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -12359,6 +12438,10 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -13532,6 +13615,8 @@ snapshots:
     optionalDependencies:
       '@grpc/grpc-js': 1.14.3
       express: 5.2.1
+
+  '@adobe/css-tools@4.5.0': {}
 
   '@ai-sdk/gateway@3.0.114(zod@4.3.6)':
     dependencies:
@@ -18988,6 +19073,40 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.4
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.2.3(@types/react@19.1.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -19009,6 +19128,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -19452,7 +19573,7 @@ snapshots:
 
   '@videojs/http-streaming@3.17.4(video.js@8.23.7)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@videojs/vhs-utils': 4.1.1
       aes-decrypter: 4.0.2
       global: 4.4.0
@@ -19463,12 +19584,12 @@ snapshots:
 
   '@videojs/vhs-utils@4.1.1':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       global: 4.4.0
 
   '@videojs/xhr@2.7.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       global: 4.4.0
       is-function: 1.0.2
 
@@ -20187,7 +20308,7 @@ snapshots:
 
   aes-decrypter@4.0.2:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@videojs/vhs-utils': 4.1.1
       global: 4.4.0
       pkcs7: 1.0.4
@@ -20323,6 +20444,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -21356,6 +21481,8 @@ snapshots:
       '@rspack/core': 1.7.11(@swc/helpers@0.5.15)
       webpack: 5.106.2(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.13)
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
   cssom@0.3.8: {}
@@ -21527,6 +21654,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-walk@0.1.2: {}
 
@@ -21824,7 +21955,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
@@ -21840,7 +21971,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -21877,11 +22008,11 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -21901,7 +22032,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -21912,7 +22043,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24798,9 +24929,11 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
   m3u8-parser@7.2.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@videojs/vhs-utils': 4.1.1
       global: 4.4.0
 
@@ -25303,12 +25436,12 @@ snapshots:
 
   metro-runtime@0.83.3:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.83.7:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       flow-enums-runtime: 0.0.6
 
   metro-runtime@0.84.4:
@@ -25865,6 +25998,8 @@ snapshots:
     dependencies:
       dom-walk: 0.1.2
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -25904,7 +26039,7 @@ snapshots:
 
   mpd-parser@1.3.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@videojs/vhs-utils': 4.1.1
       '@xmldom/xmldom': 0.8.12
       global: 4.4.0
@@ -25973,7 +26108,7 @@ snapshots:
 
   mux.js@7.1.0:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       global: 4.4.0
 
   mz@2.7.0:
@@ -26546,7 +26681,7 @@ snapshots:
 
   pkcs7@1.0.4:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
 
   pkg-dir@4.2.0:
     dependencies:
@@ -26666,6 +26801,12 @@ snapshots:
   prettier@3.8.1: {}
 
   pretty-bytes@5.6.0: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@29.7.0:
     dependencies:
@@ -26873,6 +27014,8 @@ snapshots:
       react: 19.1.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -27232,6 +27375,11 @@ snapshots:
     dependencies:
       resolve: 1.22.11
     optional: true
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -28132,6 +28280,10 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 


### PR DESCRIPTION
## What

Migrates `apps/chat`'s five DOM test files off the monorepo's plain
`react-dom/client` + `act` convention onto **React Testing Library** +
`@testing-library/user-event` + `renderHook`. Implements roadmap ticket
`feat-206` (ai-chat lane).

This is a **test-mechanism swap, not a coverage change** — every existing
assertion survives and all **63 tests stay green**. A deliberate, **chat-only**
divergence ahead of feat-205's async Mastra wiring; `apps/admin` / `apps/web`
keep their no-testing-library convention untouched.

## Changes

- **deps:** `@testing-library/{react,dom,user-event,jest-dom}`
- **`vitest.setup.ts`** (jest-dom matchers + `afterEach(cleanup)`), **`src/vitest.d.ts`**
  for the matcher types, **`vitest.config.ts`** flipped to `jsdom` as the app default
- **`renderHook`** replaces the `useEffect`-capture harness in `use-sidebar-chrome`
- per-file `// @vitest-environment` directives and the hand-rolled value-setter /
  raw-event / `createRoot` plumbing removed
- **`apps/chat/CLAUDE.md`** records the deliberate divergence + the browser-verify
  caveat (focus-restore-on-close depends on `offsetParent`, which jsdom can't represent)

## Notes for reviewers

- Two assertions legitimately changed because `user-event` is more realistic than
  the old synthetic dispatch: Shift+Enter now proves the real newline insertion
  (`"no send\n"`), and the throw test needed an `act(() => {})` flush + an explicit
  `toBeEnabled()` recovery assertion.
- The working fake-timer config is `vi.useFakeTimers({ shouldAdvanceTime: true })` +
  `userEvent.setup({ advanceTimers })` — the documented `advanceTimers`-only pattern
  hangs user-event under Vitest 3.
- Pure-function tests (`conversations`, `chat-stub`, `sidebar-collapsed-styles`) stay
  plain vitest by design.

## Verification

- `pnpm --filter @forge/chat test` — 8 files / 63 tests pass
- `pnpm --filter @forge/chat lint` + `typecheck` — clean
- Grep clean of the retired plumbing; no `@vitest-environment` directives remain

Plan: `docs/plans/2026-06-25-001-feat-chat-react-testing-library-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)