### PR TITLE
fix(watch): delay muted preview activation

### DIFF
--- a/apps/web/src/components/watch/HeroPlayer.tsx
+++ b/apps/web/src/components/watch/HeroPlayer.tsx
@@ -135,7 +135,10 @@ function buildHeroPlaybackFallbackHref(playbackId: string | undefined): string {
     : `#${HERO_PLAYER_MEDIA_ID}`
 }
 
-const IDLE_PREVIEW_FALLBACK_DELAY_MS = 1200
+// Keep automatic muted-preview activation out of the critical first-load
+// window. The poster is already the intentional LCP surface, and user intent
+// still activates the player synchronously through the click/pointer handlers.
+const IDLE_PREVIEW_FALLBACK_DELAY_MS = 8000
 const IDLE_PREVIEW_VIEWPORT_MARGIN_PX = 200
 
 type IdleWindow = Window & {
@@ -406,16 +409,17 @@ export function HeroPlayer({
 
     const scheduleIdleActivation = () => {
       if (cancelled || idleHandle != null || timeoutHandle != null) return
-      if (idleWindow.requestIdleCallback) {
-        idleHandle = idleWindow.requestIdleCallback(tryActivatePreview, {
-          timeout: IDLE_PREVIEW_FALLBACK_DELAY_MS,
-        })
-        return
-      }
-      timeoutHandle = window.setTimeout(
-        tryActivatePreview,
-        IDLE_PREVIEW_FALLBACK_DELAY_MS,
-      )
+      timeoutHandle = window.setTimeout(() => {
+        timeoutHandle = null
+        if (cancelled) return
+        if (idleWindow.requestIdleCallback) {
+          idleHandle = idleWindow.requestIdleCallback(tryActivatePreview, {
+            timeout: 1000,
+          })
+          return
+        }
+        tryActivatePreview()
+      }, IDLE_PREVIEW_FALLBACK_DELAY_MS)
     }
 
     const scheduleAfterLoad = () => {

--- a/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
+++ b/apps/web/src/components/watch/__tests__/HeroPlayer.test.tsx
@@ -241,6 +241,10 @@ function installIdleCallbackStub() {
   }
   const originalRequestIdleCallback = windowWithIdle.requestIdleCallback
   const originalCancelIdleCallback = windowWithIdle.cancelIdleCallback
+  const originalSetTimeout = window.setTimeout
+  const originalClearTimeout = window.clearTimeout
+  const previewDelayTimers = new Map<number, () => void>()
+  let previewDelayTimerId = 0
 
   Object.defineProperty(windowWithIdle, "requestIdleCallback", {
     configurable: true,
@@ -254,6 +258,29 @@ function installIdleCallbackStub() {
     value: vi.fn((handle: number) => {
       idleCallbacks.splice(Math.max(0, handle - 1), 1)
     }),
+  })
+  Object.defineProperty(window, "setTimeout", {
+    configurable: true,
+    value: vi.fn(
+      (callback: TimerHandler, timeout?: number, ...args: unknown[]) => {
+        if (timeout === 8000 && typeof callback === "function") {
+          const handle = ++previewDelayTimerId
+          previewDelayTimers.set(handle, () => callback(...args))
+          callback(...args)
+          return handle
+        }
+        return originalSetTimeout(callback, timeout, ...args)
+      },
+    ) as unknown as typeof window.setTimeout,
+  })
+  Object.defineProperty(window, "clearTimeout", {
+    configurable: true,
+    value: vi.fn((handle?: number) => {
+      if (typeof handle === "number" && previewDelayTimers.delete(handle)) {
+        return
+      }
+      return originalClearTimeout(handle)
+    }) as typeof window.clearTimeout,
   })
 
   return {
@@ -280,6 +307,8 @@ function installIdleCallbackStub() {
       } else {
         Reflect.deleteProperty(windowWithIdle, "cancelIdleCallback")
       }
+      window.setTimeout = originalSetTimeout
+      window.clearTimeout = originalClearTimeout
     },
   }
 }


### PR DESCRIPTION
## Summary
- delay automatic muted-preview activation until after the first-load window
- keep poster-first rendering and immediate user-intent activation intact
- update HeroPlayer tests to fast-forward the new preview-delay timer in the existing idle callback helper

## Why
The saved Lighthouse trace shows the hero poster image is discovered and loaded early, but the final LCP candidate is committed much later while the muted preview/video layer is also being activated. Deferring automatic MuxVideo/HLS work should let the poster remain the stable first-load LCP surface while still allowing immediate playback on tap/click.

## Validation
- `pnpm --filter @forge/web test -- HeroPlayer SiblingCarousel WatchPageClient.download WatchPageClient.navigation`
- `pnpm --filter @forge/web exec eslint src/components/watch/HeroPlayer.tsx src/components/watch/__tests__/HeroPlayer.test.tsx`