### PR TITLE
fix(admin): add watch video query indexes

### DIFF
--- a/apps/admin/prisma/migrations/0035_watch_video_query_indexes/migration.sql
+++ b/apps/admin/prisma/migrations/0035_watch_video_query_indexes/migration.sql
@@ -1,0 +1,50 @@
+-- Watch single-video GraphQL queries are latency-sensitive and repeatedly
+-- resolve the same small set of public child relations. These partial indexes
+-- cover the production query shapes observed in Datadog APM for
+-- videoBySlug/watch route snapshots.
+
+CREATE INDEX IF NOT EXISTS "video_dub_watch_playable_duration_idx"
+  ON "video_dub"("video_id", "duration" DESC, "id" ASC)
+  WHERE "deleted_at" IS NULL
+    AND "published" = true
+    AND "hls" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "video_dub_watch_playable_language_idx"
+  ON "video_dub"("video_id", "language_id", "duration" DESC, "id" ASC)
+  WHERE "deleted_at" IS NULL
+    AND "published" = true
+    AND "hls" IS NOT NULL
+    AND "language_id" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "video_dub_watch_playable_mux_idx"
+  ON "video_dub"("video_id", "mux_video_id", "duration" DESC, "id" ASC)
+  WHERE "deleted_at" IS NULL
+    AND "published" = true
+    AND "hls" IS NOT NULL
+    AND "mux_video_id" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "video_locale_watch_lookup_idx"
+  ON "video_locale"("video_id", "locale", "status", "language_slug", "id")
+  WHERE "deleted_at" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "video_locale_watch_visibility_idx"
+  ON "video_locale"("video_id", "status")
+  WHERE "deleted_at" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "video_relation_watch_children_order_idx"
+  ON "video_relation"("parent_id", "order" ASC NULLS LAST, "created_at" ASC, "id" ASC);
+
+CREATE INDEX IF NOT EXISTS "video_relation_watch_parents_order_idx"
+  ON "video_relation"("child_id", "order" ASC NULLS LAST, "created_at" ASC, "id" ASC);
+
+CREATE INDEX IF NOT EXISTS "video_image_watch_video_active_idx"
+  ON "video_image"("video_id")
+  WHERE "deleted_at" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "video_study_question_watch_lookup_idx"
+  ON "video_study_question"("video_id", "locale", "order" ASC, "language_slug" ASC, "id" ASC)
+  WHERE "deleted_at" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "bible_citation_watch_video_active_idx"
+  ON "bible_citation"("video_id", "order" ASC, "id" ASC)
+  WHERE "deleted_at" IS NULL;

--- a/docs/roadmap/platform/feat-212-watch-video-db-index-performance.md
+++ b/docs/roadmap/platform/feat-212-watch-video-db-index-performance.md
@@ -1,0 +1,50 @@
+---
+id: feat-212
+title: Clamp Watch single-video GraphQL DB latency with targeted indexes
+status: in-progress
+lane: platform
+depends_on:
+  - feat-211
+blocks: []
+---
+
+## Problem
+
+The Watch single-video route still spends an internet-eternity amount of time
+inside Admin GraphQL. After `feat-211`, the selected-dub projection reduced
+payload size and improved median latency, but production APM still showed
+`/api/graphql` watch probes at roughly p50 9.28s, p95 14.12s, and p99 15.60s
+over the sampled 24h window on 2026-06-26.
+
+Datadog traces for `videoBySlug` showed the remaining cost concentrated in
+Prisma/Postgres work:
+
+- `VideoDub.findMany` / playable-duration fallback SQL reached ~6.45s in the
+  slowest sampled trace.
+- `Video.findFirst` for `videoBySlug` stayed open for ~8.94s while nested
+  relation work completed.
+- Repeated watch relation lookups touched `video_locale`, `video_relation`,
+  `video_image`, `video_study_question`, and `bible_citation` with predicates
+  that existing simple indexes only partially covered.
+
+## Scope
+
+- Add raw Postgres indexes in `apps/admin/prisma/migrations/`.
+- Prefer partial indexes for public Watch query predicates that always require
+  non-deleted/playable rows.
+- Use regular `CREATE INDEX IF NOT EXISTS` rather than `CONCURRENTLY` because
+  Admin deploys through Prisma migrate in a transaction.
+- Do not change the GraphQL schema or web route contract in this step.
+- Re-measure the same production probe after deploy.
+
+## Verification
+
+1. Apply the migration in production through the normal Admin deploy path.
+2. Re-run `apps/web/scripts/probe-watch-video-snapshot.ts` against
+   `https://admin.jesusfilm.org/api/graphql` for `videoSlug=jesus`,
+   `languageSlug=english`, `locale=en`, selected-dub projection.
+3. Compare Datadog APM for `service:forge-admin env:prod
+@http.path_group:/api/graphql` and `forge-admin-prisma` spans before/after.
+4. If p50 remains above 2s, follow with a purpose-built Watch snapshot resolver
+   to collapse the remaining relation fanout instead of relying on nested
+   Pothos relation resolution.


### PR DESCRIPTION
## Summary
- add targeted partial/composite Postgres indexes for Watch single-video GraphQL query shapes seen in Datadog
- document feat-212 with current production APM baseline and post-deploy verification steps

## Verification
- pnpm --filter @forge/admin exec prisma validate
- pnpm --filter @forge/admin test -- src/graphql/schema.test.ts src/graphql/public-resolvers.regression.test.ts