### PR TITLE
perf(search): batch keyword-first lexical retrieval

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -107,6 +107,14 @@ a high-strength source attribution on their own.
 
 A request-side selector that chooses which retrieval pipeline Admin search should run for a caller. A Search Pipeline Mode changes how candidates are gathered and fused; it is not a health signal.
 
+### Search Candidate Window
+
+A bounded per-retriever set of eligible search candidates that is handed to
+fusion after retrieval-specific ranking and filtering. Eligibility gates that
+affect whether a result can appear must run before the window; display-only
+hydration should run after the window so it cannot multiply or reorder
+candidates.
+
 ### Search Eval Caller Track
 
 A search-evaluation prompt group scoped to a caller's job rather than only to a

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts
@@ -13,6 +13,7 @@ import {
   MAX_EXACT_TITLE_TOKENS,
   searchByExactTitle,
   searchByKeywordWeighted,
+  searchKeywordFirstVideoLexical,
   searchByTrigram,
   tokenizeForExactTitle,
 } from "./hybrid-search-keyword-first-retrievers"
@@ -20,8 +21,11 @@ import { SearchTimingRecorder } from "./hybrid-search-timing"
 
 function mockPrisma() {
   const $queryRaw = vi.fn()
+  const tx = { $queryRaw }
+  const $transaction = vi.fn(async (run) => run(tx))
   return {
     $queryRaw,
+    $transaction,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
 }
@@ -413,5 +417,98 @@ describe("searchByExactTitle", () => {
     const callArgs = prisma.$queryRaw.mock.calls[0]
     const ilikeChain = callArgs[1] as { values: string[] }
     expect(ilikeChain.values).toEqual(["%the%", "%bible%"])
+  })
+})
+
+describe("searchKeywordFirstVideoLexical", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("runs all three lexical retrievers inside one transaction", async () => {
+    prisma.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          video_id: "vid-kw",
+          video_core_id: "core-kw",
+          video_slug: "kw",
+          video_title: "Keyword",
+          description: "keyword result",
+          rank: 0.7,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          video_id: "vid-trgm",
+          video_core_id: "core-trgm",
+          video_slug: "trgm",
+          video_title: "Trigram",
+          description: "trigram result",
+          similarity: 0.5,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          video_id: "vid-exact",
+          video_core_id: "core-exact",
+          video_slug: "exact",
+          video_title: "Exact",
+          description: "exact result",
+          title_length: 5,
+        },
+      ])
+    const timing = new SearchTimingRecorder()
+
+    const result = await searchKeywordFirstVideoLexical(
+      prisma,
+      {
+        query: "the bible project",
+        locale: "en",
+        limit: 10,
+      },
+      timing,
+    )
+
+    expect(prisma.$transaction).toHaveBeenCalledOnce()
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      maxWait: 5_000,
+      timeout: 20_000,
+    })
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(3)
+    expect(result.keywordWeighted[0]).toMatchObject({
+      resultId: "vid-kw",
+      rank: 0.7,
+    })
+    expect(result.trigram[0]).toMatchObject({
+      resultId: "vid-trgm",
+      similarity: 0.5,
+    })
+    expect(result.exactTitle[0]).toMatchObject({
+      resultId: "vid-exact",
+      titleLength: 5,
+    })
+    expect(timing.snapshotDbTimings().map((row) => row.label)).toEqual([
+      "keyword-weighted-video.query",
+      "trigram-video.query",
+      "exact-title-video.query",
+    ])
+  })
+
+  it("short-circuits whitespace-only input before opening a transaction", async () => {
+    await expect(
+      searchKeywordFirstVideoLexical(prisma, {
+        query: "   ",
+        locale: "en",
+        limit: 10,
+      }),
+    ).resolves.toEqual({
+      keywordWeighted: [],
+      trigram: [],
+      exactTitle: [],
+    })
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(prisma.$queryRaw).not.toHaveBeenCalled()
   })
 })

--- a/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts
@@ -49,6 +49,12 @@ export type ExactTitleSearchParams = {
   limit: number
 }
 
+export type KeywordFirstVideoLexicalSearchParams = {
+  query: string
+  locale: string
+  limit: number
+}
+
 // -----------------------------------------------------------------------------
 // Return shapes — all three carry the same row contract as R4's
 // `searchVideoKeyword`, plus a retriever-specific score field
@@ -78,6 +84,12 @@ export type KeywordWeightedResult = VideoKeywordRowShape & { rank: number }
  */
 export type TrigramResult = VideoKeywordRowShape & { similarity: number }
 export type ExactTitleResult = VideoKeywordRowShape & { titleLength: number }
+
+export type KeywordFirstVideoLexicalResults = {
+  keywordWeighted: KeywordWeightedResult[]
+  trigram: TrigramResult[]
+  exactTitle: ExactTitleResult[]
+}
 
 // -----------------------------------------------------------------------------
 // Internal raw-row shapes
@@ -109,6 +121,11 @@ type ExactTitleRow = {
   description: string | null
   title_length: number
 }
+
+type QueryRawClient = Pick<PrismaClient, "$queryRaw">
+
+const KEYWORD_FIRST_LEXICAL_TRANSACTION_MAX_WAIT_MS = 5_000
+const KEYWORD_FIRST_LEXICAL_TRANSACTION_TIMEOUT_MS = 20_000
 
 // -----------------------------------------------------------------------------
 // Exact-title tokenizer + DoS cap
@@ -172,7 +189,7 @@ export function tokenizeForExactTitle(query: string): string[] {
  * Empty / whitespace input short-circuits to `[]`.
  */
 export async function searchByKeywordWeighted(
-  prisma: PrismaClient,
+  prisma: QueryRawClient,
   params: KeywordWeightedSearchParams,
   timing?: SearchTimingRecorder,
 ): Promise<KeywordWeightedResult[]> {
@@ -260,7 +277,7 @@ export async function searchByKeywordWeighted(
  * Empty input short-circuits to `[]`.
  */
 export async function searchByTrigram(
-  prisma: PrismaClient,
+  prisma: QueryRawClient,
   params: TrigramSearchParams,
   timing?: SearchTimingRecorder,
 ): Promise<TrigramResult[]> {
@@ -333,7 +350,7 @@ export async function searchByTrigram(
  * placeholders at parse time, which is the safe failure mode.
  */
 export async function searchByExactTitle(
-  prisma: PrismaClient,
+  prisma: QueryRawClient,
   params: ExactTitleSearchParams,
   timing?: SearchTimingRecorder,
 ): Promise<ExactTitleResult[]> {
@@ -385,4 +402,43 @@ export async function searchByExactTitle(
     description: row.description,
     titleLength: Number(row.title_length),
   }))
+}
+
+/**
+ * Run the keyword-first video lexical stack on one DB connection.
+ *
+ * The three underlying SQL queries stay byte-for-byte owned by their
+ * retrievers above; this helper changes only connection scheduling. In
+ * production that cuts pool fan-out from three concurrent video-lexical
+ * connections to one transaction-bound connection while preserving the
+ * three logical result lists consumed by RRF, debug attribution, and the
+ * dilution cap.
+ */
+export async function searchKeywordFirstVideoLexical(
+  prisma: PrismaClient,
+  params: KeywordFirstVideoLexicalSearchParams,
+  timing?: SearchTimingRecorder,
+): Promise<KeywordFirstVideoLexicalResults> {
+  if (params.query.trim().length === 0) {
+    return {
+      keywordWeighted: [],
+      trigram: [],
+      exactTitle: [],
+    }
+  }
+
+  return prisma.$transaction(
+    async (tx) => {
+      const client: QueryRawClient = tx
+      return {
+        keywordWeighted: await searchByKeywordWeighted(client, params, timing),
+        trigram: await searchByTrigram(client, params, timing),
+        exactTitle: await searchByExactTitle(client, params, timing),
+      }
+    },
+    {
+      maxWait: KEYWORD_FIRST_LEXICAL_TRANSACTION_MAX_WAIT_MS,
+      timeout: KEYWORD_FIRST_LEXICAL_TRANSACTION_TIMEOUT_MS,
+    },
+  )
 }

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -304,7 +304,12 @@ describe("searchVideoSemantic", () => {
 
     const sql = latestRawSql(prisma)
     expect((sql.match(/v\.deleted_at IS NULL/g) ?? []).length).toBe(1)
-    expect((sql.match(/vl\.status = 'published'/g) ?? []).length).toBe(1)
+    expect((sql.match(/vl_visible\.status = 'published'/g) ?? []).length).toBe(
+      1,
+    )
+    expect((sql.match(/vl_display\.status = 'published'/g) ?? []).length).toBe(
+      1,
+    )
     const sqlWithFragments = latestRawSqlWithFragments(prisma)
     expect((sqlWithFragments.match(/IS NOT NULL/g) ?? []).length).toBe(1)
     expect(sqlWithFragments).not.toContain("vsl.embedding")
@@ -318,20 +323,26 @@ describe("searchVideoSemantic", () => {
       latestRawValues(prisma).filter((value) => value === "[0.1,0.2]"),
     ).toHaveLength(1)
 
+    const candidateWindow = sqlBetween(
+      sqlWithFragments,
+      "visible_semantic_candidates AS",
+      "requested_language AS MATERIALIZED",
+    )
+    const candidateLimitIndex = candidateWindow.lastIndexOf("LIMIT")
+    expect(candidateWindow.indexOf("v.deleted_at IS NULL")).toBeLessThan(
+      candidateLimitIndex,
+    )
+    expect(
+      candidateWindow.indexOf("vl_visible.status = 'published'"),
+    ).toBeLessThan(candidateLimitIndex)
+    expect(
+      candidateWindow.indexOf("vl_visible.deleted_at IS NULL"),
+    ).toBeLessThan(candidateLimitIndex)
+
     const transcriptSource = sqlBetween(
       sqlWithFragments,
       "transcript_source AS",
       "requested_language AS MATERIALIZED",
-    )
-    const transcriptOrderIndex = transcriptSource.indexOf("ORDER BY")
-    expect(transcriptSource.indexOf("v.deleted_at IS NULL")).toBeLessThan(
-      transcriptOrderIndex,
-    )
-    expect(transcriptSource.indexOf("vl.status = 'published'")).toBeLessThan(
-      transcriptOrderIndex,
-    )
-    expect(transcriptSource.indexOf("vl.deleted_at IS NULL")).toBeLessThan(
-      transcriptOrderIndex,
     )
     expect(transcriptSource).not.toContain("LATERAL")
     expect(transcriptSource).not.toContain("embedding::text")
@@ -340,6 +351,11 @@ describe("searchVideoSemantic", () => {
       sqlWithFragments.indexOf("requested_language AS MATERIALIZED"),
     )
     expect(hydratedTail).toContain("LEFT JOIN LATERAL")
+    expect(hydratedTail).toContain("JOIN LATERAL")
+    expect(hydratedTail).toContain("FROM video_locale vl_display")
+    expect(hydratedTail).toMatch(
+      /ORDER BY\s+vl_display\.language_core_id ASC NULLS LAST,\s+vl_display\.language_slug ASC NULLS LAST,\s+vl_display\.id ASC/,
+    )
     expect(hydratedTail).toContain(
       "vd.language_id IN (SELECT id FROM requested_language)",
     )
@@ -365,12 +381,79 @@ describe("searchVideoSemantic", () => {
       "ORDER BY",
       sql.indexOf("SELECT DISTINCT ON (vt.video_id)"),
     )
-    const transcriptCandidateLimitIndex = sql.indexOf(
-      "LIMIT",
-      sql.indexOf("best_transcript_per_video"),
+    const preCandidateWindow = sqlBetween(
+      sql,
+      "best_transcript_per_video AS",
+      "transcript_source AS",
     )
+    expect(preCandidateWindow).not.toContain("LIMIT")
+
+    const transcriptSource = sqlBetween(
+      sql,
+      "transcript_source AS",
+      "requested_language AS MATERIALIZED",
+    )
+    const transcriptCandidateLimitIndex = transcriptSource.indexOf("LIMIT")
     expect(transcriptOrderIndex).toBeGreaterThan(-1)
-    expect(transcriptOrderIndex).toBeLessThan(transcriptCandidateLimitIndex)
+    expect(transcriptCandidateLimitIndex).toBeGreaterThan(
+      transcriptSource.indexOf("FROM visible_semantic_candidates"),
+    )
+  })
+
+  it("keeps locale visibility before the candidate limit and display selection after it", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 5,
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    const bestTranscript = sqlBetween(
+      sql,
+      "best_transcript_per_video AS",
+      "visible_semantic_candidates AS",
+    )
+    expect(bestTranscript).toContain("SELECT DISTINCT ON (vt.video_id)")
+    expect(bestTranscript).not.toContain("JOIN video v")
+    expect(bestTranscript).not.toContain("video_locale")
+
+    const visibleCandidates = sqlBetween(
+      sql,
+      "visible_semantic_candidates AS",
+      "transcript_source AS",
+    )
+    expect(visibleCandidates).toContain("JOIN video v")
+    expect(visibleCandidates).toContain("WHERE EXISTS")
+    expect(visibleCandidates).toContain("FROM video_locale vl_visible")
+    expect(visibleCandidates).toContain("vl_visible.status = 'published'")
+    expect(visibleCandidates).toContain("vl_visible.deleted_at IS NULL")
+    expect(visibleCandidates).not.toContain("JOIN LATERAL")
+    expect(visibleCandidates).not.toContain("vl_display")
+    expect(visibleCandidates).not.toContain("LIMIT")
+
+    const transcriptSource = sqlBetween(
+      sql,
+      "transcript_source AS",
+      "requested_language AS MATERIALIZED",
+    )
+    expect(transcriptSource).toContain("FROM visible_semantic_candidates")
+    expect(transcriptSource).not.toContain("video_locale")
+    expect(transcriptSource.indexOf("LIMIT")).toBeGreaterThan(
+      transcriptSource.indexOf("FROM visible_semantic_candidates"),
+    )
+
+    const hydratedTail = sql.slice(
+      sql.indexOf("requested_language AS MATERIALIZED"),
+    )
+    expect(hydratedTail).toContain("FROM video_locale vl_display")
+    expect(hydratedTail).toContain("vl_display.status = 'published'")
+    expect(hydratedTail).toContain("vl_display.deleted_at IS NULL")
+    expect(hydratedTail).toMatch(
+      /ORDER BY\s+vl_display\.language_core_id ASC NULLS LAST,\s+vl_display\.language_slug ASC NULLS LAST,\s+vl_display\.id ASC/,
+    )
+    expect(hydratedTail).toMatch(/LIMIT\s+1/)
   })
 
   it("uses bounded per-source candidate windows after per-video collapse", async () => {
@@ -612,6 +695,33 @@ describe("mixVideoSemanticEvidenceRows", () => {
 
     expect(rows.map((row) => row.video_id)).toEqual(["a", "b"])
     expect(rows[0]!.scene_description).toBe("Scene A")
+  })
+
+  it("uses video id as the final public tie-breaker for otherwise equal winners", () => {
+    const rows = mixVideoSemanticEvidenceRows([
+      {
+        ...base,
+        video_id: "b",
+        evidence_id: "chunk-b",
+        evidence_source: "transcript",
+        scene_description: "Transcript B",
+        start_seconds: 3,
+        source_score: 0.8,
+        similarity: 0.8,
+      },
+      {
+        ...base,
+        video_id: "a",
+        evidence_id: "chunk-a",
+        evidence_source: "transcript",
+        scene_description: "Transcript A",
+        start_seconds: 3,
+        source_score: 0.8,
+        similarity: 0.8,
+      },
+    ])
+
+    expect(rows.map((row) => row.video_id)).toEqual(["a", "b"])
   })
 })
 

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -334,43 +334,58 @@ export async function searchVideoSemantic(
       WITH query_embedding AS MATERIALIZED (
         SELECT ${queryEmbedding}::vector AS embedding
       ),
+      best_transcript_per_video AS (
+        SELECT DISTINCT ON (vt.video_id)
+          vt.video_id                       AS video_id,
+          vt.video_edition_id               AS video_edition_id,
+          vtc.id                            AS evidence_id,
+          'transcript'                      AS evidence_source,
+          COALESCE(
+            NULLIF(vtc.content_summary, ''),
+            NULLIF(vtc.raw_source_text, ''),
+            vtc.text
+          )                                 AS scene_description,
+          vtc.start_seconds                 AS start_seconds,
+          1 - (vtc.embedding <=> qe.embedding) AS source_score
+        FROM video_transcript_chunk vtc
+        CROSS JOIN query_embedding qe
+        JOIN video_transcript vt ON vt.id = vtc.transcript_id
+          AND vt.language = ${locale}
+        WHERE vtc.embedding IS NOT NULL
+          ${transcriptProvenanceFilter}
+          AND vtc.language = ${locale}
+        ORDER BY
+          vt.video_id,
+          vtc.embedding <=> qe.embedding,
+          vtc.start_seconds ASC NULLS LAST,
+          vtc.id ASC
+      ),
+      visible_semantic_candidates AS (
+        SELECT
+          b.video_id                       AS video_id,
+          v.core_id                        AS video_core_id,
+          v.slug                           AS video_slug,
+          b.video_edition_id               AS video_edition_id,
+          b.evidence_id                    AS evidence_id,
+          b.evidence_source                AS evidence_source,
+          b.scene_description              AS scene_description,
+          b.start_seconds                  AS start_seconds,
+          b.source_score                   AS source_score
+        FROM best_transcript_per_video b
+        JOIN video v ON v.id = b.video_id
+          AND v.deleted_at IS NULL
+        WHERE EXISTS (
+          SELECT 1
+          FROM video_locale vl_visible
+          WHERE vl_visible.video_id = v.id
+            AND vl_visible.locale = ${locale}
+            AND vl_visible.status = 'published'
+            AND vl_visible.deleted_at IS NULL
+        )
+      ),
       transcript_source AS (
-        SELECT * FROM (
-          SELECT DISTINCT ON (vt.video_id)
-            vt.video_id                       AS video_id,
-            v.core_id                         AS video_core_id,
-            v.slug                            AS video_slug,
-            vl.title                          AS video_title,
-            vt.video_edition_id               AS video_edition_id,
-            vtc.id                            AS evidence_id,
-            'transcript'                      AS evidence_source,
-            COALESCE(
-              NULLIF(vtc.content_summary, ''),
-              NULLIF(vtc.raw_source_text, ''),
-              vtc.text
-            )                                 AS scene_description,
-            vtc.start_seconds                 AS start_seconds,
-            1 - (vtc.embedding <=> qe.embedding) AS source_score
-          FROM video_transcript_chunk vtc
-          CROSS JOIN query_embedding qe
-          JOIN video_transcript vt ON vt.id = vtc.transcript_id
-            AND vt.language = ${locale}
-          JOIN video v ON v.id = vt.video_id
-            AND v.deleted_at IS NULL
-          JOIN video_locale vl
-            ON vl.video_id = v.id
-            AND vl.locale = ${locale}
-            AND vl.status = 'published'
-            AND vl.deleted_at IS NULL
-          WHERE vtc.embedding IS NOT NULL
-            ${transcriptProvenanceFilter}
-            AND vtc.language = ${locale}
-          ORDER BY
-            vt.video_id,
-            vtc.embedding <=> qe.embedding,
-            vtc.start_seconds ASC NULLS LAST,
-            vtc.id ASC
-        ) best_transcript_per_video
+        SELECT *
+        FROM visible_semantic_candidates
         ORDER BY source_score DESC, start_seconds ASC NULLS LAST, evidence_id ASC
         LIMIT ${candidateLimit}
       ),
@@ -383,7 +398,7 @@ export async function searchVideoSemantic(
         ts.video_id                      AS video_id,
         ts.video_core_id                 AS video_core_id,
         ts.video_slug                    AS video_slug,
-        ts.video_title                   AS video_title,
+        display_locale.title             AS video_title,
         COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
         ts.evidence_id                   AS evidence_id,
         ts.evidence_source               AS evidence_source,
@@ -395,6 +410,19 @@ export async function searchVideoSemantic(
       FROM transcript_source ts
       LEFT JOIN video_transcript_chunk vtc_final
         ON vtc_final.id = ts.evidence_id
+      JOIN LATERAL (
+        SELECT vl_display.title
+        FROM video_locale vl_display
+        WHERE vl_display.video_id = ts.video_id
+          AND vl_display.locale = ${locale}
+          AND vl_display.status = 'published'
+          AND vl_display.deleted_at IS NULL
+        ORDER BY
+          vl_display.language_core_id ASC NULLS LAST,
+          vl_display.language_slug ASC NULLS LAST,
+          vl_display.id ASC
+        LIMIT 1
+      ) display_locale ON true
       LEFT JOIN LATERAL (
         SELECT mv.playback_id
         FROM video_dub vd

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -22,17 +22,31 @@ vi.mock("./hybrid-search-retrievers", () => ({
   searchExperienceKeyword: vi.fn(),
 }))
 
-vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
-  searchByKeywordWeighted: vi.fn(),
-  searchByTrigram: vi.fn(),
-  searchByExactTitle: vi.fn(),
-  MAX_EXACT_TITLE_TOKENS: 16,
-  tokenizeForExactTitle: (q: string) =>
-    q
-      .toLowerCase()
-      .split(/[^\p{L}\p{N}]+/u)
-      .filter((t) => t.length > 0),
-}))
+vi.mock("./hybrid-search-keyword-first-retrievers", () => {
+  const searchByKeywordWeighted = vi.fn()
+  const searchByTrigram = vi.fn()
+  const searchByExactTitle = vi.fn()
+  const searchKeywordFirstVideoLexical = vi.fn(
+    async (prisma: unknown, params: unknown, timing: unknown) => ({
+      keywordWeighted: await searchByKeywordWeighted(prisma, params, timing),
+      trigram: await searchByTrigram(prisma, params, timing),
+      exactTitle: await searchByExactTitle(prisma, params, timing),
+    }),
+  )
+
+  return {
+    searchByKeywordWeighted,
+    searchByTrigram,
+    searchByExactTitle,
+    searchKeywordFirstVideoLexical,
+    MAX_EXACT_TITLE_TOKENS: 16,
+    tokenizeForExactTitle: (q: string) =>
+      q
+        .toLowerCase()
+        .split(/[^\p{L}\p{N}]+/u)
+        .filter((t) => t.length > 0),
+  }
+})
 
 import {
   searchVideoSemantic,

--- a/apps/admin/src/services/hybrid-search.debug.test.ts
+++ b/apps/admin/src/services/hybrid-search.debug.test.ts
@@ -20,13 +20,27 @@ vi.mock("./hybrid-search-retrievers", () => ({
   searchExperienceKeyword: vi.fn(),
 }))
 
-vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
-  searchByKeywordWeighted: vi.fn(),
-  searchByTrigram: vi.fn(),
-  searchByExactTitle: vi.fn(),
-  MAX_EXACT_TITLE_TOKENS: 16,
-  tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
-}))
+vi.mock("./hybrid-search-keyword-first-retrievers", () => {
+  const searchByKeywordWeighted = vi.fn()
+  const searchByTrigram = vi.fn()
+  const searchByExactTitle = vi.fn()
+  const searchKeywordFirstVideoLexical = vi.fn(
+    async (prisma: unknown, params: unknown, timing: unknown) => ({
+      keywordWeighted: await searchByKeywordWeighted(prisma, params, timing),
+      trigram: await searchByTrigram(prisma, params, timing),
+      exactTitle: await searchByExactTitle(prisma, params, timing),
+    }),
+  )
+
+  return {
+    searchByKeywordWeighted,
+    searchByTrigram,
+    searchByExactTitle,
+    searchKeywordFirstVideoLexical,
+    MAX_EXACT_TITLE_TOKENS: 16,
+    tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
+  }
+})
 
 import {
   searchVideoSemantic,

--- a/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
+++ b/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
@@ -326,17 +326,31 @@ vi.mock("./hybrid-search-retrievers", () => ({
   searchExperienceKeyword: vi.fn(),
 }))
 
-vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
-  searchByKeywordWeighted: vi.fn(),
-  searchByTrigram: vi.fn(),
-  searchByExactTitle: vi.fn(),
-  MAX_EXACT_TITLE_TOKENS: 16,
-  tokenizeForExactTitle: (q: string) =>
-    q
-      .toLowerCase()
-      .split(/[^\p{L}\p{N}]+/u)
-      .filter((t) => t.length > 0),
-}))
+vi.mock("./hybrid-search-keyword-first-retrievers", () => {
+  const searchByKeywordWeighted = vi.fn()
+  const searchByTrigram = vi.fn()
+  const searchByExactTitle = vi.fn()
+  const searchKeywordFirstVideoLexical = vi.fn(
+    async (prisma: unknown, params: unknown, timing: unknown) => ({
+      keywordWeighted: await searchByKeywordWeighted(prisma, params, timing),
+      trigram: await searchByTrigram(prisma, params, timing),
+      exactTitle: await searchByExactTitle(prisma, params, timing),
+    }),
+  )
+
+  return {
+    searchByKeywordWeighted,
+    searchByTrigram,
+    searchByExactTitle,
+    searchKeywordFirstVideoLexical,
+    MAX_EXACT_TITLE_TOKENS: 16,
+    tokenizeForExactTitle: (q: string) =>
+      q
+        .toLowerCase()
+        .split(/[^\p{L}\p{N}]+/u)
+        .filter((t) => t.length > 0),
+  }
+})
 
 describe("isDilutionCapEnabled (SEARCH_DILUTION_CAP_ENABLED parser)", () => {
   beforeEach(() => {

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -25,13 +25,27 @@ vi.mock("./hybrid-search-retrievers", () => ({
   searchExperienceKeyword: vi.fn(),
 }))
 
-vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
-  searchByKeywordWeighted: vi.fn(),
-  searchByTrigram: vi.fn(),
-  searchByExactTitle: vi.fn(),
-  MAX_EXACT_TITLE_TOKENS: 16,
-  tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
-}))
+vi.mock("./hybrid-search-keyword-first-retrievers", () => {
+  const searchByKeywordWeighted = vi.fn()
+  const searchByTrigram = vi.fn()
+  const searchByExactTitle = vi.fn()
+  const searchKeywordFirstVideoLexical = vi.fn(
+    async (prisma: unknown, params: unknown, timing: unknown) => ({
+      keywordWeighted: await searchByKeywordWeighted(prisma, params, timing),
+      trigram: await searchByTrigram(prisma, params, timing),
+      exactTitle: await searchByExactTitle(prisma, params, timing),
+    }),
+  )
+
+  return {
+    searchByKeywordWeighted,
+    searchByTrigram,
+    searchByExactTitle,
+    searchKeywordFirstVideoLexical,
+    MAX_EXACT_TITLE_TOKENS: 16,
+    tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
+  }
+})
 
 import {
   searchVideoSemantic,
@@ -195,7 +209,7 @@ describe("HybridSearchService keyword-first branch", () => {
       mode: "keyword-first",
     })
     await flushQueuedPromises()
-    await delayMs(40)
+    await delayMs(90)
 
     expect(searchByKeywordWeighted).toHaveBeenCalled()
     expect(searchByTrigram).toHaveBeenCalled()
@@ -205,8 +219,8 @@ describe("HybridSearchService keyword-first branch", () => {
     embedding.resolve([0.1, 0.2, 0.3])
     const traced = await searchPromise
 
-    expect(traced.timings.embeddingMs).toBeGreaterThanOrEqual(35)
-    expect(traced.timings.retrievalsMs).toBeGreaterThanOrEqual(15)
+    expect(traced.timings.embeddingMs).toBeGreaterThanOrEqual(85)
+    expect(traced.timings.retrievalsMs).toBeGreaterThanOrEqual(55)
     expect(traced.timings.retrievalsMs).toBeLessThan(traced.timings.embeddingMs)
     expect(traced.timings.retrievalWaitMs).toBeLessThan(
       traced.timings.embeddingMs / 2,
@@ -266,7 +280,7 @@ describe("HybridSearchService keyword-first branch", () => {
     expect(searchByExactTitle).not.toHaveBeenCalled()
   })
 
-  it("isolates per-retriever failures via Promise.allSettled (one rejected list = empty list, response still returns)", async () => {
+  it("isolates a lexical batch failure via Promise.allSettled while other retrievers still return", async () => {
     const loggerError = vi.fn()
     vi.mocked(searchByTrigram).mockRejectedValue(new Error("boom trigram"))
     vi.mocked(searchByKeywordWeighted).mockResolvedValue([
@@ -279,6 +293,21 @@ describe("HybridSearchService keyword-first branch", () => {
         imageUrl: null,
         description: "kw weighted survivor",
         rank: 0.7,
+      },
+    ])
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-semantic",
+        videoCoreId: null,
+        videoSlug: "semantic",
+        videoTitle: "Semantic",
+        imageUrl: null,
+        sceneDescription: "semantic survivor",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 0.8,
+        embeddingText: "[0.1,0.2,0.3]",
       },
     ])
 
@@ -295,9 +324,15 @@ describe("HybridSearchService keyword-first branch", () => {
     })
 
     expect(result.results).toHaveLength(1)
-    expect(result.results[0]!.id).toBe("vid-1")
+    expect(result.results[0]!.id).toBe("vid-semantic")
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.stringContaining("keyword-weighted-video retrieval failed"),
+    )
     expect(loggerError).toHaveBeenCalledWith(
       expect.stringContaining("trigram-video retrieval failed"),
+    )
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.stringContaining("exact-title-video retrieval failed"),
     )
   })
 
@@ -320,6 +355,21 @@ describe("HybridSearchService keyword-first branch", () => {
         imageUrl: null,
         description: "kw weighted survivor",
         rank: 0.7,
+      },
+    ])
+    vi.mocked(searchVideoSemantic).mockResolvedValue([
+      {
+        resultType: "video",
+        resultId: "vid-semantic",
+        videoCoreId: null,
+        videoSlug: "semantic",
+        videoTitle: "Semantic",
+        imageUrl: null,
+        sceneDescription: "semantic survivor",
+        startSeconds: 0,
+        playbackId: null,
+        similarity: 0.8,
+        embeddingText: "[0.1,0.2,0.3]",
       },
     ])
 
@@ -347,9 +397,15 @@ describe("HybridSearchService keyword-first branch", () => {
       await flushQueuedPromises()
 
       expect(result.results).toHaveLength(1)
-      expect(result.results[0]!.id).toBe("vid-1")
+      expect(result.results[0]!.id).toBe("vid-semantic")
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining("keyword-weighted-video retrieval failed"),
+      )
       expect(loggerError).toHaveBeenCalledWith(
         expect.stringContaining("trigram-video retrieval failed"),
+      )
+      expect(loggerError).toHaveBeenCalledWith(
+        expect.stringContaining("exact-title-video retrieval failed"),
       )
       expect(unhandledRejections).toEqual([])
     } finally {

--- a/apps/admin/src/services/hybrid-search.regression.test.ts
+++ b/apps/admin/src/services/hybrid-search.regression.test.ts
@@ -34,13 +34,27 @@ vi.mock("./hybrid-search-retrievers", () => ({
   searchExperienceKeyword: vi.fn(),
 }))
 
-vi.mock("./hybrid-search-keyword-first-retrievers", () => ({
-  searchByKeywordWeighted: vi.fn().mockResolvedValue([]),
-  searchByTrigram: vi.fn().mockResolvedValue([]),
-  searchByExactTitle: vi.fn().mockResolvedValue([]),
-  MAX_EXACT_TITLE_TOKENS: 16,
-  tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
-}))
+vi.mock("./hybrid-search-keyword-first-retrievers", () => {
+  const searchByKeywordWeighted = vi.fn().mockResolvedValue([])
+  const searchByTrigram = vi.fn().mockResolvedValue([])
+  const searchByExactTitle = vi.fn().mockResolvedValue([])
+  const searchKeywordFirstVideoLexical = vi.fn(
+    async (prisma: unknown, params: unknown, timing: unknown) => ({
+      keywordWeighted: await searchByKeywordWeighted(prisma, params, timing),
+      trigram: await searchByTrigram(prisma, params, timing),
+      exactTitle: await searchByExactTitle(prisma, params, timing),
+    }),
+  )
+
+  return {
+    searchByKeywordWeighted,
+    searchByTrigram,
+    searchByExactTitle,
+    searchKeywordFirstVideoLexical,
+    MAX_EXACT_TITLE_TOKENS: 16,
+    tokenizeForExactTitle: (q: string) => q.toLowerCase().split(/\s+/),
+  }
+})
 
 import {
   searchVideoSemantic,

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -37,10 +37,9 @@ import {
   searchExperienceKeyword,
 } from "./hybrid-search-retrievers"
 import {
-  searchByKeywordWeighted,
-  searchByTrigram,
-  searchByExactTitle,
+  searchKeywordFirstVideoLexical,
   tokenizeForExactTitle,
+  type KeywordFirstVideoLexicalResults,
 } from "./hybrid-search-keyword-first-retrievers"
 import {
   activeTimingIntervalsMs,
@@ -934,6 +933,54 @@ export class HybridSearchService {
           },
         )
     }
+    const timedKeywordFirstVideoLexicalBatch = (
+      run: () => Promise<KeywordFirstVideoLexicalResults>,
+    ): Promise<KeywordFirstVideoLexicalResults> => {
+      const labels = [
+        "keyword-weighted-video",
+        "trigram-video",
+        "exact-title-video",
+      ] as const
+      const startedAt = nowMs()
+      return Promise.resolve()
+        .then(run)
+        .then(
+          (value) => {
+            const endedAt = nowMs()
+            const elapsed = boundedMs(endedAt - startedAt)
+            retrievalIntervals.push({ startedAt, endedAt })
+            for (const label of labels) {
+              const resultCount =
+                label === "keyword-weighted-video"
+                  ? value.keywordWeighted.length
+                  : label === "trigram-video"
+                    ? value.trigram.length
+                    : value.exactTitle.length
+              retrieverTimings.set(label, {
+                label,
+                status: "fulfilled",
+                elapsedMs: elapsed,
+                resultCount,
+              })
+            }
+            return value
+          },
+          (error) => {
+            const endedAt = nowMs()
+            const elapsed = boundedMs(endedAt - startedAt)
+            retrievalIntervals.push({ startedAt, endedAt })
+            for (const label of labels) {
+              retrieverTimings.set(label, {
+                label,
+                status: "rejected",
+                elapsedMs: elapsed,
+                resultCount: 0,
+              })
+            }
+            throw error
+          },
+        )
+    }
 
     const earlyKeywordFirstRetrievals: Retrieval[] = []
     if (wantsVideos && pipelineMode === "keyword-first") {
@@ -941,53 +988,34 @@ export class HybridSearchService {
       // Attaching allSettled immediately prevents a fast DB rejection
       // from surfacing as an unhandled promise rejection while embedding
       // is still pending.
+      const lexicalBatch = timedKeywordFirstVideoLexicalBatch(() =>
+        searchKeywordFirstVideoLexical(
+          this.prisma,
+          {
+            query,
+            locale,
+            limit: overfetchLimit,
+          },
+          timing,
+        ),
+      )
       earlyKeywordFirstRetrievals.push(
         {
           label: "keyword-weighted-video",
-          promise: timedRetrieval(
-            "keyword-weighted-video",
-            () =>
-              searchByKeywordWeighted(
-                this.prisma,
-                {
-                  query,
-                  locale,
-                  limit: overfetchLimit,
-                },
-                timing,
-              ) as Promise<RankedItem[]>,
+          promise: lexicalBatch.then(
+            (result) => result.keywordWeighted as RankedItem[],
           ),
         },
         {
           label: "trigram-video",
-          promise: timedRetrieval(
-            "trigram-video",
-            () =>
-              searchByTrigram(
-                this.prisma,
-                {
-                  query,
-                  locale,
-                  limit: overfetchLimit,
-                },
-                timing,
-              ) as Promise<RankedItem[]>,
+          promise: lexicalBatch.then(
+            (result) => result.trigram as RankedItem[],
           ),
         },
         {
           label: "exact-title-video",
-          promise: timedRetrieval(
-            "exact-title-video",
-            () =>
-              searchByExactTitle(
-                this.prisma,
-                {
-                  query,
-                  locale,
-                  limit: overfetchLimit,
-                },
-                timing,
-              ) as Promise<RankedItem[]>,
+          promise: lexicalBatch.then(
+            (result) => result.exactTitle as RankedItem[],
           ),
         },
       )

--- a/docs/plans/2026-06-25-003-perf-admin-search-semantic-db-retrieval-plan.md
+++ b/docs/plans/2026-06-25-003-perf-admin-search-semantic-db-retrieval-plan.md
@@ -1,0 +1,284 @@
+---
+title: "perf: Optimize Admin semantic DB retrieval"
+type: "perf"
+date: "2026-06-25"
+execution: "code"
+---
+
+# perf: Optimize Admin semantic DB retrieval
+
+## Summary
+
+Reduce the production `semantic-video.query` bottleneck without changing Admin
+search ranking, result IDs, result order, scores, or public card fields. The
+safe first slice is an exact SQL-shape rewrite: choose the best transcript
+evidence per video before joining visibility and display tables, then keep the
+same post-collapse candidate ordering and limit.
+
+---
+
+## Problem Frame
+
+After PR #1370, production timing for `keyword-first` search improved, but the
+dominant service-layer cost remains semantic database retrieval. The newest
+canaries showed median `semantic-video.query`/retrieval wait around 1.7-2.3s
+for `the bible project`, `jesus`, and `hope when life is hard`.
+
+The tempting optimization is an HNSW-first nearest-neighbor window, but that can
+change recall before Admin collapses transcript chunks to one result per video.
+This plan therefore starts with an exact rewrite that preserves current
+best-transcript-evidence-per-video semantics while reducing the number of rows
+that flow through `video`, `video_locale`, image, dub, and embedding-text
+hydration work.
+
+---
+
+## Requirements
+
+- R1. The public search response must preserve result IDs, order, scores,
+  `searchMode`, `hasMore`, `query`, snippets, start seconds, images,
+  playback IDs, labels, durations, and child counts for equivalent DB rows.
+- R2. `semantic-video` must stay one RRF retriever label; do not add a new
+  transcript-specific list or change keyword-first dilution semantics.
+- R3. The SQL rewrite must preserve transcript-only evidence, provenance gates,
+  locale/language gates, published visibility gates, and stable tie-breakers.
+- R4. Any faster query shape must keep the existing `semantic-video.query`
+  timing label so production before/after comparisons remain apples-to-apples.
+- R5. HNSW-first candidate windows are deferred unless implementation proves
+  result parity with a distinct-video guarantee or explicit eval gate.
+- R6. Validation must include focused unit coverage and a production canary
+  timing/result-stability comparison after deploy.
+- R7. Pre-merge validation must include data-level parity coverage for
+  duplicate locale rows, hidden/unpublished visibility, null start seconds,
+  equal-score ties, and bounded hydration fallbacks; SQL shape alone is not
+  enough to prove R1.
+
+---
+
+## Key Technical Decisions
+
+- **Optimize the exact path first:** Keep the current all-transcript best row
+  per video semantics. Rewrite the query so the all-chunk scan no longer joins
+  video visibility and display data for every candidate chunk.
+- **Move visibility after per-video collapse but before candidate limit without
+  multiplying videos:** Visibility is video-level for the selected locale, so
+  filtering after best evidence is selected per video preserves evidence choice.
+  Because broad `video_locale.locale` is not unique per video, the visibility
+  step must use a one-row-per-video shape: gate with `EXISTS` before the
+  candidate window and select a deterministic display locale row only after the
+  window is bounded.
+- **Keep survivor hydration bounded:** Display title, image, dub, and `embedding::text`
+  hydration should stay after the semantic candidate window, not inside the
+  unbounded transcript chunk collapse.
+- **Do not force HNSW with planner knobs in this pass:** `SET LOCAL` or
+  `enable_seqscan=off` can hide planner problems and change connection-wide
+  behavior. If exact SQL remains slow, a later PR should prototype an HNSW-first
+  window with recall proof and production `EXPLAIN`.
+- **Use SQL-shape tests plus data-level parity tests:** Raw SQL structure should
+  assert CTE order, gates, candidate-window tie-breakers, and bounded hydration
+  placement using the existing tagged-template scraping pattern. Data-backed
+  parity tests should cover the result-preservation edges that SQL text cannot
+  prove.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["video_transcript_chunk rows"] --> B["best transcript evidence per video"]
+  B --> C["gate published locale visibility"]
+  C --> D["order by score, start seconds, evidence id"]
+  D --> E["candidate limit"]
+  E --> F["bounded display, image, dub, embedding-text hydration"]
+  F --> G["VideoSemanticResult rows"]
+
+  H["Deferred HNSW-first window"] -. "requires recall/parity proof" .-> B
+```
+
+The exact rewrite keeps the same logical output as the current query. It changes
+where expensive joins happen: from every transcript chunk in the collapse step
+to one best evidence row per video before candidate-window ordering.
+
+---
+
+## Implementation Units
+
+### U1. Add semantic DB SQL-shape characterization
+
+- **Goal:** Lock the current semantic retrieval contract before rewriting SQL.
+- **Requirements:** R1, R2, R3, R4, R7
+- **Dependencies:** none
+- **Files:**
+  - `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+  - `apps/admin/src/services/transcript-embedding-ingest.contract.test.ts`
+- **Approach:** Strengthen SQL-text tests around `searchVideoSemantic` so they
+  fail if transcript evidence, provenance gates, language gates, visibility
+  gates, candidate-limit placement, one-row-per-video candidate shape, or
+  bounded hydration placement changes. Add data-level parity fixtures for
+  duplicate locale variants, hidden/unpublished visibility, null start seconds,
+  equal-score ties, image fallback, and dub playback fallback. Keep row-mapping
+  tests focused on the public `VideoSemanticResult` shape.
+- **Execution note:** Add characterization before touching the retriever query.
+- **Patterns to follow:** `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`.
+- **Test scenarios:**
+  - SQL contains exactly one `semantic-video.query` DB timing path through
+    `searchVideoSemantic`.
+  - SQL reads `video_transcript_chunk` and does not read scene embedding tables
+    or removed Qwen columns.
+  - SQL keeps `vt.language`, `vtc.language`, embedding non-null, approved model,
+    dimensions, provider, native dimensions, and null transform gates.
+  - SQL keeps `v.deleted_at IS NULL`, `vl.status = 'published'`, and
+    `vl.deleted_at IS NULL` before the final semantic candidate limit.
+  - SQL keeps candidate-window tie-breakers by score, start seconds, and
+    evidence id, and existing post-mix public ordering by video id for exact
+    ties remains covered.
+- **Verification:** Focused retriever tests fail for semantic topology drift
+  before any performance rewrite lands.
+
+### U2. Rewrite semantic-video SQL to collapse before visibility/display joins
+
+- **Goal:** Reduce semantic DB retrieval time while preserving exact result
+  semantics.
+- **Requirements:** R1, R2, R3, R4, R7
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search-retrievers.ts`
+  - `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+  - `apps/admin/src/services/transcript-embedding-ingest.contract.test.ts`
+- **Approach:** Restructure `searchVideoSemantic` into separate CTEs: query
+  vector, raw best transcript evidence per video, visible semantic candidates,
+  requested language ids, and final bounded hydration. The visibility CTE joins
+  `video` after best evidence selection and gates published locale availability
+  with `EXISTS` before `ORDER BY ... LIMIT`. The final select then hydrates
+  exactly one deterministic `video_locale` display row for each bounded
+  survivor, along with image, dub, and embedding text.
+- **Technical design:** Directional CTE shape:
+  - `query_embedding`: bind the vector once.
+  - `best_transcript_per_video`: choose one transcript chunk per video by
+    distance, start seconds, and evidence id.
+  - `visible_semantic_candidates`: keep exactly one row per visible video by
+    using `EXISTS` for published requested-locale visibility.
+  - `transcript_source`: order visible candidates by source score and stable
+    candidate-window tie-breakers, then apply `candidateLimit`.
+  - final select: hydrate deterministic display title, image, dub playback, and
+    embedding text for survivors.
+- **Patterns to follow:** `docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`; `docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md`; `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md`.
+- **Test scenarios:**
+  - Mocked rows still map to identical `VideoSemanticResult` fields.
+  - SQL places `JOIN video` and display-locale selection after the best
+    transcript per-video CTE, but proves the locale lookup cannot multiply
+    candidates before the candidate-window limit.
+  - Data-level fixtures with duplicate published `video_locale` rows for one
+    broad locale still emit one `VideoSemanticResult` for that video.
+  - SQL keeps image, dub, and `embedding::text` hydration outside the unbounded
+    best-evidence collapse.
+  - SQL still binds the query vector once through the materialized CTE.
+  - Contract tests that ingest transcript chunks still feed searchable rows into
+    `searchVideoSemantic`.
+- **Verification:** Focused search retriever and transcript-ingest contract
+  tests pass, with no public response-shape changes.
+
+### U3. Add a safe production explain/timing comparison path
+
+- **Goal:** Prove the exact rewrite improved the real production bottleneck and
+  did not destabilize results.
+- **Requirements:** R1, R4, R5, R6
+- **Dependencies:** U2
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+  - `docs/solutions/performance-issues/`
+- **Approach:** After merge and deployment, run the same production canaries:
+  `the bible project`, `jesus`, and `hope when life is hard` through Admin
+  GraphQL `mode=keyword-first`. Compare client timings, service timings,
+  `semantic-video.query` timings, top result signatures, and full response
+  stability. If possible, capture production `EXPLAIN (FORMAT JSON)` for the
+  new SQL shape without `ANALYZE`.
+- **Patterns to follow:** `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`; `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`.
+- **Test scenarios:** Test expectation: none -- this unit is deployment
+  measurement and documentation, not runtime behavior.
+- **Verification:** The final report names old vs new service timing, client
+  timing, `semantic-video.query` timing, and whether every repeated response was
+  stable.
+
+### U4. Decide whether HNSW-first needs a follow-up
+
+- **Goal:** Keep a sharper next step if exact SQL still leaves semantic DB
+  retrieval too slow.
+- **Requirements:** R5, R6
+- **Dependencies:** U3
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+  - `docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`
+- **Approach:** If the exact rewrite materially improves timings, keep
+  HNSW-first deferred. If semantic DB retrieval remains dominant, record a
+  follow-up scope that prototypes an adaptive nearest-neighbor window with a
+  distinct-video floor, duplicate-heavy regression prompts, and Mastra search
+  eval proof before it can ship.
+- **Patterns to follow:** `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md`.
+- **Test scenarios:** Test expectation: none -- this unit is a go/no-go
+  decision based on production measurement.
+- **Verification:** The roadmap ticket either moves closer to completion or
+  names the exact follow-up proof needed for HNSW-first work.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Rewrite `semantic-video.query` for exact candidate semantics.
+- Strengthen raw SQL-shape tests around semantic DB retrieval.
+- Add data-level parity coverage for duplicate locale and tie-breaker edge
+  cases before the rewrite ships.
+- Re-run production timing and result-stability canaries after deploy.
+- Record the HNSW-first follow-up decision in the roadmap and solution notes
+  after production measurement.
+
+### Deferred to Follow-Up Work
+
+- HNSW-first nearest-neighbor windows that can change pre-collapse recall.
+- New pgvector indexes or index-rebuild operations.
+- Ranking, RRF weights, dilution-cap behavior, or public response contract
+  changes.
+- Trace-write repair or offloading.
+
+---
+
+## Risks & Dependencies
+
+- **Equivalence risk:** Moving visibility after evidence selection is safe only
+  because visibility is video/locale-level, not chunk-level. Because broad
+  locale rows can be duplicated per video, tests should keep visibility before
+  candidate limiting and prove the visibility/display step cannot multiply a
+  video into multiple semantic candidates.
+- **Planner uncertainty:** The exact rewrite may reduce join work but still scan
+  and sort transcript chunks. Production timing determines whether this slice is
+  enough.
+- **HNSW temptation:** A nearest-neighbor source window is likely faster but can
+  drop distinct videos when one long video contributes many top chunks.
+- **Production variance:** Compare medians and per-layer timings across repeated
+  runs rather than one request.
+
+---
+
+## Documentation / Operational Notes
+
+- Keep the `feat-175` roadmap ticket in progress until production timings and
+  result-stability checks are recorded.
+- Do not mark HNSW-first complete from this PR; it is a separate relevance and
+  recall proof.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-25-001-perf-admin-search-hydration-semantic-cache-plan.md`
+- `docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`
+- `docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md`
+- `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`
+- `apps/admin/AGENTS.md`
+- `CONCEPTS.md`

--- a/docs/plans/2026-06-25-004-perf-admin-search-pool-fanout-plan.md
+++ b/docs/plans/2026-06-25-004-perf-admin-search-pool-fanout-plan.md
@@ -1,0 +1,155 @@
+---
+title: "perf: Tune Admin search pool and lexical fan-out"
+type: "perf"
+date: "2026-06-25"
+execution: "code"
+---
+
+# perf: Tune Admin search pool and lexical fan-out
+
+## Summary
+
+Run a production pool-size experiment for Admin search, keep the pool setting
+only if it improves representative canaries without changing results, then
+reduce keyword-first video lexical DB connection fan-out while preserving the
+same retriever lists and ranking inputs.
+
+---
+
+## Problem Frame
+
+Production search timings still show multi-second `keyword-first` responses
+even after the semantic DB retrieval safe slice. A production-shaped
+`EXPLAIN ANALYZE` for the current semantic-video SQL executed in tens of
+milliseconds, while app-observed DB timings remain in repeated hundreds-of-ms
+bands. That points at connection acquisition, Prisma/Railway runtime overhead,
+and fan-out pressure as the next safest optimization target.
+
+The roadmap ticket keeps HNSW-first semantic retrieval deferred until parity is
+proven. This plan therefore works on result-preserving operational and query
+orchestration changes first.
+
+---
+
+## Requirements
+
+- R1. Production pool changes must not alter search SQL, rankings, result IDs,
+  result order, snippets, images, playback IDs, `searchMode`, or `hasMore`.
+- R2. The pool-size experiment must compare the same representative queries:
+  `the bible project`, `jesus`, and `hope when life is hard`.
+- R3. The code change must keep `semantic-video`, `keyword-weighted-video`,
+  `trigram-video`, and `exact-title-video` as separate RRF lists.
+- R4. Keyword-first lexical video retrieval must reduce DB connection fan-out
+  without changing the existing lexical SQL predicates, limits, or row mapping.
+- R5. Validation must compare speed and result signatures before and after the
+  production change.
+- R6. HNSW-first remains out of scope for this PR.
+
+---
+
+## Key Technical Decisions
+
+- **Start with an env-only pool experiment:** Admin Railway dashboard env is
+  authoritative, and `apps/admin/railway.toml` is documented as dead config.
+  Tune `DATABASE_URL` in production first so the lowest-risk change is measured
+  before code changes.
+- **Use the existing documented pool target first:** Start with
+  `connection_limit=10&pool_timeout=20`, matching the comment in
+  `apps/admin/src/db/client.ts`, while watching for DB connection pressure.
+- **Batch lexical video reads through one connection:** Keep the three existing
+  keyword-first SQL functions, but run them inside one transaction-scoped helper
+  from the orchestrator. This reduces pool fan-out more safely than rewriting
+  all three SQL shapes into one new UNION query.
+- **Preserve RRF inputs:** The service still exposes three labeled lexical
+  lists to fusion and debug attribution; only their DB connection scheduling
+  changes.
+
+---
+
+## Implementation Units
+
+### U1. Run and retain the production pool experiment
+
+- **Goal:** Prove whether production pool settings reduce search latency before
+  code changes.
+- **Requirements:** R1, R2, R5
+- **Dependencies:** none
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+  - `docs/solutions/performance-issues/`
+- **Approach:** Capture baseline result signatures and timings, update the
+  production Admin `DATABASE_URL` pool query parameters in Railway, wait for
+  deployment/restart, then rerun the same canaries. Keep the env change only if
+  timings improve and result signatures remain stable.
+- **Patterns to follow:** `apps/admin/CLAUDE.md`; `docs/solutions/platform/railway-mcp-staged-config-never-commits-20260420.md`.
+- **Test scenarios:** Test expectation: none -- this unit is an operational
+  experiment whose proof is production timing/result comparison.
+- **Verification:** Report before/after service timing, client timing,
+  `semantic-video.query` timing, DB timing fields, and top result signatures.
+
+### U2. Batch keyword-first video lexical DB fan-out
+
+- **Goal:** Reduce keyword-first video lexical connection pressure while
+  preserving exact retriever outputs.
+- **Requirements:** R3, R4
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts`
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search-keyword-first-retrievers.test.ts`
+  - `apps/admin/src/services/hybrid-search.keyword-first.test.ts`
+  - `apps/admin/src/services/hybrid-search.bible-project.test.ts`
+  - `apps/admin/src/services/hybrid-search.debug.test.ts`
+  - `apps/admin/src/services/hybrid-search.dilution-cap.test.ts`
+  - `apps/admin/src/services/hybrid-search.regression.test.ts`
+- **Approach:** Add a `searchKeywordFirstVideoLexical` helper that runs
+  `searchByKeywordWeighted`, `searchByTrigram`, and `searchByExactTitle` inside
+  one Prisma transaction. Update `HybridSearchService` to start that helper
+  before embedding resolves, then split the returned lists back into the
+  existing RRF labels.
+- **Patterns to follow:** Existing keyword-first retriever tests and
+  `SearchTimingRecorder` DB timing labels.
+- **Test scenarios:**
+  - The batch helper returns the same three arrays produced by the individual
+    retrievers.
+  - The batch helper uses one Prisma transaction and preserves the individual
+    DB timing labels from the existing functions.
+  - Keyword-first still starts lexical work while query embedding is pending.
+  - Keyword-first still does not dispatch the legacy hybrid keyword retriever.
+  - Bible Project and dilution-cap orchestrator fixtures keep the same ranked
+    result behavior.
+- **Verification:** Focused Admin search tests pass.
+
+### U3. Merge, deploy, and compare production speed/results
+
+- **Goal:** Validate that the retained pool setting plus code change improves
+  real production latency without result regression.
+- **Requirements:** R1, R2, R5
+- **Dependencies:** U2
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+  - `docs/solutions/performance-issues/`
+- **Approach:** Merge the PR to `main`, let production deploy, then rerun the
+  same canaries. Compare new timing distributions against the pre-pool and
+  post-pool/pre-code snapshots, and compare top result IDs and displayed fields.
+- **Patterns to follow:** Existing production search timing probes and
+  `event=search_timing` log parsing.
+- **Test scenarios:** Test expectation: none -- this unit is deployment
+  measurement and reporting.
+- **Verification:** Final report includes whether results stayed the same and
+  whether service/client timings improved enough to proceed or rethink.
+
+## Scope Boundaries
+
+- HNSW-first semantic retrieval is deferred to a separate gated prototype.
+- This work does not change public Web search UI behavior.
+- This work does not change ranking weights, RRF constants, overfetch limits,
+  or semantic evidence selection.
+
+## Sources / Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-25-003-perf-admin-search-semantic-db-retrieval-plan.md`
+- `apps/admin/src/db/client.ts`
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/services/hybrid-search-keyword-first-retrievers.ts`

--- a/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
+++ b/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
@@ -33,7 +33,10 @@ Railway HTTP logs showed Web `POST /watch` search-action requests near the
 historical 15 second Admin caller budget. The current safe slice keeps Admin's
 existing transcript best-evidence-per-video semantics, but removes expensive
 image/dub hydration and `embedding::text` projection from the unbounded
-candidate-collapse work.
+candidate-collapse work. The semantic DB retrieval follow-up also keeps
+published-locale visibility before the candidate limit while moving display
+locale selection after the limit, because broad `video_locale.locale` is not a
+unique row identity.
 
 An HNSW-first raw nearest-neighbor window remains a possible follow-up
 performance lever only if the safe slice and instrumentation show the semantic
@@ -45,6 +48,9 @@ diversity while losing recall, and degrade semantic relevance.
 
 - [x] Move image lookup, dub playback lookup, and `embedding::text` hydration
       after transcript candidates are narrowed.
+- [x] Gate published requested-locale visibility with a one-row-per-video
+      `EXISTS` check before the semantic candidate limit, then hydrate one
+      deterministic display locale row only after the limit.
 - [x] Preserve the existing per-source best-evidence-per-video semantics for
       the default path.
 - [x] Keep the existing `semantic-video` retriever label and public search

--- a/docs/solutions/performance-issues/admin-semantic-db-retrieval-visible-candidate-window.md
+++ b/docs/solutions/performance-issues/admin-semantic-db-retrieval-visible-candidate-window.md
@@ -1,0 +1,157 @@
+---
+title: "Admin semantic DB retrieval visible candidate window"
+date: "2026-06-25"
+category: "performance-issues"
+module: "apps/admin"
+problem_type: "performance_issue"
+component: "database"
+symptoms:
+  - "Production keyword-first search still spends seconds inside semantic-video.query"
+  - "Joining video_locale during transcript collapse can multiply candidates because locale is not unique per video"
+  - "Moving semantic candidate limits earlier risks changing recall and result quality"
+root_cause: "wrong_api"
+resolution_type: "code_fix"
+severity: "high"
+tags:
+  - "admin-search"
+  - "semantic-video"
+  - "pgvector"
+  - "video-locale"
+  - "transcripts"
+  - "result-parity"
+  - "raw-sql"
+---
+
+# Admin Semantic DB Retrieval Visible Candidate Window
+
+## Problem
+
+Admin search timing showed `semantic-video.query` remained a dominant
+production cost after the earlier embedding-cache and hydration optimizations.
+The next safe optimization had to reduce unbounded SQL work without changing
+semantic ranking, result IDs, result order, scores, or display fields.
+
+## Symptoms
+
+- Keyword-first search can still spend several seconds in the semantic video DB
+  retrieval path.
+- `video_locale.locale` is not a unique display identity, so joining
+  `video_locale` before candidate limiting can multiply rows for one video.
+- A naive HNSW-first row window could return many chunks from one long video and
+  reduce distinct-video recall before the per-video collapse.
+
+## What Didn't Work
+
+- **Joining display locale rows inside the unbounded transcript collapse.** That
+  gives every transcript chunk the full display join cost and can duplicate a
+  candidate when more than one published row shares the requested locale.
+- **Moving display selection before the candidate limit with `JOIN LATERAL`.**
+  It is deterministic, but still pays the display lookup for every visible
+  semantic candidate instead of only bounded survivors.
+- **Using an HNSW-first nearest-neighbor window as the first fix.** It may be
+  faster, but it changes which chunks can compete before `DISTINCT ON
+(video_id)`, so it needs separate recall and diversity proof.
+
+## Solution
+
+Keep the exact transcript best-evidence semantics, but split visibility,
+candidate limiting, and display hydration into separate SQL stages:
+
+```sql
+WITH query_embedding AS MATERIALIZED (...),
+best_transcript_per_video AS (
+  SELECT DISTINCT ON (vt.video_id) ...
+  FROM video_transcript_chunk vtc
+  JOIN video_transcript vt ON vt.id = vtc.transcript_id
+  WHERE vtc.embedding IS NOT NULL
+  ORDER BY vt.video_id, vtc.embedding <=> qe.embedding, vtc.start_seconds, vtc.id
+),
+visible_semantic_candidates AS (
+  SELECT b.*, v.core_id, v.slug
+  FROM best_transcript_per_video b
+  JOIN video v ON v.id = b.video_id AND v.deleted_at IS NULL
+  WHERE EXISTS (
+    SELECT 1
+    FROM video_locale vl_visible
+    WHERE vl_visible.video_id = v.id
+      AND vl_visible.locale = $locale
+      AND vl_visible.status = 'published'
+      AND vl_visible.deleted_at IS NULL
+  )
+),
+transcript_source AS (
+  SELECT *
+  FROM visible_semantic_candidates
+  ORDER BY source_score DESC, start_seconds ASC NULLS LAST, evidence_id ASC
+  LIMIT $candidate_limit
+)
+SELECT ...
+FROM transcript_source ts
+JOIN LATERAL (
+  SELECT vl_display.title
+  FROM video_locale vl_display
+  WHERE vl_display.video_id = ts.video_id
+    AND vl_display.locale = $locale
+    AND vl_display.status = 'published'
+    AND vl_display.deleted_at IS NULL
+  ORDER BY
+    vl_display.language_core_id ASC NULLS LAST,
+    vl_display.language_slug ASC NULLS LAST,
+    vl_display.id ASC
+  LIMIT 1
+) display_locale ON true
+```
+
+The load-bearing details are:
+
+- `best_transcript_per_video` reads transcript tables only and has no candidate
+  limit. This preserves the current "best chunk per video across the full
+  transcript corpus" behavior.
+- `visible_semantic_candidates` joins `video` after the collapse and uses
+  `EXISTS` for published requested-locale visibility. That keeps one row per
+  visible video before `transcript_source` applies the candidate limit.
+- The final select hydrates deterministic display title, image, dub playback,
+  and `embedding::text` only for bounded survivors.
+- The DB timing label remains `semantic-video.query`, so production before/after
+  timing logs stay comparable.
+
+## Why This Works
+
+The query still chooses the same best transcript evidence per video before the
+semantic candidate window is bounded. Visibility remains before the limit, so a
+hidden or unpublished video cannot take a candidate slot. Display title
+selection moves after the limit, where it cannot multiply candidates or expand
+the unbounded vector-distance work.
+
+The `EXISTS` gate is the important shape. It answers "is this video visible in
+the requested locale?" without selecting a display row. The later
+`JOIN LATERAL` answers "which display title should this already-selected
+survivor show?" with a deterministic tie-breaker.
+
+## Prevention
+
+- Treat visibility and display selection as separate operations in semantic
+  search SQL. Visibility can gate candidate eligibility; display metadata should
+  hydrate bounded survivors.
+- Do not join non-unique locale/display tables before a candidate limit unless
+  the SQL proves one row per candidate.
+- Keep raw SQL invariant tests around CTE order, absence of `LIMIT` before the
+  best-evidence collapse, `EXISTS`-based visibility, and deterministic display
+  ordering.
+- Pair SQL-shape tests with production canary result signatures. The always-on
+  unit tests can prove the query topology, but this repo does not yet have an
+  always-on pgvector fixture that proves data-level parity across production
+  edge cases.
+- Keep HNSW-first transcript windows as a separate PR that must prove distinct
+  video recall and result quality before it ships.
+
+## Related Issues
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-25-003-perf-admin-search-semantic-db-retrieval-plan.md`
+- `docs/solutions/performance-issues/admin-search-result-preserving-latency-optimization.md`
+- `docs/solutions/performance-issues/admin-search-stage-db-timing-instrumentation-20260624.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `docs/solutions/platform/admin-mixed-video-semantic-evidence-pattern-20260521.md`
+- `docs/solutions/best-practices/prisma-raw-sql-invariant-assertions-20260423.md`
+- `docs/solutions/database-issues/stable-admin-search-dub-hydration-ordering.md`


### PR DESCRIPTION
## Summary
- keep the production Admin pool experiment at `connection_limit=10&pool_timeout=20` after warm canaries improved median service time without top-result ID changes
- batch the three keyword-first video lexical retrievers through one Prisma transaction-bound connection
- preserve the three logical RRF/debug labels: `keyword-weighted-video`, `trigram-video`, and `exact-title-video`
- add an explicit 20s transaction timeout so slow production lexical reads do not hit Prisma's default interactive transaction timeout

## Timing evidence before code change
Warm prod canaries after pool setting, compared to pre-pool baseline:

| Query | Service median | Client median | Top result IDs |
|---|---:|---:|---|
| the bible project | 3431.3 -> 1995.5 ms (-41.8%) | 3914.0 -> 2491.8 ms (-36.3%) | same |
| jesus | 2455.3 -> 2006.2 ms (-18.3%) | 2987.8 -> 2487.3 ms (-16.8%) | same |
| hope when life is hard | 2314.9 -> 1363.1 ms (-41.1%) | 2801.0 -> 1855.0 ms (-33.8%) | same |

## Verification
- `pnpm --filter @forge/admin test -- hybrid-search-keyword-first-retrievers.test.ts hybrid-search.keyword-first.test.ts hybrid-search.debug.test.ts hybrid-search.bible-project.test.ts hybrid-search.dilution-cap.test.ts hybrid-search.regression.test.ts`
- `pnpm --filter @forge/admin typecheck`
- `pnpm --filter @forge/admin lint`

Plan: docs/plans/2026-06-25-004-perf-admin-search-pool-fanout-plan.md
Review artifact: /tmp/compound-engineering/ce-code-review/20260625-235643-6078fc52/report.md
