### PR TITLE
fix(watch): defer transcript payload on first load

### DIFF
--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx
@@ -29,7 +29,6 @@ const {
   isWatchHideBibleQuotesEnabledMock,
   fetchYouVersionBibleQuotePassagesMock,
   isWatchQuestionPanelEnabledMock,
-  getInitialSubtitleTranscriptMock,
 } = vi.hoisted(() => ({
   resolveWatchRouteBySlugMock: vi.fn(),
   resolveSeriesEpisodeBySlugMock: vi.fn(),
@@ -56,7 +55,6 @@ const {
   isWatchHideBibleQuotesEnabledMock: vi.fn(async () => false),
   fetchYouVersionBibleQuotePassagesMock: vi.fn(),
   isWatchQuestionPanelEnabledMock: vi.fn(async () => false),
-  getInitialSubtitleTranscriptMock: vi.fn(async () => null),
 }))
 
 vi.mock("@/lib/admin-client", () => ({
@@ -77,10 +75,6 @@ vi.mock("@/lib/content", async () => {
 
 vi.mock("@/lib/watch-home", () => ({
   resolveWatchHome: resolveWatchHomeMock,
-}))
-
-vi.mock("@/lib/watch-transcript", () => ({
-  getInitialSubtitleTranscript: getInitialSubtitleTranscriptMock,
 }))
 
 vi.mock("next/navigation", () => ({
@@ -178,8 +172,6 @@ beforeEach(() => {
   fetchYouVersionBibleQuotePassagesMock.mockResolvedValue([])
   isWatchQuestionPanelEnabledMock.mockReset()
   isWatchQuestionPanelEnabledMock.mockResolvedValue(false)
-  getInitialSubtitleTranscriptMock.mockReset()
-  getInitialSubtitleTranscriptMock.mockResolvedValue(null)
   container = document.createElement("div")
   document.body.appendChild(container)
   root = createRoot(container)
@@ -767,38 +759,32 @@ describe("Catch-all routing — series branch (2-seg)", () => {
     expect(seriesPageClientMock).not.toHaveBeenCalled()
   })
 
-  it("passes initial transcript cues and prunes client variant rows", async () => {
-    const initialTranscript = {
-      vttSrc: "https://cdn.example/storyclubs.vtt",
-      cues: [{ start: 1, end: 4, text: "Server cue" }],
-    }
-    getInitialSubtitleTranscriptMock.mockResolvedValue(
-      initialTranscript as never,
-    )
+  it("defers transcript cues and prunes client variant rows", async () => {
     const watchVideoResult = makeWatchVideoResult("featureFilm")
     mockRouteVideo(watchVideoResult)
 
     await render2Seg("jesus", "english")
 
-    expect(getInitialSubtitleTranscriptMock).toHaveBeenCalledWith({
-      subtitles: watchVideoResult.video.subtitles,
-      audioSlug: "english",
-      durationSeconds: 30,
-    })
     const props = watchPageClientMock.mock.calls[0]?.[0] as {
-      initialTranscript: unknown
-      video: { variants: unknown[] }
+      initialTranscript?: unknown
+      variant: { videoEdition: unknown }
+      video: { variants: Array<{ videoEdition: unknown }> }
       mergedBlocks: Array<{
         kind?: string
         playableLanguageCount?: number
-        video?: { variants: unknown[] }
+        variant?: { videoEdition: unknown }
+        video?: { variants: Array<{ videoEdition: unknown }> }
       }>
     }
-    expect(props.initialTranscript).toBe(initialTranscript)
+    expect(props.initialTranscript).toBeUndefined()
+    expect(props.variant.videoEdition).toBeNull()
     expect(props.video.variants).toHaveLength(1)
+    expect(props.video.variants[0]?.videoEdition).toBeNull()
     const hero = props.mergedBlocks.find((block) => block.kind === "HeroPlayer")
     expect(hero?.playableLanguageCount).toBe(2)
+    expect(hero?.variant?.videoEdition).toBeNull()
     expect(hero?.video?.variants).toHaveLength(1)
+    expect(hero?.video?.variants[0]?.videoEdition).toBeNull()
   })
 
   it("renders a sanitized VideoObject JSON-LD script for playable videos", async () => {

--- a/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[htmlLang]/[...rest]/page.tsx
@@ -54,7 +54,6 @@ import {
 } from "@/lib/url-shape"
 import { watchVideoStructuredDataJson } from "@/lib/watch-structured-data"
 import { logWatchServerEvent } from "@/lib/watch-observability"
-import { getInitialSubtitleTranscript } from "@/lib/watch-transcript"
 import { fetchYouVersionBibleQuotePassages } from "@/lib/youversion-passage"
 
 // ISR: pages cached for 1 hour. Cookie-driven language redirect lives in
@@ -86,7 +85,17 @@ function pruneWatchVideoForClient(
     video.variants.find(
       (variant) => variant.documentId === selectedVariant.documentId,
     ) ?? selectedVariant
-  return { ...video, variants: [selected] }
+  return { ...video, variants: [pruneWatchVariantForClient(selected)] }
+}
+
+function pruneWatchVariantForClient(variant: WatchVariant): WatchVariant {
+  return {
+    ...variant,
+    // `video.subtitles` is the canonical client-side subtitle list. Keeping
+    // the selected variant's full edition subtitle payload duplicates every
+    // track in the RSC stream and initial HTML.
+    videoEdition: null,
+  }
 }
 
 function pruneMergedWatchBlocksForClient(
@@ -98,6 +107,11 @@ function pruneMergedWatchBlocksForClient(
     switch (block.kind) {
       case "HeroPlayer":
       case "WatchBody":
+        return {
+          ...block,
+          video: pruneWatchVideoForClient(block.video, selectedVariant),
+          variant: pruneWatchVariantForClient(block.variant),
+        }
       case "Share":
         return {
           ...block,
@@ -467,22 +481,16 @@ async function renderEpisode(shape: {
       getQuestionPanelEnabled(route),
       getHideBibleQuotesEnabled(route),
     ])
-  const [youVersionPassages, initialTranscript] = await Promise.all([
-    hideBibleQuotes
-      ? Promise.resolve([])
-      : getYouVersionBibleQuotePassages(route, resolved.video.bibleCitations),
-    getInitialSubtitleTranscript({
-      subtitles: resolved.video.subtitles,
-      audioSlug: resolved.selectedVariant.language?.slug ?? rawLocale,
-      durationSeconds: resolved.selectedVariant.duration ?? null,
-    }),
-  ])
+  const youVersionPassages = await (hideBibleQuotes
+    ? Promise.resolve([])
+    : getYouVersionBibleQuotePassages(route, resolved.video.bibleCitations))
   const mergedBlocks = mergeWatchExperience({
     video: resolved.video,
     variant: resolved.selectedVariant,
     canonicalParent: resolved.series,
     youVersionPassages,
   })
+  const clientVariant = pruneWatchVariantForClient(resolved.selectedVariant)
   const clientMergedBlocks = pruneMergedWatchBlocksForClient(
     mergedBlocks,
     resolved.selectedVariant,
@@ -515,14 +523,13 @@ async function renderEpisode(shape: {
       <WatchPageClient
         downloadButtonLabel={downloadButtonLabel}
         mergedBlocks={clientMergedBlocks}
-        variant={resolved.selectedVariant}
+        variant={clientVariant}
         video={clientVideo}
         languageSlug={resolved.selectedVariant.language?.slug ?? rawLocale}
         collectionSlug={seriesSlug}
         locale={locale}
         hideBibleQuotes={hideBibleQuotes}
         questionPanelEnabled={questionPanelEnabled}
-        initialTranscript={initialTranscript}
       />
     </>
   )
@@ -563,25 +570,16 @@ async function renderVideo(shape: {
         getQuestionPanelEnabled(route),
         getHideBibleQuotesEnabled(route),
       ])
-    const [youVersionPassages, initialTranscript] = await Promise.all([
-      hideBibleQuotes
-        ? Promise.resolve([])
-        : getYouVersionBibleQuotePassages(
-            route,
-            watchVideo.video.bibleCitations,
-          ),
-      getInitialSubtitleTranscript({
-        subtitles: watchVideo.video.subtitles,
-        audioSlug: watchVideo.selectedVariant.language?.slug ?? rawLocale,
-        durationSeconds: watchVideo.selectedVariant.duration ?? null,
-      }),
-    ])
+    const youVersionPassages = await (hideBibleQuotes
+      ? Promise.resolve([])
+      : getYouVersionBibleQuotePassages(route, watchVideo.video.bibleCitations))
     const mergedBlocks = mergeWatchExperience({
       video: watchVideo.video,
       variant: watchVideo.selectedVariant,
       canonicalParent: null,
       youVersionPassages,
     })
+    const clientVariant = pruneWatchVariantForClient(watchVideo.selectedVariant)
     const clientMergedBlocks = pruneMergedWatchBlocksForClient(
       mergedBlocks,
       watchVideo.selectedVariant,
@@ -612,13 +610,12 @@ async function renderVideo(shape: {
         <WatchPageClient
           downloadButtonLabel={downloadButtonLabel}
           mergedBlocks={clientMergedBlocks}
-          variant={watchVideo.selectedVariant}
+          variant={clientVariant}
           video={clientVideo}
           languageSlug={watchVideo.selectedVariant.language?.slug ?? rawLocale}
           locale={locale}
           hideBibleQuotes={hideBibleQuotes}
           questionPanelEnabled={questionPanelEnabled}
-          initialTranscript={initialTranscript}
         />
       </>
     )


### PR DESCRIPTION
## Summary
- stop server-prefetching and rendering full subtitle transcript cues on the initial watch page response
- prune duplicated selected-variant `videoEdition.subtitles` before props cross the RSC/client boundary
- keep the existing client transcript fetch path so transcript functionality still loads after hydration

## Verification
- pnpm --filter @forge/web test -- page-routing SubtitleTranscript.render WatchPageClient.download WatchPageClient.navigation
- pnpm --filter @forge/web exec eslint src/app/[locale]/[htmlLang]/[...rest]/page.tsx src/app/[locale]/[htmlLang]/[...rest]/__tests__/page-routing.test.tsx src/components/watch/SubtitleTranscript.tsx src/components/watch/WatchPageClient.tsx

## Performance hypothesis
Production HTML for /watch/jesus.html/english.html is 1.57 MB, with the transcript cues and duplicated subtitle edition data appearing in the initial document/RSC stream. Deferring cue rendering should reduce cold route work, document size, and mobile Lighthouse first-load pressure without removing the transcript feature.