### PR TITLE
fix(admin): normalize Datadog environment tags

### DIFF
--- a/apps/admin/src/config/datadog-env.test.ts
+++ b/apps/admin/src/config/datadog-env.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeDatadogEnv } from "./datadog-env"
+
+describe("normalizeDatadogEnv", () => {
+  it("normalizes common production aliases to the org's Datadog environment name", () => {
+    expect(normalizeDatadogEnv("prod")).toBe("prod")
+    expect(normalizeDatadogEnv("production")).toBe("prod")
+    expect(normalizeDatadogEnv("PRODUCTION")).toBe("prod")
+  })
+
+  it("normalizes other common environment aliases", () => {
+    expect(normalizeDatadogEnv("stage")).toBe("stage")
+    expect(normalizeDatadogEnv("dev")).toBe("development")
+    expect(normalizeDatadogEnv("test")).toBe("test")
+    expect(normalizeDatadogEnv("preview")).toBe("preview")
+  })
+
+  it("preserves unknown lowercase environment names", () => {
+    expect(normalizeDatadogEnv("Sandbox")).toBe("sandbox")
+    expect(normalizeDatadogEnv("")).toBeUndefined()
+    expect(normalizeDatadogEnv(undefined)).toBeUndefined()
+  })
+})

--- a/apps/admin/src/config/datadog-env.ts
+++ b/apps/admin/src/config/datadog-env.ts
@@ -1,0 +1,29 @@
+function emptyToUndefined(value: string | undefined): string | undefined {
+  return value === "" ? undefined : value
+}
+
+export function normalizeDatadogEnv(
+  value: string | undefined,
+): string | undefined {
+  const normalized = emptyToUndefined(value)?.toLowerCase()
+
+  switch (normalized) {
+    case undefined:
+      return undefined
+    case "production":
+    case "prod":
+      return "prod"
+    case "staging":
+    case "stage":
+      return "stage"
+    case "preview":
+      return "preview"
+    case "development":
+    case "dev":
+      return "development"
+    case "test":
+      return "test"
+    default:
+      return normalized
+  }
+}

--- a/apps/admin/src/config/datadog-rum-env.ts
+++ b/apps/admin/src/config/datadog-rum-env.ts
@@ -1,3 +1,5 @@
+import { normalizeDatadogEnv } from "./datadog-env"
+
 const DATADOG_SITE_VALUES = [
   "datadoghq.com",
   "us3.datadoghq.com",
@@ -12,30 +14,6 @@ type DatadogSite = (typeof DATADOG_SITE_VALUES)[number]
 
 function emptyToUndefined(value: string | undefined): string | undefined {
   return value === "" ? undefined : value
-}
-
-function normalizeDatadogEnv(value: string | undefined): string {
-  const normalized = emptyToUndefined(value)?.toLowerCase()
-
-  switch (normalized) {
-    case "production":
-    case "prod":
-      return "prod"
-    case "staging":
-    case "stage":
-      return "stage"
-    case "preview":
-      return "preview"
-    case "development":
-    case "dev":
-      return "development"
-    case "test":
-      return "test"
-    case undefined:
-      return "development"
-    default:
-      return normalized
-  }
 }
 
 function normalizeDatadogSite(value: string | undefined): DatadogSite {
@@ -56,9 +34,10 @@ export const datadogRumEnv = {
   NEXT_PUBLIC_DATADOG_SITE: normalizeDatadogSite(
     process.env.NEXT_PUBLIC_DATADOG_SITE,
   ),
-  NEXT_PUBLIC_DATADOG_ENV: normalizeDatadogEnv(
-    process.env.NEXT_PUBLIC_DATADOG_ENV ?? process.env.NODE_ENV,
-  ),
+  NEXT_PUBLIC_DATADOG_ENV:
+    normalizeDatadogEnv(
+      process.env.NEXT_PUBLIC_DATADOG_ENV ?? process.env.NODE_ENV,
+    ) ?? "development",
   NEXT_PUBLIC_DATADOG_VERSION: emptyToUndefined(
     process.env.NEXT_PUBLIC_DATADOG_VERSION,
   ),

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -1,6 +1,8 @@
 import { createEnv } from "@t3-oss/env-nextjs"
 import { z } from "zod"
 
+import { normalizeDatadogEnv } from "./datadog-env"
+
 // Doppler sends empty strings for unconfigured vars. Zod's `.optional()`
 // only matches `undefined`, so `""` fails `.min(1)`. Coerce empties to
 // `undefined` before validation.
@@ -19,33 +21,19 @@ const DATADOG_SITE_VALUES = [
   "ap2.datadoghq.com",
 ] as const
 
-function normalizeDatadogEnv(value: string | undefined): string | undefined {
-  const normalized = emptyToUndefined(value)?.toLowerCase()
-
-  switch (normalized) {
-    case undefined:
-      return undefined
-    case "production":
-    case "prod":
-      return "prod"
-    case "staging":
-    case "stage":
-      return "stage"
-    case "preview":
-      return "preview"
-    case "development":
-    case "dev":
-      return "development"
-    case "test":
-      return "test"
-    default:
-      return normalized
-  }
-}
-
-function datadogEnvFallback(): string | undefined {
+function datadogPublicEnvFallback(): string | undefined {
   return normalizeDatadogEnv(
     process.env.NEXT_PUBLIC_DATADOG_ENV ??
+      process.env.RAILWAY_ENVIRONMENT_NAME ??
+      process.env.VERCEL_ENV ??
+      process.env.NODE_ENV,
+  )
+}
+
+function datadogServerEnvFallback(): string | undefined {
+  return normalizeDatadogEnv(
+    process.env.DD_ENV ??
+      process.env.NEXT_PUBLIC_DATADOG_ENV ??
       process.env.RAILWAY_ENVIRONMENT_NAME ??
       process.env.VERCEL_ENV ??
       process.env.NODE_ENV,
@@ -509,11 +497,11 @@ export const env = createEnv({
     NEXT_PUBLIC_DATADOG_SITE: emptyToUndefined(
       process.env.NEXT_PUBLIC_DATADOG_SITE,
     ),
-    NEXT_PUBLIC_DATADOG_ENV: datadogEnvFallback(),
+    NEXT_PUBLIC_DATADOG_ENV: datadogPublicEnvFallback(),
     NEXT_PUBLIC_DATADOG_VERSION: datadogVersionFallback(),
     DD_AGENT_HOST: emptyToUndefined(process.env.DD_AGENT_HOST),
     DD_AGENT_SYSLOG_PORT: emptyToUndefined(process.env.DD_AGENT_SYSLOG_PORT),
-    DD_ENV: datadogEnvFallback(),
+    DD_ENV: datadogServerEnvFallback(),
     DD_SERVICE: emptyToUndefined(process.env.DD_SERVICE),
     DD_VERSION: datadogVersionFallback(),
     DATABASE_URL_SYNC: emptyToUndefined(process.env.DATABASE_URL_SYNC),

--- a/docs/roadmap/platform/feat-210-admin-datadog-log-forwarding.md
+++ b/docs/roadmap/platform/feat-210-admin-datadog-log-forwarding.md
@@ -32,10 +32,13 @@ networking.
 - Enabled Agent log collection and syslog UDP exposure in the Agent Dockerfile.
 - Added Admin server console forwarding to the Agent over UDP syslog.
 - Included Datadog service/env/version tags and active trace/span ids.
+- Normalized Datadog env aliases so logs, APM, and RUM use the org-standard `prod`.
 - Documented `DD_AGENT_SYSLOG_PORT=514` and Agent log variables.
 
 ## Verification
 
 - `pnpm --filter @forge/admin test -- src/observability/datadog.test.ts src/observability/datadog-logs.test.ts`
+- `pnpm --filter @forge/admin test -- src/config/datadog-env.test.ts src/observability/datadog-logs.test.ts src/components/__tests__/DatadogRum.test.tsx`
 - `pnpm --filter @forge/admin lint -- src/observability/datadog.ts src/observability/datadog.test.ts src/observability/datadog-logs.ts src/observability/datadog-logs.test.ts src/config/env.ts`
+- `pnpm --filter @forge/admin lint -- src/config/datadog-env.ts src/config/datadog-env.test.ts src/config/env.ts src/config/datadog-rum-env.ts src/observability/datadog-logs.ts src/observability/datadog-logs.test.ts src/components/DatadogRum.tsx src/components/__tests__/DatadogRum.test.tsx`
 - `git diff --check`


### PR DESCRIPTION
Admin Datadog telemetry now lands in the same environment buckets as the rest of the org. `production` and `prod` normalize to `prod`, `staging` and `stage` normalize to `stage`, and server-side `DD_ENV` is respected before falling back to public or platform-derived values.

The shared normalizer is used by both Admin backend env parsing and RUM env parsing, so logs, APM, and browser RUM do not drift into separate Datadog env facets.

## Verification

- `pnpm --filter @forge/admin test -- src/config/datadog-env.test.ts src/observability/datadog-logs.test.ts src/components/__tests__/DatadogRum.test.tsx`
- `pnpm --filter @forge/admin lint -- src/config/datadog-env.ts src/config/datadog-env.test.ts src/config/env.ts src/config/datadog-rum-env.ts src/observability/datadog-logs.ts src/observability/datadog-logs.test.ts src/components/DatadogRum.tsx src/components/__tests__/DatadogRum.test.tsx`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)