### PR TITLE
fix(web): use next start for Railway Datadog config

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -104,7 +104,7 @@ must set Datadog service env (`DD_SERVICE=forge-web`, `DD_ENV=prod`,
 `DD_VERSION=<git sha>`), point at the private Datadog Agent
 (`DD_AGENT_HOST`, `DD_TRACE_AGENT_PORT=8126`, `DD_AGENT_SYSLOG_PORT=514`), and
 load the tracer before application modules through the `startCommand`:
-`NODE_OPTIONS='--require dd-trace/init' node ...server.js`. Do not set
+`NODE_OPTIONS='--require dd-trace/init' pnpm --filter @forge/web start`. Do not set
 `NODE_OPTIONS` as a global Railway service variable because service variables
 are also present during Railpack setup before dependencies are installed.
 

--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -8,7 +8,7 @@
 
 [build]
 builder = "RAILPACK"
-buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/web build && cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static"
+buildCommand = "pnpm install --frozen-lockfile && pnpm --filter @forge/web build"
 watchPatterns = [
   "/apps/web/**",
   "/packages/admin-graphql/**",
@@ -22,7 +22,7 @@ watchPatterns = [
 ]
 
 [deploy]
-startCommand = "HOSTNAME=0.0.0.0 NODE_OPTIONS='--require dd-trace/init' node apps/web/.next/standalone/apps/web/server.js"
+startCommand = "HOSTNAME=0.0.0.0 NODE_OPTIONS='--require dd-trace/init' pnpm --filter @forge/web start"
 healthcheckPath = "/watch"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary
- remove the standalone output copy/server path from the web Railway config
- keep Datadog's dd-trace preload scoped to the web start command
- update the web Datadog docs to match the actual Railway runtime

## Validation
- pnpm --filter @forge/web test -- env DatadogRum
- pnpm --filter @forge/web exec eslint src/instrumentation.ts src/observability/datadog.ts src/observability/datadog-logs.ts src/env.ts src/env.test.ts src/components/DatadogRum.tsx src/components/__tests__/DatadogRum.test.tsx
- ADMIN_GRAPHQL_URL=http://localhost:3003/api/graphql WEB_ADMIN_API_KEYS=test-admin-bearer-key REVALIDATION_SECRET=test-revalidation-secret STRAPI_PREVIEW_SECRET=test-preview-secret pnpm --filter @forge/web build