### PR TITLE
fix(web): resolve Datadog preload from web package

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -104,9 +104,10 @@ must set Datadog service env (`DD_SERVICE=forge-web`, `DD_ENV=prod`,
 `DD_VERSION=<git sha>`), point at the private Datadog Agent
 (`DD_AGENT_HOST`, `DD_TRACE_AGENT_PORT=8126`, `DD_AGENT_SYSLOG_PORT=514`), and
 load the tracer before application modules through the `startCommand`:
-`NODE_OPTIONS='--require dd-trace/init' pnpm --filter @forge/web start`. Do not set
-`NODE_OPTIONS` as a global Railway service variable because service variables
-are also present during Railpack setup before dependencies are installed.
+`cd apps/web && NODE_OPTIONS='--require ./node_modules/dd-trace/init' pnpm start`.
+Do not set `NODE_OPTIONS` as a global Railway service variable because service
+variables are also present during Railpack setup before dependencies are
+installed.
 
 ## Feature flags
 

--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -22,7 +22,7 @@ watchPatterns = [
 ]
 
 [deploy]
-startCommand = "HOSTNAME=0.0.0.0 NODE_OPTIONS='--require dd-trace/init' pnpm --filter @forge/web start"
+startCommand = "cd apps/web && HOSTNAME=0.0.0.0 NODE_OPTIONS='--require ./node_modules/dd-trace/init' pnpm start"
 healthcheckPath = "/watch"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary
- run the web Railway start command from apps/web
- preload dd-trace through the package-local node_modules path so Node can resolve it before pnpm starts
- update web Datadog docs to match the production command

## Validation
- cd apps/web && NODE_OPTIONS='--require ./node_modules/dd-trace/init' node -e "console.log(require.resolve('dd-trace/init'))"
- pnpm exec prettier --check apps/web/CLAUDE.md

## Production note
Railway deployment d2bc58af failed because the root-level NODE_OPTIONS preload could not resolve dd-trace/init before pnpm changed context. This fixes that startup path.