### PR TITLE
fix(tv): remove the Download pill from the watch detail action row

### DIFF
--- a/apps/tv/src/components/watch/DetailsActionRow.tsx
+++ b/apps/tv/src/components/watch/DetailsActionRow.tsx
@@ -1,6 +1,6 @@
 // Video-details inline pills row (Claude Design handoff): [Play] [Language] [Subtitles]
-// [Share] [Download] left-aligned under the title; WATCH_THEME, a TVFocusGuideView (autoFocus).
-// Focus R7: Play gets one-shot hasTVPreferredFocus + re-arms as restore target on overlay dismiss. R5: Play validates hls (validateStreamingUrl) then playVideo; Share/Download R18/R19 open the QR LinkModal.
+// [Share] left-aligned under the title; WATCH_THEME, a TVFocusGuideView (autoFocus).
+// Focus R7: Play gets one-shot hasTVPreferredFocus + re-arms as restore target on overlay dismiss. R5: Play validates hls (validateStreamingUrl) then playVideo; Share R18 opens the QR LinkModal.
 
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native"
@@ -58,8 +58,8 @@ export function DetailsActionRow({
     playVideo(hls, title ?? undefined, undefined)
   }
 
-  // Share / Download continuation URL → QR fallback. Same public watch URL for
-  // both in v1 (the phone page exposes share + download); validated before use.
+  // Share continuation URL → QR fallback: the public watch URL, validated
+  // before use so the phone can pick the video up.
   const shareUrl = buildShareUrl(video, activeVariant?.languageSlug ?? null)
   const canShare = shareUrl != null && validateActionUrl(shareUrl)
 
@@ -103,15 +103,6 @@ export function DetailsActionRow({
             icon="share-outline"
             label="Share"
             onPress={() => openModal(shareUrl, "Scan to share on your phone")}
-          />
-        ) : null}
-        {canShare ? (
-          <SecondaryPill
-            icon="download-outline"
-            label="Download"
-            onPress={() =>
-              openModal(shareUrl, "Scan to download on your phone")
-            }
           />
         ) : null}
       </TVFocusGuideView>


### PR DESCRIPTION
## Summary

Removes the `[Download]` pill from the TV watch-detail action row. On TV there is no local download story, so the pill only opened a QR code pointing at the phone's download page — redundant with `[Share]`, which already exposes the same public watch URL. The row keeps `[Play] [Language] [Subtitles] [Share]`.

Single-file change (`apps/tv/src/components/watch/DetailsActionRow.tsx`): drops the `SecondaryPill` and updates the now-stale header/inline comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
