### PR TITLE
fix(admin): batch relation videos by query selection

### DIFF
--- a/apps/admin/src/graphql/loaders.test.ts
+++ b/apps/admin/src/graphql/loaders.test.ts
@@ -39,6 +39,7 @@ describe("createLoaders", () => {
       "experienceLocaleById",
       "languageById",
       "videoById",
+      "videoByIdWithQuery",
       "videoMuxPlaybackIdByIdAndLanguageSlug",
       "videoPrimaryDubDurationById",
     ])
@@ -103,6 +104,62 @@ describe("createLoaders", () => {
       loaders.experienceById.load("x1"), // duplicate; batched + cached
     ])
     expect(calls).toBe(1)
+  })
+
+  it("batches video loads that share a Pothos query selection", async () => {
+    const calls: Array<{ ids: string[]; query: object }> = []
+    const prisma = {
+      experience: { findMany: async () => [] },
+      experienceLocale: { findMany: async () => [] },
+      language: { findMany: async () => [] },
+      video: {
+        findMany: async (args: { where: { id: { in: string[] } } }) => {
+          calls.push({ ids: args.where.id.in, query: args })
+          return args.where.id.in.map((id) => ({ id }))
+        },
+      },
+    } as unknown as Parameters<typeof createLoaders>[0]
+
+    const loaders = createLoaders(prisma)
+    const query = { include: { images: true } }
+    await Promise.all([
+      loaders.videoByIdWithQuery.load({ id: "v1", query }),
+      loaders.videoByIdWithQuery.load({ id: "v2", query }),
+    ])
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.ids).toEqual(["v1", "v2"])
+    expect(calls[0]?.query).toMatchObject(query)
+  })
+
+  it("does not batch video loads with different Pothos query selections", async () => {
+    const calls: Array<{ ids: string[] }> = []
+    const prisma = {
+      experience: { findMany: async () => [] },
+      experienceLocale: { findMany: async () => [] },
+      language: { findMany: async () => [] },
+      video: {
+        findMany: async (args: { where: { id: { in: string[] } } }) => {
+          calls.push({ ids: args.where.id.in })
+          return args.where.id.in.map((id) => ({ id }))
+        },
+      },
+    } as unknown as Parameters<typeof createLoaders>[0]
+
+    const loaders = createLoaders(prisma)
+    await Promise.all([
+      loaders.videoByIdWithQuery.load({
+        id: "v1",
+        query: { include: { images: true } },
+      }),
+      loaders.videoByIdWithQuery.load({
+        id: "v2",
+        query: { include: { locales: true } },
+      }),
+    ])
+
+    expect(calls).toHaveLength(2)
+    expect(calls.map((call) => call.ids)).toEqual([["v1"], ["v2"]])
   })
 })
 

--- a/apps/admin/src/graphql/loaders.ts
+++ b/apps/admin/src/graphql/loaders.ts
@@ -49,6 +49,52 @@ export function createLoaders(prisma: PrismaClient) {
       return mapToInputOrder(ids, rows, (r) => r.id)
     }),
 
+    /**
+     * Hydrate Video rows by id while preserving Pothos Prisma's nested
+     * selection query. `VideoRelation.parent/child` need this: plain
+     * `videoById` batches well but discards nested selection preloading,
+     * while direct `findUnique({ ...query })` preserves the selection but
+     * creates one query per sibling. Grouping by the serialized query keeps
+     * both properties.
+     */
+    videoByIdWithQuery: new DataLoader<
+      VideoByIdWithQueryKey,
+      VideoRow | null,
+      string
+    >(
+      async (keys) => {
+        const groups = new Map<string, VideoByIdWithQueryKey[]>()
+        for (const key of keys) {
+          const groupKey = serializeVideoByIdWithQuerySelection(key.query)
+          groups.set(groupKey, [...(groups.get(groupKey) ?? []), key])
+        }
+
+        const rowsByLoaderKey = new Map<string, VideoRow | null>()
+        await Promise.all(
+          Array.from(groups.values()).map(async (group) => {
+            const ids = unique(group.map((key) => key.id))
+            const rows = await prisma.video.findMany({
+              ...withVideoIdSelected(group[0]?.query ?? {}),
+              where: { id: { in: ids } },
+            })
+            const rowsById = new Map(rows.map((row) => [row.id, row]))
+            for (const key of group) {
+              rowsByLoaderKey.set(
+                serializeVideoByIdWithQueryKey(key),
+                rowsById.get(key.id) ?? null,
+              )
+            }
+          }),
+        )
+
+        return keys.map(
+          (key) =>
+            rowsByLoaderKey.get(serializeVideoByIdWithQueryKey(key)) ?? null,
+        )
+      },
+      { cacheKeyFn: serializeVideoByIdWithQueryKey },
+    ),
+
     /** Hydrate Language rows by id. */
     languageById: new DataLoader<string, LanguageRow | null>(async (ids) => {
       const rows = await prisma.language.findMany({
@@ -210,6 +256,31 @@ const PRIMARY_DUB_PLAYBACK_SCAN_LIMIT = 5
 export type VideoMuxPlaybackKey = {
   videoId: string
   languageSlug: string | null
+}
+
+export type VideoByIdWithQueryKey = {
+  id: string
+  query: object
+}
+
+function serializeVideoByIdWithQuerySelection(query: object): string {
+  return JSON.stringify(query)
+}
+
+function serializeVideoByIdWithQueryKey(key: VideoByIdWithQueryKey): string {
+  return `${key.id}:${serializeVideoByIdWithQuerySelection(key.query)}`
+}
+
+function withVideoIdSelected(query: object): object {
+  const prismaQuery = query as { select?: Record<string, unknown> }
+  if (!prismaQuery.select) return query
+  return {
+    ...prismaQuery,
+    select: {
+      ...prismaQuery.select,
+      id: true,
+    },
+  }
 }
 
 function normalizeVideoMuxPlaybackKey(

--- a/apps/admin/src/graphql/types/video.ts
+++ b/apps/admin/src/graphql/types/video.ts
@@ -403,19 +403,13 @@ builder.prismaObject("VideoRelation", {
       type: "Video",
       nullable: true,
       resolve: (query, relation, _args, ctx) =>
-        ctx.prisma.video.findUnique({
-          ...query,
-          where: { id: relation.parentId },
-        }),
+        ctx.loaders.videoByIdWithQuery.load({ id: relation.parentId, query }),
     }),
     child: t.prismaField({
       type: "Video",
       nullable: true,
       resolve: (query, relation, _args, ctx) =>
-        ctx.prisma.video.findUnique({
-          ...query,
-          where: { id: relation.childId },
-        }),
+        ctx.loaders.videoByIdWithQuery.load({ id: relation.childId, query }),
     }),
   }),
 })


### PR DESCRIPTION
## Summary
- add a query-aware Video DataLoader that groups loads by Pothos Prisma selection
- use it for VideoRelation.parent and VideoRelation.child
- cover same-selection batching and different-selection separation in loader tests

## Why
PR #1388 restored Pothos query passthrough and deployed successfully, but production still measured selected Watch snapshot median around 6.89s with p95 around 8.80s. Datadog showed the route still had many sibling Video.findUnique calls after the deploy. This keeps query passthrough while batching siblings with the same nested selection into findMany groups.

## Verification
- pnpm --filter @forge/admin test -- src/graphql/loaders.test.ts src/graphql/schema.test.ts src/graphql/public-resolvers.regression.test.ts src/graphql/classification.test.ts
- pnpm --filter @forge/admin exec eslint src/graphql/types/video.ts src/graphql/loaders.ts src/graphql/loaders.test.ts
- pnpm --filter @forge/admin schema:print
- pnpm --filter @forge/admin-graphql generate