### PR TITLE
fix(admin): facet Datadog forwarded logs by env

### DIFF
--- a/apps/admin/src/observability/datadog-logs.test.ts
+++ b/apps/admin/src/observability/datadog-logs.test.ts
@@ -93,6 +93,7 @@ describe("buildDatadogSyslogMessage", () => {
     )
     expect(message).toContain('"message":"request failed"')
     expect(message).toContain('"status":"error"')
+    expect(message).toContain('"env":"prod"')
     expect(message).toContain('"service":"forge-admin"')
     expect(message).toContain(
       '"ddtags":"env:prod,service:forge-admin,version:abc123"',

--- a/apps/admin/src/observability/datadog-logs.ts
+++ b/apps/admin/src/observability/datadog-logs.ts
@@ -95,6 +95,7 @@ export function buildDatadogSyslogMessage(input: SyslogPayloadInput): string {
   const payload = {
     ddsource: "nodejs",
     ddtags: tags.join(","),
+    env: input.environment,
     message: input.message,
     service: input.service,
     status,


### PR DESCRIPTION
Forwarded Admin logs now include an explicit JSON `env` field alongside `ddtags`, so Datadog can facet and filter them with the same `env:prod` query syntax used by APM.

This closes the gap found during production verification: APM spans were correctly tagged `env:prod`, while syslog-forwarded logs only carried `env:prod` inside `custom.ddtags`.

## Verification

- `pnpm --filter @forge/admin test -- src/observability/datadog-logs.test.ts`
- `pnpm --filter @forge/admin lint -- src/observability/datadog-logs.ts src/observability/datadog-logs.test.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)