### PR TITLE
fix(admin): batch nested video rows for watch

### DIFF
--- a/apps/admin/src/graphql/loaders.test.ts
+++ b/apps/admin/src/graphql/loaders.test.ts
@@ -26,7 +26,11 @@ function makeFakePrisma(rowsByModel: Record<string, Array<{ id: string }>>) {
     experience: make("experience"),
     experienceLocale: make("experienceLocale"),
     video: make("video"),
+    videoImage: { findMany: async () => [] },
+    videoLocale: { findMany: async () => [] },
     videoRelation: { findMany: async () => [] },
+    videoStudyQuestion: { findMany: async () => [] },
+    bibleCitation: { findMany: async () => [] },
     language: make("language"),
     // Loose typing — each test provides only the delegates it exercises.
   } as unknown as Parameters<typeof createLoaders>[0]
@@ -39,12 +43,16 @@ describe("createLoaders", () => {
       "experienceById",
       "experienceLocaleById",
       "languageById",
+      "videoBibleCitationsByVideoId",
       "videoById",
       "videoByIdWithQuery",
       "videoChildrenByParentId",
+      "videoImagesByVideoId",
+      "videoLocalesByVideoIdAndFilter",
       "videoMuxPlaybackIdByIdAndLanguageSlug",
       "videoParentsByChildId",
       "videoPrimaryDubDurationById",
+      "videoStudyQuestionsByVideoIdAndFilter",
     ])
   })
 

--- a/apps/admin/src/graphql/loaders.ts
+++ b/apps/admin/src/graphql/loaders.ts
@@ -127,6 +127,90 @@ export function createLoaders(prisma: PrismaClient) {
       { cacheKeyFn: serializeVideoRelationVisibilityKey },
     ),
 
+    /** Hydrate non-deleted VideoImage rows by Video id. */
+    videoImagesByVideoId: new DataLoader<string, VideoImageRow[]>(async (ids) =>
+      loadRowsByVideoId({
+        ids,
+        findMany: (videoIds) =>
+          prisma.videoImage.findMany({
+            where: { videoId: { in: videoIds }, deletedAt: null },
+          }),
+      }),
+    ),
+
+    /** Hydrate visible VideoLocale rows by Video id and locale/language args. */
+    videoLocalesByVideoIdAndFilter: new DataLoader<
+      VideoLocaleFilterKey,
+      VideoLocaleRow[],
+      string
+    >(
+      async (keys) =>
+        loadVideoScopedRowsByFilter({
+          keys,
+          filterKey: serializeVideoLocaleFilter,
+          findMany: (videoIds, key) =>
+            prisma.videoLocale.findMany({
+              where: {
+                videoId: { in: videoIds },
+                deletedAt: null,
+                ...(key.locale != null ? { locale: key.locale } : {}),
+                ...(key.languageSlug != null
+                  ? { languageSlug: key.languageSlug }
+                  : {}),
+                ...(key.visibleOnly ? { status: "PUBLISHED" as const } : {}),
+              },
+              orderBy: [{ languageSlug: "asc" }, { id: "asc" }],
+            }),
+        }),
+      { cacheKeyFn: serializeVideoLocaleFilterKey },
+    ),
+
+    /** Hydrate VideoStudyQuestion rows by Video id and locale/language args. */
+    videoStudyQuestionsByVideoIdAndFilter: new DataLoader<
+      VideoStudyQuestionFilterKey,
+      VideoStudyQuestionRow[],
+      string
+    >(
+      async (keys) =>
+        loadVideoScopedRowsByFilter({
+          keys,
+          filterKey: serializeVideoStudyQuestionFilter,
+          findMany: (videoIds, key) =>
+            prisma.videoStudyQuestion.findMany({
+              where: {
+                videoId: { in: videoIds },
+                deletedAt: null,
+                ...(key.locale != null
+                  ? { locale: key.locale }
+                  : key.languageSlug == null
+                    ? { primary: true }
+                    : {}),
+                ...(key.languageSlug != null
+                  ? { languageSlug: key.languageSlug }
+                  : {}),
+              },
+              orderBy: [
+                { order: "asc" },
+                { languageSlug: "asc" },
+                { id: "asc" },
+              ],
+            }),
+        }),
+      { cacheKeyFn: serializeVideoStudyQuestionFilterKey },
+    ),
+
+    /** Hydrate non-deleted BibleCitation rows by Video id. */
+    videoBibleCitationsByVideoId: new DataLoader<string, BibleCitationRow[]>(
+      async (ids) =>
+        loadRowsByVideoId({
+          ids,
+          findMany: (videoIds) =>
+            prisma.bibleCitation.findMany({
+              where: { videoId: { in: videoIds }, deletedAt: null },
+            }),
+        }),
+    ),
+
     /** Hydrate Language rows by id. */
     languageById: new DataLoader<string, LanguageRow | null>(async (ids) => {
       const rows = await prisma.language.findMany({
@@ -300,6 +384,87 @@ export type VideoRelationVisibilityKey = {
   visibleOnly: boolean
 }
 
+export type VideoLocaleFilterKey = {
+  videoId: string
+  locale: string | null
+  languageSlug: string | null
+  visibleOnly: boolean
+}
+
+export type VideoStudyQuestionFilterKey = {
+  videoId: string
+  locale: string | null
+  languageSlug: string | null
+}
+
+type VideoScopedRow = { videoId: string }
+
+type VideoScopedFilterKey = { videoId: string }
+
+async function loadRowsByVideoId<R extends VideoScopedRow>({
+  ids,
+  findMany,
+}: {
+  ids: readonly string[]
+  findMany: (videoIds: string[]) => Promise<R[]>
+}): Promise<R[][]> {
+  const videoIds = unique(ids as string[])
+  const rows = await findMany(videoIds)
+  const rowsByVideoId = groupRowsByVideoId(rows)
+  return ids.map((id) => rowsByVideoId.get(id) ?? [])
+}
+
+async function loadVideoScopedRowsByFilter<
+  K extends VideoScopedFilterKey,
+  R extends VideoScopedRow,
+>({
+  keys,
+  filterKey,
+  findMany,
+}: {
+  keys: readonly K[]
+  filterKey: (key: K) => string
+  findMany: (videoIds: string[], key: K) => Promise<R[]>
+}): Promise<R[][]> {
+  const groupedKeys = new Map<string, K[]>()
+  for (const key of keys) {
+    const groupKey = filterKey(key)
+    groupedKeys.set(groupKey, [...(groupedKeys.get(groupKey) ?? []), key])
+  }
+
+  const rowsByLoaderKey = new Map<string, R[]>()
+  await Promise.all(
+    Array.from(groupedKeys.values()).map(async (group) => {
+      const videoIds = unique(group.map((key) => key.videoId))
+      const rows = await findMany(videoIds, group[0]!)
+      const rowsByVideoId = groupRowsByVideoId(rows)
+      for (const key of group) {
+        rowsByLoaderKey.set(
+          `${key.videoId}:${filterKey(key)}`,
+          rowsByVideoId.get(key.videoId) ?? [],
+        )
+      }
+    }),
+  )
+
+  return keys.map(
+    (key) => rowsByLoaderKey.get(`${key.videoId}:${filterKey(key)}`) ?? [],
+  )
+}
+
+function groupRowsByVideoId<R extends VideoScopedRow>(
+  rows: R[],
+): Map<string, R[]> {
+  const rowsByVideoId = new Map<string, R[]>()
+  for (const row of rows) {
+    rowsByVideoId.set(row.videoId, [
+      ...(rowsByVideoId.get(row.videoId) ?? []),
+      row,
+    ])
+  }
+  return rowsByVideoId
+}
+
 const videoRelationOrderBy = [
   { order: { sort: "asc" as const, nulls: "last" as const } },
   { createdAt: "asc" as const },
@@ -373,6 +538,37 @@ function serializeVideoRelationVisibilityKey(
   return `${key.videoId}:${key.visibleOnly ? "public" : "all"}`
 }
 
+function normalizeNullableArg(value: string | null | undefined): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function serializeVideoLocaleFilter(key: VideoLocaleFilterKey): string {
+  return [
+    normalizeNullableArg(key.locale) ?? "",
+    normalizeNullableArg(key.languageSlug) ?? "",
+    key.visibleOnly ? "public" : "all",
+  ].join(":")
+}
+
+function serializeVideoLocaleFilterKey(key: VideoLocaleFilterKey): string {
+  return `${key.videoId}:${serializeVideoLocaleFilter(key)}`
+}
+
+function serializeVideoStudyQuestionFilter(
+  key: VideoStudyQuestionFilterKey,
+): string {
+  return [
+    normalizeNullableArg(key.locale) ?? "",
+    normalizeNullableArg(key.languageSlug) ?? "",
+  ].join(":")
+}
+
+function serializeVideoStudyQuestionFilterKey(
+  key: VideoStudyQuestionFilterKey,
+): string {
+  return `${key.videoId}:${serializeVideoStudyQuestionFilter(key)}`
+}
+
 function serializeVideoByIdWithQuerySelection(query: object): string {
   return JSON.stringify(query)
 }
@@ -424,6 +620,18 @@ type ExperienceLocaleRow = Awaited<
 type VideoRow = Awaited<ReturnType<PrismaClient["video"]["findMany"]>>[number]
 type VideoRelationRow = Awaited<
   ReturnType<PrismaClient["videoRelation"]["findMany"]>
+>[number]
+type VideoImageRow = Awaited<
+  ReturnType<PrismaClient["videoImage"]["findMany"]>
+>[number]
+type VideoLocaleRow = Awaited<
+  ReturnType<PrismaClient["videoLocale"]["findMany"]>
+>[number]
+type VideoStudyQuestionRow = Awaited<
+  ReturnType<PrismaClient["videoStudyQuestion"]["findMany"]>
+>[number]
+type BibleCitationRow = Awaited<
+  ReturnType<PrismaClient["bibleCitation"]["findMany"]>
 >[number]
 type LanguageRow = Awaited<
   ReturnType<PrismaClient["language"]["findMany"]>

--- a/apps/admin/src/graphql/types/video.ts
+++ b/apps/admin/src/graphql/types/video.ts
@@ -249,46 +249,6 @@ builder.prismaObject("BibleBook", {
 })
 
 /** @classification public-shape */
-builder.prismaObject("BibleCitation", {
-  description: "A Core-sourced Bible passage cited by a video.",
-  fields: (t) => ({
-    id: t.exposeID("id"),
-    coreId: t.exposeString("coreId", { nullable: true }),
-    osisId: t.exposeString("osisId", { nullable: true }),
-    order: t.exposeInt("order", { nullable: true }),
-    chapterStart: t.exposeInt("chapterStart", { nullable: true }),
-    chapterEnd: t.exposeInt("chapterEnd", { nullable: true }),
-    verseStart: t.exposeInt("verseStart", { nullable: true }),
-    verseEnd: t.exposeInt("verseEnd", { nullable: true }),
-    bibleBook: t.relation("bibleBook"),
-  }),
-})
-
-/** @classification public-shape */
-builder.prismaObject("VideoImage", {
-  fields: (t) => ({
-    id: t.exposeID("id"),
-    url: t.exposeString("url", { nullable: true }),
-    width: t.exposeInt("width", { nullable: true }),
-    height: t.exposeInt("height", { nullable: true }),
-    aspectRatio: t.exposeString("aspectRatio", { nullable: true }),
-    mobileCinematicHigh: t.exposeString("mobileCinematicHigh", {
-      nullable: true,
-    }),
-    mobileCinematicLow: t.exposeString("mobileCinematicLow", {
-      nullable: true,
-    }),
-    mobileCinematicVeryLow: t.exposeString("mobileCinematicVeryLow", {
-      nullable: true,
-    }),
-    thumbnail: t.exposeString("thumbnail", { nullable: true }),
-    videoStill: t.exposeString("videoStill", { nullable: true }),
-    blurhash: t.exposeString("blurhash", { nullable: true }),
-    kind: t.exposeString("kind", { nullable: true }),
-  }),
-})
-
-/** @classification public-shape */
 builder.prismaObject("VideoSubtitle", {
   fields: (t) => ({
     id: t.exposeID("id"),
@@ -356,7 +316,47 @@ builder.prismaObject("VideoDub", {
 })
 
 /** @classification public-shape */
-builder.prismaObject("VideoLocale", {
+const BibleCitationRef = builder.prismaObject("BibleCitation", {
+  description: "A Core-sourced Bible passage cited by a video.",
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    coreId: t.exposeString("coreId", { nullable: true }),
+    osisId: t.exposeString("osisId", { nullable: true }),
+    order: t.exposeInt("order", { nullable: true }),
+    chapterStart: t.exposeInt("chapterStart", { nullable: true }),
+    chapterEnd: t.exposeInt("chapterEnd", { nullable: true }),
+    verseStart: t.exposeInt("verseStart", { nullable: true }),
+    verseEnd: t.exposeInt("verseEnd", { nullable: true }),
+    bibleBook: t.relation("bibleBook"),
+  }),
+})
+
+/** @classification public-shape */
+const VideoImageRef = builder.prismaObject("VideoImage", {
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    url: t.exposeString("url", { nullable: true }),
+    width: t.exposeInt("width", { nullable: true }),
+    height: t.exposeInt("height", { nullable: true }),
+    aspectRatio: t.exposeString("aspectRatio", { nullable: true }),
+    mobileCinematicHigh: t.exposeString("mobileCinematicHigh", {
+      nullable: true,
+    }),
+    mobileCinematicLow: t.exposeString("mobileCinematicLow", {
+      nullable: true,
+    }),
+    mobileCinematicVeryLow: t.exposeString("mobileCinematicVeryLow", {
+      nullable: true,
+    }),
+    thumbnail: t.exposeString("thumbnail", { nullable: true }),
+    videoStill: t.exposeString("videoStill", { nullable: true }),
+    blurhash: t.exposeString("blurhash", { nullable: true }),
+    kind: t.exposeString("kind", { nullable: true }),
+  }),
+})
+
+/** @classification public-shape */
+const VideoLocaleRef = builder.prismaObject("VideoLocale", {
   description: "Per-locale title/description/snippet/imageAlt for a Video.",
   fields: (t) => ({
     id: t.exposeID("id"),
@@ -377,7 +377,7 @@ builder.prismaObject("VideoLocale", {
 })
 
 /** @classification public-shape */
-builder.prismaObject("VideoStudyQuestion", {
+const VideoStudyQuestionRef = builder.prismaObject("VideoStudyQuestion", {
   description: "A per-locale Core-sourced study question attached to a video.",
   fields: (t) => ({
     id: t.exposeID("id"),
@@ -516,30 +516,51 @@ builder.prismaObject("Video", {
       resolve: (video, _args, ctx) =>
         ctx.services.video.countPlayableDubLanguages({ videoId: video.id }),
     }),
-    locales: t.relation("locales", {
+    locales: t.field({
+      type: [VideoLocaleRef],
+      nullable: true,
       description:
         "PUBLIC/VIEWER see PUBLISHED only; EDITOR/ADMIN see all. Pass `locale` to narrow the result to a single BCP-47 locale (web's WatchVideo fragment uses this to avoid overfetching every locale).",
       args: {
         locale: t.arg.string({ required: false }),
         languageSlug: t.arg.string({ required: false }),
       },
-      query: (args, ctx) => videoLocalesFilter(args, ctx.user),
+      resolve: (video, args, ctx) =>
+        ctx.loaders.videoLocalesByVideoIdAndFilter.load({
+          videoId: video.id,
+          locale: args.locale ?? null,
+          languageSlug: args.languageSlug ?? null,
+          visibleOnly: !isEditorOrAdmin(ctx.user),
+        }),
     }),
     dubs: t.relation("dubs", {
       query: { where: { deletedAt: null } },
     }),
-    images: t.relation("images", {
-      query: { where: { deletedAt: null } },
+    images: t.field({
+      type: [VideoImageRef],
+      nullable: true,
+      resolve: (video, _args, ctx) =>
+        ctx.loaders.videoImagesByVideoId.load(video.id),
     }),
-    studyQuestions: t.relation("studyQuestions", {
+    studyQuestions: t.field({
+      type: [VideoStudyQuestionRef],
+      nullable: true,
       args: {
         locale: t.arg.string({ required: false }),
         languageSlug: t.arg.string({ required: false }),
       },
-      query: (args) => videoStudyQuestionsFilter(args),
+      resolve: (video, args, ctx) =>
+        ctx.loaders.videoStudyQuestionsByVideoIdAndFilter.load({
+          videoId: video.id,
+          locale: args.locale ?? null,
+          languageSlug: args.languageSlug ?? null,
+        }),
     }),
-    bibleCitations: t.relation("bibleCitations", {
-      query: { where: { deletedAt: null } },
+    bibleCitations: t.field({
+      type: [BibleCitationRef],
+      nullable: true,
+      resolve: (video, _args, ctx) =>
+        ctx.loaders.videoBibleCitationsByVideoId.load(video.id),
     }),
     parents: t.field({
       type: [VideoRelationRef],


### PR DESCRIPTION
## Summary
- replace high-volume Video.images/locales/studyQuestions/bibleCitations Pothos relation fields with DataLoader-backed fields
- batch those nested Watch snapshot rows by video id and locale/language filters
- preserve the existing GraphQL schema and public/editor visibility behavior

## Verification
- pnpm --filter @forge/admin test -- src/graphql/loaders.test.ts src/graphql/schema.test.ts src/graphql/public-resolvers.regression.test.ts src/graphql/classification.test.ts src/graphql/types/video.principal-filter.test.ts
- pnpm --filter @forge/admin exec eslint src/graphql/types/video.ts src/graphql/loaders.ts src/graphql/loaders.test.ts
- pnpm --filter @forge/admin schema:print
- pnpm --filter @forge/admin-graphql generate

After #1390 deployed, Datadog still showed 66 Video.findUniqueOrThrow spans in Watch video traces. This targets the remaining Pothos relation fanout on sibling Video rows.