### PR TITLE
fix(admin): preserve video relation query passthrough

### DIFF
--- a/apps/admin/src/graphql/types/video.ts
+++ b/apps/admin/src/graphql/types/video.ts
@@ -402,14 +402,20 @@ builder.prismaObject("VideoRelation", {
     parent: t.prismaField({
       type: "Video",
       nullable: true,
-      resolve: (_query, relation, _args, ctx) =>
-        ctx.loaders.videoById.load(relation.parentId),
+      resolve: (query, relation, _args, ctx) =>
+        ctx.prisma.video.findUnique({
+          ...query,
+          where: { id: relation.parentId },
+        }),
     }),
     child: t.prismaField({
       type: "Video",
       nullable: true,
-      resolve: (_query, relation, _args, ctx) =>
-        ctx.loaders.videoById.load(relation.childId),
+      resolve: (query, relation, _args, ctx) =>
+        ctx.prisma.video.findUnique({
+          ...query,
+          where: { id: relation.childId },
+        }),
     }),
   }),
 })

--- a/docs/roadmap/platform/feat-212-watch-video-db-index-performance.md
+++ b/docs/roadmap/platform/feat-212-watch-video-db-index-performance.md
@@ -1,7 +1,7 @@
 ---
 id: feat-212
 title: Clamp Watch single-video GraphQL DB latency with targeted indexes
-status: in-progress
+status: complete
 lane: platform
 depends_on:
   - feat-211
@@ -48,3 +48,12 @@ Prisma/Postgres work:
 4. If p50 remains above 2s, follow with a purpose-built Watch snapshot resolver
    to collapse the remaining relation fanout instead of relying on nested
    Pothos relation resolution.
+
+## Outcome
+
+Merged and deployed on 2026-06-26. The indexes exist in production, but the
+post-deploy probe still measured the selected Watch snapshot around 7.6s
+median with p95 above 13s. Datadog showed the worst `video_dub` spans improved
+from the prior ~6.45s outlier, but the route remained dominated by nested
+`Video.findUniqueOrThrow` / relation fanout. Follow-up work moves to
+`feat-213`.

--- a/docs/roadmap/platform/feat-213-watch-video-relation-query-passthrough.md
+++ b/docs/roadmap/platform/feat-213-watch-video-relation-query-passthrough.md
@@ -1,0 +1,43 @@
+---
+id: feat-213
+title: Clamp Watch single-video GraphQL relation fanout
+status: in-progress
+lane: platform
+depends_on:
+  - feat-212
+blocks: []
+---
+
+## Problem
+
+The Watch single-video route still takes roughly 7-8s in production after the
+targeted database indexes from `feat-212`. Datadog traces after the deploy show
+the bottleneck has shifted from one obvious missing-index candidate to nested
+Admin GraphQL resolver fanout: thousands of `Video.findUniqueOrThrow` spans and
+many repeated relation reads for the same video graph.
+
+The prior relation-loader optimization batched `VideoRelation.parent` and
+`VideoRelation.child` row hydration, but those fields are Pothos
+`prismaField`s and the resolver ignored the `query` argument. Ignoring that
+argument prevents Pothos from applying the nested selection it already computed,
+so the Watch query falls back into many smaller resolver trips for images,
+locales, child relations, and other nested fields.
+
+## Scope
+
+- Keep the Admin GraphQL schema and Web Watch route contract unchanged.
+- Make `VideoRelation.parent` and `VideoRelation.child` honor Pothos
+  `query` passthrough when hydrating the related video.
+- Re-run Admin schema/contract tests and Web Watch content tests.
+- Ship and re-measure the same production Watch probe and Datadog trace query.
+
+## Verification
+
+1. `pnpm --filter @forge/admin test -- src/graphql/schema.test.ts src/graphql/public-resolvers.regression.test.ts src/graphql/classification.test.ts`
+2. `pnpm --filter @forge/web test -- src/lib/content.test.ts`
+3. Production after deploy:
+   - `apps/web/scripts/probe-watch-video-snapshot.ts` against
+     `https://admin.jesusfilm.org/api/graphql` for `videoSlug=jesus`,
+     `languageSlug=english`, `locale=en`.
+   - Datadog APM for the production Admin GraphQL route, watching total
+     latency and Prisma span count.


### PR DESCRIPTION
## Summary
- restore Pothos Prisma query passthrough for VideoRelation parent/child hydration
- keep the Admin GraphQL schema and Web Watch operation unchanged
- record feat-212 production outcome and open feat-213 for the relation-fanout follow-up

## Why
The index deploy was verified in production but did not clamp the Watch single-video route: selected snapshot probes stayed around 7.6s median and Datadog still showed thousands of nested Video.findUniqueOrThrow/relation spans. The prior relation loader batched row hydration but ignored the Pothos query object on prismaField resolvers, preventing nested selections from being applied when hydrating related videos.

## Verification
- pnpm --filter @forge/admin test -- src/graphql/schema.test.ts src/graphql/public-resolvers.regression.test.ts src/graphql/classification.test.ts
- pnpm --filter @forge/web test -- src/lib/content.test.ts
- pnpm --filter @forge/admin schema:print
- pnpm --filter @forge/admin-graphql generate

## Notes
A broader web route test target still fails in this local environment because Vite cannot resolve next-intl/server from the Next page test. Full admin tsc also has pre-existing unrelated failures in experience-ai files and missing zod types from packages/experience-schema.