### PR TITLE
fix(admin): batch video relation row loading

### DIFF
--- a/apps/admin/src/graphql/loaders.test.ts
+++ b/apps/admin/src/graphql/loaders.test.ts
@@ -26,8 +26,9 @@ function makeFakePrisma(rowsByModel: Record<string, Array<{ id: string }>>) {
     experience: make("experience"),
     experienceLocale: make("experienceLocale"),
     video: make("video"),
+    videoRelation: { findMany: async () => [] },
     language: make("language"),
-    // Loose typing — DataLoader factory only touches the four above.
+    // Loose typing — each test provides only the delegates it exercises.
   } as unknown as Parameters<typeof createLoaders>[0]
 }
 
@@ -40,7 +41,9 @@ describe("createLoaders", () => {
       "languageById",
       "videoById",
       "videoByIdWithQuery",
+      "videoChildrenByParentId",
       "videoMuxPlaybackIdByIdAndLanguageSlug",
+      "videoParentsByChildId",
       "videoPrimaryDubDurationById",
     ])
   })
@@ -71,6 +74,7 @@ describe("createLoaders", () => {
       },
       experienceLocale: { findMany: async () => [] },
       video: { findMany: async () => [] },
+      videoRelation: { findMany: async () => [] },
       language: { findMany: async () => [] },
     } as unknown as Parameters<typeof createLoaders>[0]
 
@@ -118,6 +122,7 @@ describe("createLoaders", () => {
           return args.where.id.in.map((id) => ({ id }))
         },
       },
+      videoRelation: { findMany: async () => [] },
     } as unknown as Parameters<typeof createLoaders>[0]
 
     const loaders = createLoaders(prisma)
@@ -144,6 +149,7 @@ describe("createLoaders", () => {
           return args.where.id.in.map((id) => ({ id }))
         },
       },
+      videoRelation: { findMany: async () => [] },
     } as unknown as Parameters<typeof createLoaders>[0]
 
     const loaders = createLoaders(prisma)
@@ -160,6 +166,94 @@ describe("createLoaders", () => {
 
     expect(calls).toHaveLength(2)
     expect(calls.map((call) => call.ids)).toEqual([["v1"], ["v2"]])
+  })
+
+  it("batches parent relation rows by child id with public visibility", async () => {
+    const calls: Array<{ where: unknown }> = []
+    const prisma = {
+      experience: { findMany: async () => [] },
+      experienceLocale: { findMany: async () => [] },
+      language: { findMany: async () => [] },
+      video: { findMany: async () => [] },
+      videoRelation: {
+        findMany: async (args: { where: { childId: { in: string[] } } }) => {
+          calls.push({ where: args.where })
+          return args.where.childId.in.map((childId) => ({
+            id: `rel-${childId}`,
+            parentId: `parent-${childId}`,
+            childId,
+          }))
+        },
+      },
+    } as unknown as Parameters<typeof createLoaders>[0]
+
+    const loaders = createLoaders(prisma)
+    const rows = await Promise.all([
+      loaders.videoParentsByChildId.load({
+        videoId: "child-1",
+        visibleOnly: true,
+      }),
+      loaders.videoParentsByChildId.load({
+        videoId: "child-2",
+        visibleOnly: true,
+      }),
+    ])
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.where).toMatchObject({
+      childId: { in: ["child-1", "child-2"] },
+      parent: {
+        deletedAt: null,
+        locales: { some: { status: "PUBLISHED", deletedAt: null } },
+      },
+    })
+    expect(rows.map((group) => group.map((row) => row.childId))).toEqual([
+      ["child-1"],
+      ["child-2"],
+    ])
+  })
+
+  it("batches child relation rows by parent id with editor visibility", async () => {
+    const calls: Array<{ where: unknown }> = []
+    const prisma = {
+      experience: { findMany: async () => [] },
+      experienceLocale: { findMany: async () => [] },
+      language: { findMany: async () => [] },
+      video: { findMany: async () => [] },
+      videoRelation: {
+        findMany: async (args: {
+          where: { parentId: { in: string[] }; child?: unknown }
+        }) => {
+          calls.push({ where: args.where })
+          return args.where.parentId.in.map((parentId) => ({
+            id: `rel-${parentId}`,
+            parentId,
+            childId: `child-${parentId}`,
+          }))
+        },
+      },
+    } as unknown as Parameters<typeof createLoaders>[0]
+
+    const loaders = createLoaders(prisma)
+    const rows = await Promise.all([
+      loaders.videoChildrenByParentId.load({
+        videoId: "parent-1",
+        visibleOnly: false,
+      }),
+      loaders.videoChildrenByParentId.load({
+        videoId: "parent-2",
+        visibleOnly: false,
+      }),
+    ])
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.where).toEqual({
+      parentId: { in: ["parent-1", "parent-2"] },
+    })
+    expect(rows.map((group) => group.map((row) => row.parentId))).toEqual([
+      ["parent-1"],
+      ["parent-2"],
+    ])
   })
 })
 

--- a/apps/admin/src/graphql/loaders.ts
+++ b/apps/admin/src/graphql/loaders.ts
@@ -15,7 +15,7 @@
 // Per Unit 6 of docs/plans/2026-04-13-002-feat-admin-app-graphql-postgres-plan.md.
 
 import DataLoader from "dataloader"
-import type { PrismaClient } from "@prisma/client"
+import { Prisma, type PrismaClient } from "@prisma/client"
 
 export type Loaders = ReturnType<typeof createLoaders>
 
@@ -93,6 +93,38 @@ export function createLoaders(prisma: PrismaClient) {
         )
       },
       { cacheKeyFn: serializeVideoByIdWithQueryKey },
+    ),
+
+    /** Hydrate VideoRelation rows where the input Video is the child. */
+    videoParentsByChildId: new DataLoader<
+      VideoRelationVisibilityKey,
+      VideoRelationRow[],
+      string
+    >(
+      async (keys) =>
+        loadVideoRelationsByVideoId({
+          keys,
+          idField: "childId",
+          visibleRelationField: "parent",
+          prisma,
+        }),
+      { cacheKeyFn: serializeVideoRelationVisibilityKey },
+    ),
+
+    /** Hydrate VideoRelation rows where the input Video is the parent. */
+    videoChildrenByParentId: new DataLoader<
+      VideoRelationVisibilityKey,
+      VideoRelationRow[],
+      string
+    >(
+      async (keys) =>
+        loadVideoRelationsByVideoId({
+          keys,
+          idField: "parentId",
+          visibleRelationField: "child",
+          prisma,
+        }),
+      { cacheKeyFn: serializeVideoRelationVisibilityKey },
     ),
 
     /** Hydrate Language rows by id. */
@@ -263,6 +295,84 @@ export type VideoByIdWithQueryKey = {
   query: object
 }
 
+export type VideoRelationVisibilityKey = {
+  videoId: string
+  visibleOnly: boolean
+}
+
+const videoRelationOrderBy = [
+  { order: { sort: "asc" as const, nulls: "last" as const } },
+  { createdAt: "asc" as const },
+  { id: "asc" as const },
+] satisfies Prisma.VideoRelationOrderByWithRelationInput[]
+
+async function loadVideoRelationsByVideoId({
+  keys,
+  idField,
+  visibleRelationField,
+  prisma,
+}: {
+  keys: readonly VideoRelationVisibilityKey[]
+  idField: "parentId" | "childId"
+  visibleRelationField: "parent" | "child"
+  prisma: PrismaClient
+}): Promise<VideoRelationRow[][]> {
+  const groupedKeys = new Map<boolean, VideoRelationVisibilityKey[]>()
+  for (const key of keys) {
+    groupedKeys.set(key.visibleOnly, [
+      ...(groupedKeys.get(key.visibleOnly) ?? []),
+      key,
+    ])
+  }
+
+  const rowsByLoaderKey = new Map<string, VideoRelationRow[]>()
+  await Promise.all(
+    Array.from(groupedKeys.entries()).map(async ([visibleOnly, group]) => {
+      const ids = unique(group.map((key) => key.videoId))
+      const rows = await prisma.videoRelation.findMany({
+        where: {
+          [idField]: { in: ids },
+          ...(visibleOnly
+            ? {
+                [visibleRelationField]: {
+                  deletedAt: null,
+                  locales: {
+                    some: { status: "PUBLISHED" as const, deletedAt: null },
+                  },
+                },
+              }
+            : {}),
+        },
+        orderBy: videoRelationOrderBy,
+      })
+
+      const rowsByVideoId = new Map<string, VideoRelationRow[]>()
+      for (const row of rows) {
+        const videoId = row[idField]
+        rowsByVideoId.set(videoId, [...(rowsByVideoId.get(videoId) ?? []), row])
+      }
+
+      for (const key of group) {
+        rowsByLoaderKey.set(
+          serializeVideoRelationVisibilityKey(key),
+          rowsByVideoId.get(key.videoId) ?? [],
+        )
+      }
+    }),
+  )
+
+  return keys.map(
+    (key) =>
+      rowsByLoaderKey.get(serializeVideoRelationVisibilityKey(key)) ?? [],
+  )
+}
+
+function serializeVideoRelationVisibilityKey(
+  key: VideoRelationVisibilityKey,
+): string {
+  return `${key.videoId}:${key.visibleOnly ? "public" : "all"}`
+}
+
 function serializeVideoByIdWithQuerySelection(query: object): string {
   return JSON.stringify(query)
 }
@@ -312,6 +422,9 @@ type ExperienceLocaleRow = Awaited<
   ReturnType<PrismaClient["experienceLocale"]["findMany"]>
 >[number]
 type VideoRow = Awaited<ReturnType<PrismaClient["video"]["findMany"]>>[number]
+type VideoRelationRow = Awaited<
+  ReturnType<PrismaClient["videoRelation"]["findMany"]>
+>[number]
 type LanguageRow = Awaited<
   ReturnType<PrismaClient["language"]["findMany"]>
 >[number]

--- a/apps/admin/src/graphql/types/video.ts
+++ b/apps/admin/src/graphql/types/video.ts
@@ -393,7 +393,7 @@ builder.prismaObject("VideoStudyQuestion", {
 })
 
 /** @classification public-shape */
-builder.prismaObject("VideoRelation", {
+const VideoRelationRef = builder.prismaObject("VideoRelation", {
   description:
     "Self-referential parent/child join between Videos (e.g. series→episode). Exposes the related parent/child Video plus its ordering position.",
   fields: (t) => ({
@@ -541,15 +541,27 @@ builder.prismaObject("Video", {
     bibleCitations: t.relation("bibleCitations", {
       query: { where: { deletedAt: null } },
     }),
-    parents: t.relation("parents", {
+    parents: t.field({
+      type: [VideoRelationRef],
+      nullable: true,
       description:
         "Parent Video-Video relations: rows where this Video appears on the CHILD side of the VideoRelation join. Traverse `parent { … }` to read the foreign Video. PUBLIC/VIEWER see only relations whose parent has a PUBLISHED locale and is not soft-deleted; EDITOR/ADMIN see all.",
-      query: (_args, ctx) => videoParentsFilter(ctx.user),
+      resolve: (video, _args, ctx) =>
+        ctx.loaders.videoParentsByChildId.load({
+          videoId: video.id,
+          visibleOnly: !isEditorOrAdmin(ctx.user),
+        }),
     }),
-    children: t.relation("children", {
+    children: t.field({
+      type: [VideoRelationRef],
+      nullable: true,
       description:
         "Child Video-Video relations: rows where this Video appears on the PARENT side of the VideoRelation join. Traverse `child { … }` to read the foreign Video. PUBLIC/VIEWER see only relations whose child has a PUBLISHED locale and is not soft-deleted; EDITOR/ADMIN see all.",
-      query: (_args, ctx) => videoChildrenFilter(ctx.user),
+      resolve: (video, _args, ctx) =>
+        ctx.loaders.videoChildrenByParentId.load({
+          videoId: video.id,
+          visibleOnly: !isEditorOrAdmin(ctx.user),
+        }),
     }),
   }),
 })


### PR DESCRIPTION
## Summary
- replace Video.parents/children Pothos relation fields with explicit per-request DataLoader-backed relation row fetches
- keep public/editor visibility semantics for related videos
- add loader tests proving parent/child relation batching and visibility filters

## Verification
- pnpm --filter @forge/admin test -- src/graphql/loaders.test.ts src/graphql/schema.test.ts src/graphql/public-resolvers.regression.test.ts src/graphql/classification.test.ts src/graphql/types/video.principal-filter.test.ts
- pnpm --filter @forge/admin exec eslint src/graphql/types/video.ts src/graphql/loaders.ts src/graphql/loaders.test.ts
- pnpm --filter @forge/admin schema:print
- pnpm --filter @forge/admin-graphql generate

Datadog after #1389 still showed 66 Video.findUniqueOrThrow spans in a slow Watch video trace. This targets that remaining fanout by batching relation row loading instead of relying on Pothos relation resolution for Video.parents/children.