### PR TITLE
fix(admin): batch video relation lookups

### DIFF
--- a/apps/admin/src/graphql/types/video.ts
+++ b/apps/admin/src/graphql/types/video.ts
@@ -399,8 +399,18 @@ builder.prismaObject("VideoRelation", {
   fields: (t) => ({
     id: t.exposeID("id"),
     order: t.exposeInt("order", { nullable: true }),
-    parent: t.relation("parent"),
-    child: t.relation("child"),
+    parent: t.prismaField({
+      type: "Video",
+      nullable: true,
+      resolve: (_query, relation, _args, ctx) =>
+        ctx.loaders.videoById.load(relation.parentId),
+    }),
+    child: t.prismaField({
+      type: "Video",
+      nullable: true,
+      resolve: (_query, relation, _args, ctx) =>
+        ctx.loaders.videoById.load(relation.childId),
+    }),
   }),
 })
 

--- a/docs/roadmap/platform/feat-211-watch-video-relation-loader-performance.md
+++ b/docs/roadmap/platform/feat-211-watch-video-relation-loader-performance.md
@@ -1,0 +1,57 @@
+---
+id: "feat-211"
+title: "Watch video relation loader performance"
+owner: "vlad"
+priority: "P1"
+status: "in-progress"
+start_date: "2026-06-26"
+duration: 1
+depends_on:
+  - "feat-203"
+blocks: []
+tags:
+  - "platform"
+  - "admin"
+  - "web"
+  - "watch-page"
+  - "performance"
+  - "graphql"
+---
+
+## Problem
+
+Production probes of the Watch single-video GraphQL snapshot still show
+server-side latency around 8-11 seconds after the selected-dub projection
+reduced payload size. Datadog traces show the remaining hot path includes many
+`Video.findUniqueOrThrow` spans while resolving `VideoRelation.parent` and
+`VideoRelation.child` for parent/sibling traversal.
+
+## What To Build
+
+- Resolve `VideoRelation.parent` and `VideoRelation.child` through the existing
+  request-scoped `videoById` DataLoader instead of Pothos relation resolvers.
+- Preserve the existing Admin GraphQL schema shape.
+- Re-run the production watch snapshot probe after deploy to compare against
+  the 2026-06-26 baseline.
+
+## Baseline
+
+Controlled production probe on `2026-06-26`:
+
+- `life-of-jesus-gospel-of-john`, selected-dub projection:
+  median `10277.0ms`, mean `9985.2ms`, p95 `11204.4ms`, `174.5 KiB`.
+- `jesus`, selected-dub projection:
+  median `9155.9ms`, mean `9422.0ms`, p95 `11151.7ms`, `264.2 KiB`.
+
+Datadog trace `6a3df257000000007b3a2f866cecc214` showed repeated
+`Video.findUniqueOrThrow` spans of roughly `1.6s` each during the current
+selected-dub `jesus` request.
+
+## Verification
+
+- Focused Admin GraphQL tests pass.
+- `pnpm --filter @forge/admin schema:print` produces no SDL drift.
+- Admin typecheck/lint pass for the touched scope.
+- After deployment, re-run
+  `pnpm --filter @forge/web probe:watch-video-snapshot --slug jesus --language-slug english --locale en --runs 3 --warmup 0`
+  and inspect Datadog for reduced `Video.findUniqueOrThrow` fanout.


### PR DESCRIPTION
## Summary
- Route `VideoRelation.parent` and `VideoRelation.child` through the existing request-scoped `videoById` DataLoader.
- Preserve the Admin GraphQL SDL while reducing repeated Pothos `Video.findUniqueOrThrow` relation fetches on Watch snapshots.
- Add feat-211 with the Datadog/probe baseline and post-deploy verification plan.

## Baseline
- `life-of-jesus-gospel-of-john` selected-dub projection: median 10277.0ms, mean 9985.2ms, p95 11204.4ms, 174.5 KiB.
- `jesus` selected-dub projection: median 9155.9ms, mean 9422.0ms, p95 11151.7ms, 264.2 KiB.
- Datadog trace `6a3df257000000007b3a2f866cecc214` showed repeated `Video.findUniqueOrThrow` spans around 1.6s while resolving the current selected-dub `jesus` request.

## Verification
- `pnpm --filter @forge/admin test -- src/graphql/loaders.test.ts src/graphql/classification.test.ts src/graphql/public-resolvers.regression.test.ts`
- `pnpm --filter @forge/admin schema:print` (no SDL diff)
- `pnpm --filter @forge/admin lint`

## Note
- Full `pnpm --filter @forge/admin typecheck` still fails on pre-existing unrelated `experience-ai` implicit-any / missing `zod` errors; no remaining errors in `src/graphql/types/video.ts`.
