### PR TITLE
fix(watch): disable chapter prefetch on load

### DIFF
--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -335,6 +335,7 @@ export function SiblingCarousel({
                 {href ? (
                   <Link
                     href={href}
+                    prefetch={false}
                     data-testid="sibling-carousel-item"
                     data-active={isActive ? "true" : "false"}
                     data-pending={isPending ? "true" : "false"}

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -54,17 +54,20 @@ vi.mock("next/link", () => ({
     href,
     onClick,
     onNavigate: _onNavigate,
+    prefetch,
     children,
     ...props
   }: {
     href: string
     onClick?: MouseEventHandler<HTMLAnchorElement>
     onNavigate?: unknown
+    prefetch?: boolean
     children: ReactNode
     [key: string]: unknown
   }) => (
     <a
       href={href}
+      data-prefetch={String(prefetch)}
       onClick={(event) => {
         onClick?.(event)
         event.preventDefault()
@@ -766,6 +769,7 @@ describe("SiblingCarousel — edge cases", () => {
     expect(active!.getAttribute("data-href")).toBe(
       "/jesus-collection.html/child-12-slug/english.html",
     )
+    expect(active!.getAttribute("data-prefetch")).toBe("false")
     const label = container.querySelector(
       "[data-testid='sibling-carousel-label']",
     )


### PR DESCRIPTION
## Summary
- set `prefetch={false}` on Watch sibling carousel chapter links
- keep the existing explicit warm-on-click path in `WatchPageClient` for actual chapter navigation
- add a regression assertion that carousel links opt out of automatic prefetch

## Why
After #1395 deployed, Lighthouse improved JS weight but the trace still showed first-load route prefetches for chapter links such as `/watch/jesus.html/birth-of-jesus/english.html?_rsc=...`. Those speculative RSC requests can trigger extra Watch route work and network transfer before the user clicks anything.

## Validation
- `pnpm --filter @forge/web test -- SiblingCarousel WatchPageClient.download WatchPageClient.navigation watch-interaction-loader content-watch-merge`
- `pnpm --filter @forge/web exec eslint src/components/watch/SiblingCarousel.tsx src/components/watch/__tests__/SiblingCarousel.test.tsx src/components/watch/WatchPageClient.tsx src/components/watch/WatchSectionRenderer.tsx src/lib/watch-blocks.ts src/lib/content.ts`