### PR TITLE
feat(admin): gate semantic HNSW search prototype

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -40,6 +40,7 @@
     "trigger-enrichment": "tsx src/scripts/trigger-enrichment.ts",
     "workflow:setup:postgres": "workflow-postgres-setup",
     "chat-ratings:list": "tsx src/scripts/list-chat-ratings.ts",
+    "search:hnsw-parity": "tsx src/scripts/search-hnsw-parity.ts",
     "index:local-video-embeddings": "tsx src/scripts/index-local-video-candidate-embeddings.ts",
     "mastra:dev": "mastra dev --dir src/mastra-playground",
     "smoke:draft-workflow": "tsx --env-file=.env src/scripts/smoke-mastra-draft-workflow.ts",

--- a/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
+++ b/apps/admin/src/app/api/internal/search-eval/search/route.test.ts
@@ -155,6 +155,29 @@ describe("POST /api/internal/search-eval/search", () => {
     expect(recordSearchTraceSafely).not.toHaveBeenCalled()
   })
 
+  it("passes the HNSW prototype mode through as an internal eval mode", async () => {
+    const response = await POST(
+      request({
+        query: "Jesus",
+        locale: "en",
+        limit: 10,
+        mode: "semantic-hnsw-prototype",
+        contentType: "video",
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(search).toHaveBeenCalledWith({
+      query: "Jesus",
+      locale: "en",
+      limit: 10,
+      offset: undefined,
+      mode: "semantic-hnsw-prototype",
+      allowInternalEvalModes: true,
+      contentTypes: ["video"],
+    })
+  })
+
   it("resolves a public language slug before running Admin search", async () => {
     languageFindFirst.mockResolvedValueOnce({ bcp47: "es" })
 

--- a/apps/admin/src/scripts/search-hnsw-parity.ts
+++ b/apps/admin/src/scripts/search-hnsw-parity.ts
@@ -1,0 +1,300 @@
+import { performance } from "node:perf_hooks"
+
+const DEFAULT_QUERIES = [
+  "the bible project",
+  "jesus",
+  "hope when life is hard",
+] as const
+const MODES = ["semantic-only", "semantic-hnsw-prototype"] as const
+
+type SearchMode = (typeof MODES)[number]
+
+type SearchResult = {
+  type: string
+  id: string
+  title: string
+  snippet: string
+  startSeconds: number | null
+  score: number
+}
+
+type SearchResponse = {
+  results: SearchResult[]
+  searchMode: string
+}
+
+type RunResult = {
+  query: string
+  mode: SearchMode
+  run: number
+  clientMs: number
+  searchMode: string
+  resultCount: number
+  distinctVideoCount: number
+  signature: string[]
+}
+
+function parseQueries(
+  args: Map<string, string>,
+  positional: string[],
+): string[] {
+  if (positional.length > 0) return positional
+
+  const inlineQueries = args.get("queries")
+  if (inlineQueries) {
+    return inlineQueries
+      .split("|")
+      .map((query) => query.trim())
+      .filter(Boolean)
+  }
+
+  const envQueries = process.env.SEARCH_HNSW_PARITY_QUERIES?.split("|")
+    .map((query) => query.trim())
+    .filter(Boolean)
+  return envQueries && envQueries.length > 0 ? envQueries : [...DEFAULT_QUERIES]
+}
+
+function parseArgs(argv: string[]): {
+  url: string
+  apiKey: string
+  locale: string
+  limit: number
+  runs: number
+  queries: string[]
+} {
+  const args = new Map<string, string>()
+  const queryArgs: string[] = []
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    if (arg === "--") continue
+    if (arg.startsWith("--")) {
+      const [rawKey, inlineValue] = arg.slice(2).split("=", 2)
+      const value = inlineValue ?? argv[++i]
+      if (!rawKey || value == null) {
+        throw new Error(`Missing value for ${arg}`)
+      }
+      args.set(rawKey, value)
+      continue
+    }
+    queryArgs.push(arg)
+  }
+
+  const url = args.get("url") ?? process.env.ADMIN_SEARCH_EVAL_SEARCH_URL ?? ""
+  const apiKey =
+    args.get("api-key") ?? process.env.ADMIN_SEARCH_EVAL_API_KEY ?? ""
+  if (!url) {
+    throw new Error(
+      "Missing internal search URL. Set ADMIN_SEARCH_EVAL_SEARCH_URL or pass --url.",
+    )
+  }
+  if (!apiKey) {
+    throw new Error(
+      "Missing internal search API key. Set ADMIN_SEARCH_EVAL_API_KEY or pass --api-key.",
+    )
+  }
+
+  return {
+    url,
+    apiKey,
+    locale: args.get("locale") ?? process.env.SEARCH_HNSW_PARITY_LOCALE ?? "en",
+    limit: parsePositiveInt(args.get("limit"), 20, "limit"),
+    runs: parsePositiveInt(args.get("runs"), 3, "runs"),
+    queries: parseQueries(args, queryArgs),
+  }
+}
+
+function parsePositiveInt(
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (raw == null) return fallback
+  const value = Number.parseInt(raw, 10)
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return value
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 10) / 10
+}
+
+function signatureFor(response: SearchResponse): string[] {
+  return response.results.map((result) =>
+    [
+      result.type,
+      result.id,
+      result.score.toFixed(6),
+      result.title,
+      result.snippet,
+      result.startSeconds == null ? "null" : String(result.startSeconds),
+    ].join("|"),
+  )
+}
+
+function distinctVideoCount(response: SearchResponse): number {
+  return new Set(
+    response.results
+      .filter((result) => result.type === "video")
+      .map((result) => result.id),
+  ).size
+}
+
+function sameSignature(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((item, index) => item === b[index])
+}
+
+async function runSearch(input: {
+  url: string
+  apiKey: string
+  query: string
+  locale: string
+  limit: number
+  mode: SearchMode
+  run: number
+}): Promise<RunResult> {
+  const startedAt = performance.now()
+  const response = await fetch(input.url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${input.apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      query: input.query,
+      locale: input.locale,
+      limit: input.limit,
+      mode: input.mode,
+      contentType: "video",
+    }),
+  })
+  const clientMs = elapsedMs(startedAt)
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    throw new Error(
+      `Search failed for ${input.query} ${input.mode}: ${response.status} ${body.slice(0, 200)}`,
+    )
+  }
+
+  const json = (await response.json()) as SearchResponse
+  return {
+    query: input.query,
+    mode: input.mode,
+    run: input.run,
+    clientMs,
+    searchMode: json.searchMode,
+    resultCount: json.results.length,
+    distinctVideoCount: distinctVideoCount(json),
+    signature: signatureFor(json),
+  }
+}
+
+function quantiles(values: number[]): {
+  min: number
+  median: number
+  max: number
+} {
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  return {
+    min: sorted[0] ?? 0,
+    median:
+      sorted.length % 2 === 0
+        ? Math.round(((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) * 5) /
+          10
+        : (sorted[middle] ?? 0),
+    max: sorted.at(-1) ?? 0,
+  }
+}
+
+function summarize(query: string, runs: RunResult[]) {
+  const byMode = new Map<SearchMode, RunResult[]>()
+  for (const mode of MODES) {
+    byMode.set(
+      mode,
+      runs.filter((result) => result.query === query && result.mode === mode),
+    )
+  }
+
+  const exactRuns = byMode.get("semantic-only") ?? []
+  const hnswRuns = byMode.get("semantic-hnsw-prototype") ?? []
+  const exactFirst = exactRuns[0]?.signature ?? []
+  const hnswFirst = hnswRuns[0]?.signature ?? []
+  const sharedTopIds = new Set(
+    exactFirst.map((signature) => signature.split("|")[1]),
+  )
+  const hnswTopIds = hnswFirst.map((signature) => signature.split("|")[1])
+  const topIdOverlap = hnswTopIds.filter((id) => sharedTopIds.has(id)).length
+
+  return {
+    query,
+    modes: Object.fromEntries(
+      MODES.map((mode) => {
+        const modeRuns = byMode.get(mode) ?? []
+        return [
+          mode,
+          {
+            clientMs: quantiles(modeRuns.map((result) => result.clientMs)),
+            resultCounts: modeRuns.map((result) => result.resultCount),
+            distinctVideoCounts: modeRuns.map(
+              (result) => result.distinctVideoCount,
+            ),
+            fullSignatureStable: modeRuns.every(
+              (result) =>
+                modeRuns[0] != null &&
+                sameSignature(result.signature, modeRuns[0].signature),
+            ),
+          },
+        ]
+      }),
+    ),
+    hnswMatchesExactSignature: sameSignature(hnswFirst, exactFirst),
+    topIdOverlap,
+    comparedTopN: Math.max(exactFirst.length, hnswFirst.length),
+    exactTop5: exactFirst.slice(0, 5),
+    hnswTop5: hnswFirst.slice(0, 5),
+  }
+}
+
+async function main(): Promise<void> {
+  const config = parseArgs(process.argv.slice(2))
+  const runs: RunResult[] = []
+
+  for (const query of config.queries) {
+    for (let run = 1; run <= config.runs; run++) {
+      for (const mode of MODES) {
+        runs.push(
+          await runSearch({
+            ...config,
+            query,
+            mode,
+            run,
+          }),
+        )
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        endpoint: config.url,
+        locale: config.locale,
+        limit: config.limit,
+        runsPerMode: config.runs,
+        summaries: config.queries.map((query) => summarize(query, runs)),
+        runs,
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -12,18 +12,27 @@ import {
   calculateVideoSemanticMixedScore,
   mixVideoSemanticEvidenceRows,
   searchVideoSemantic,
+  searchVideoSemanticHnswPrototype,
   searchVideoKeyword,
   searchExperienceSemantic,
   searchExperienceKeyword,
+  VIDEO_SEMANTIC_HNSW_EF_SEARCH,
+  VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES,
 } from "./hybrid-search-retrievers"
 import { SearchTimingRecorder } from "./hybrid-search-timing"
 
 function mockPrisma() {
   const $queryRaw = vi.fn()
-  return {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prisma: any = {
     $queryRaw,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any
+    $executeRaw: vi.fn(),
+    $executeRawUnsafe: vi.fn(),
+  }
+  prisma.$transaction = vi.fn(async (run: (tx: typeof prisma) => unknown) =>
+    run(prisma),
+  )
+  return prisma
 }
 
 function latestRawSql(prisma: ReturnType<typeof mockPrisma>): string {
@@ -467,6 +476,196 @@ describe("searchVideoSemantic", () => {
 
     const values = latestRawValues(prisma)
     expect(values.filter((value) => value === 14)).toHaveLength(1)
+  })
+
+  it("keeps HNSW-first windows out of the default semantic-video query", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemantic(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 7,
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    expect(sql).not.toContain("nearest_transcript_chunks")
+    expect(sql).not.toContain("source_distance")
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+  })
+})
+
+describe("searchVideoSemanticHnswPrototype", () => {
+  let prisma: ReturnType<typeof mockPrisma>
+
+  beforeEach(() => {
+    prisma = mockPrisma()
+  })
+
+  it("returns the same RankedItem-shaped rows as the default semantic retriever", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([
+      {
+        video_id: "vid-hnsw",
+        video_core_id: "core-hnsw",
+        video_slug: "hnsw-story",
+        video_title: "HNSW Story",
+        image_url: null,
+        evidence_id: "chunk-hnsw",
+        evidence_source: "transcript",
+        scene_description: "A matched transcript chunk",
+        start_seconds: 12,
+        playback_id: "mux-hnsw",
+        source_score: 0.83,
+        similarity: 0.83,
+        embedding_text: "[0.1,0.2]",
+      },
+    ])
+
+    const rows = await searchVideoSemanticHnswPrototype(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      resultType: "video",
+      resultId: "vid-hnsw",
+      videoCoreId: "core-hnsw",
+      videoSlug: "hnsw-story",
+      videoTitle: "HNSW Story",
+      imageUrl: null,
+      sceneDescription: "A matched transcript chunk",
+      startSeconds: 12,
+      playbackId: "mux-hnsw",
+      similarity: 0.83,
+      embeddingText: "[0.1,0.2]",
+    })
+  })
+
+  it("records a prototype-specific semantic-video DB timing", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+    const timing = new SearchTimingRecorder()
+
+    await searchVideoSemanticHnswPrototype(
+      prisma,
+      {
+        queryEmbedding: "[0.1,0.2]",
+        locale: "en",
+        limit: 10,
+      },
+      timing,
+    )
+
+    expect(timing.snapshotDbTimings()).toEqual([
+      expect.objectContaining({
+        label: "semantic-video-hnsw.query",
+        status: "fulfilled",
+        resultCount: 0,
+        elapsedMs: expect.any(Number),
+      }),
+    ])
+  })
+
+  it("sets HNSW scan knobs inside the transaction before querying", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemanticHnswPrototype(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 10,
+    })
+
+    expect(prisma.$transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ maxWait: 5000, timeout: 20_000 }),
+    )
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled()
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3)
+    expect(prisma.$executeRaw.mock.calls[0]?.[1]).toBe(
+      VIDEO_SEMANTIC_HNSW_EF_SEARCH,
+    )
+    expect(prisma.$executeRaw.mock.calls[1]?.[0].join("")).toContain(
+      "SET LOCAL hnsw.iterative_scan = relaxed_order",
+    )
+    expect(prisma.$executeRaw.mock.calls[2]?.[1]).toBe(
+      VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES,
+    )
+  })
+
+  it("uses an HNSW-first transcript window before per-video collapse", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemanticHnswPrototype(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "en",
+      limit: 60,
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    expect(sql).toContain("nearest_transcript_chunks AS MATERIALIZED")
+    expect(sql).toContain("FROM video_transcript_chunk vtc")
+    expect(sql).toContain("ORDER BY vtc.embedding <=> qe.embedding")
+    expect(sql).toContain("SELECT DISTINCT ON (video_id)")
+
+    const nearestWindow = sqlBetween(
+      sql,
+      "nearest_transcript_chunks AS MATERIALIZED",
+      "best_transcript_per_video AS",
+    )
+    expect(nearestWindow).toContain("LIMIT")
+    expect(nearestWindow).toContain("source_distance")
+
+    const bestTranscript = sqlBetween(
+      sql,
+      "best_transcript_per_video AS",
+      "visible_semantic_candidates AS",
+    )
+    expect(bestTranscript).toContain("FROM nearest_transcript_chunks")
+    expect(bestTranscript).toContain("source_distance ASC")
+    expect(bestTranscript).not.toContain("video_locale")
+
+    const values = latestRawValues(prisma)
+    expect(values).toContain(1200)
+    expect(values).toContain(120)
+  })
+
+  it("keeps default semantic gates and bounded hydration in the prototype SQL", async () => {
+    prisma.$queryRaw.mockResolvedValueOnce([])
+
+    await searchVideoSemanticHnswPrototype(prisma, {
+      queryEmbedding: "[0.1,0.2]",
+      locale: "fr",
+      limit: 10,
+    })
+
+    const sql = latestRawSqlWithFragments(prisma)
+    expect(sql).toContain("vtc.embedding IS NOT NULL")
+    expect(sql).toContain("vt.embedding_provider")
+    expect(sql).toContain("vt.embedding_native_dimensions")
+    expect(sql).toContain("vt.embedding_transform_version IS NULL")
+    expect(sql).toContain("vtc.language =")
+    expect(sql).toContain("vt.language =")
+    expect(sql).toContain("v.deleted_at IS NULL")
+    expect(sql).toContain("WHERE EXISTS")
+    expect(sql).toContain("FROM video_locale vl_visible")
+    expect(sql).toContain("vl_visible.status = 'published'")
+    expect(sql).toContain("vl_visible.deleted_at IS NULL")
+
+    const transcriptSource = sqlBetween(
+      sql,
+      "transcript_source AS",
+      "requested_language AS MATERIALIZED",
+    )
+    expect(transcriptSource).not.toContain("video_locale")
+    expect(transcriptSource).not.toContain("embedding::text")
+
+    const hydratedTail = sql.slice(
+      sql.indexOf("requested_language AS MATERIALIZED"),
+    )
+    expect(hydratedTail).toContain("FROM video_locale vl_display")
+    expect(hydratedTail).toContain("FROM video_dub vd")
+    expect(hydratedTail).toContain("FROM video_image vi2")
+    expect(hydratedTail).toContain("vtc_final.embedding::text")
   })
 })
 

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -55,6 +55,12 @@ export type SemanticSearchParams = {
 export const VIDEO_SEMANTIC_MAX_AGREEMENT_BONUS = 0.01
 export const VIDEO_SEMANTIC_AGREEMENT_THRESHOLD = 0.75
 export const VIDEO_SEMANTIC_AGREEMENT_FACTOR = 0.04
+export const VIDEO_SEMANTIC_HNSW_WINDOW_FACTOR = 20
+export const VIDEO_SEMANTIC_HNSW_MIN_ROW_WINDOW = 1000
+export const VIDEO_SEMANTIC_HNSW_MAX_ROW_WINDOW = 5000
+export const VIDEO_SEMANTIC_HNSW_EF_SEARCH = 200
+export const VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES = 20_000
+export const VIDEO_SEMANTIC_HNSW_TRANSACTION_TIMEOUT_MS = 20_000
 
 export function calculateVideoSemanticMixedScore(
   sourceScores: readonly number[],
@@ -260,6 +266,48 @@ export function mixVideoSemanticEvidenceRows(
   )
 }
 
+function videoTranscriptProvenanceFilter() {
+  return Prisma.sql`
+          AND vt.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
+          AND vt.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+          AND vt.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+          AND vt.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+          AND vt.embedding_transform_version IS NULL
+          AND vtc.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
+          AND vtc.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
+        `
+}
+
+function videoSemanticHnswRowWindowLimit(limit: number): number {
+  const requestedWindow = Math.max(
+    limit * VIDEO_SEMANTIC_HNSW_WINDOW_FACTOR,
+    VIDEO_SEMANTIC_HNSW_MIN_ROW_WINDOW,
+  )
+  return Math.min(requestedWindow, VIDEO_SEMANTIC_HNSW_MAX_ROW_WINDOW)
+}
+
+function mapVideoSemanticEvidenceRows(
+  evidenceRows: readonly VideoSemanticEvidenceRow[],
+  limit: number,
+): VideoSemanticResult[] {
+  return mixVideoSemanticEvidenceRows(evidenceRows)
+    .slice(0, limit)
+    .map((row) => ({
+      resultType: "video" as const,
+      resultId: row.video_id,
+      videoCoreId: row.video_core_id,
+      videoSlug: row.video_slug ?? "",
+      videoTitle: row.video_title ?? "",
+      imageUrl: row.image_url ?? null,
+      sceneDescription: row.scene_description,
+      startSeconds:
+        row.start_seconds == null ? null : Number(row.start_seconds),
+      playbackId: row.playback_id,
+      similarity: Number(row.similarity),
+      embeddingText: row.embedding_text,
+    }))
+}
+
 type VideoKeywordRow = {
   video_id: string
   video_core_id: string | null
@@ -317,15 +365,7 @@ export async function searchVideoSemantic(
   const { queryEmbedding, locale, limit } = params
   const candidateLimit = Math.max(limit * 2, limit)
 
-  const transcriptProvenanceFilter = Prisma.sql`
-          AND vt.embedding_provider = ${QWEN_CONTENT_EMBEDDING_PROVIDER}
-          AND vt.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
-          AND vt.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
-          AND vt.embedding_native_dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
-          AND vt.embedding_transform_version IS NULL
-          AND vtc.model = ${QWEN_CONTENT_EMBEDDING_MODEL}
-          AND vtc.dimensions = ${QWEN_CONTENT_EMBEDDING_DIMENSIONS}
-        `
+  const transcriptProvenanceFilter = videoTranscriptProvenanceFilter()
 
   const evidenceRows = await recordSearchDbTiming(
     timing,
@@ -444,22 +484,163 @@ export async function searchVideoSemantic(
     `,
   )
 
-  return mixVideoSemanticEvidenceRows(evidenceRows)
-    .slice(0, limit)
-    .map((row) => ({
-      resultType: "video" as const,
-      resultId: row.video_id,
-      videoCoreId: row.video_core_id,
-      videoSlug: row.video_slug ?? "",
-      videoTitle: row.video_title ?? "",
-      imageUrl: row.image_url ?? null,
-      sceneDescription: row.scene_description,
-      startSeconds:
-        row.start_seconds == null ? null : Number(row.start_seconds),
-      playbackId: row.playback_id,
-      similarity: Number(row.similarity),
-      embeddingText: row.embedding_text,
-    }))
+  return mapVideoSemanticEvidenceRows(evidenceRows, limit)
+}
+
+export async function searchVideoSemanticHnswPrototype(
+  prisma: PrismaClient,
+  params: SemanticSearchParams,
+  timing?: SearchTimingRecorder,
+): Promise<VideoSemanticResult[]> {
+  const { queryEmbedding, locale, limit } = params
+  const candidateLimit = Math.max(limit * 2, limit)
+  const hnswWindowLimit = videoSemanticHnswRowWindowLimit(limit)
+  const transcriptProvenanceFilter = videoTranscriptProvenanceFilter()
+
+  const evidenceRows = await prisma.$transaction(
+    async (tx) => {
+      await tx.$executeRaw`SET LOCAL hnsw.ef_search = ${VIDEO_SEMANTIC_HNSW_EF_SEARCH}`
+      await tx.$executeRaw`SET LOCAL hnsw.iterative_scan = relaxed_order`
+      await tx.$executeRaw`SET LOCAL hnsw.max_scan_tuples = ${VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES}`
+
+      return recordSearchDbTiming(
+        timing,
+        "semantic-video-hnsw.query",
+        () => tx.$queryRaw<VideoSemanticEvidenceRow[]>`
+        WITH query_embedding AS MATERIALIZED (
+          SELECT ${queryEmbedding}::vector AS embedding
+        ),
+        nearest_transcript_chunks AS MATERIALIZED (
+          SELECT
+            vt.video_id                       AS video_id,
+            vt.video_edition_id               AS video_edition_id,
+            vtc.id                            AS evidence_id,
+            'transcript'                      AS evidence_source,
+            COALESCE(
+              NULLIF(vtc.content_summary, ''),
+              NULLIF(vtc.raw_source_text, ''),
+              vtc.text
+            )                                 AS scene_description,
+            vtc.start_seconds                 AS start_seconds,
+            vtc.embedding <=> qe.embedding    AS source_distance,
+            1 - (vtc.embedding <=> qe.embedding) AS source_score
+          FROM video_transcript_chunk vtc
+          CROSS JOIN query_embedding qe
+          JOIN video_transcript vt ON vt.id = vtc.transcript_id
+            AND vt.language = ${locale}
+          WHERE vtc.embedding IS NOT NULL
+            ${transcriptProvenanceFilter}
+            AND vtc.language = ${locale}
+          ORDER BY vtc.embedding <=> qe.embedding
+          LIMIT ${hnswWindowLimit}
+        ),
+        best_transcript_per_video AS (
+          SELECT DISTINCT ON (video_id)
+            video_id,
+            video_edition_id,
+            evidence_id,
+            evidence_source,
+            scene_description,
+            start_seconds,
+            source_score
+          FROM nearest_transcript_chunks
+          ORDER BY
+            video_id,
+            source_distance ASC,
+            start_seconds ASC NULLS LAST,
+            evidence_id ASC
+        ),
+        visible_semantic_candidates AS (
+          SELECT
+            b.video_id                       AS video_id,
+            v.core_id                        AS video_core_id,
+            v.slug                           AS video_slug,
+            b.video_edition_id               AS video_edition_id,
+            b.evidence_id                    AS evidence_id,
+            b.evidence_source                AS evidence_source,
+            b.scene_description              AS scene_description,
+            b.start_seconds                  AS start_seconds,
+            b.source_score                   AS source_score
+          FROM best_transcript_per_video b
+          JOIN video v ON v.id = b.video_id
+            AND v.deleted_at IS NULL
+          WHERE EXISTS (
+            SELECT 1
+            FROM video_locale vl_visible
+            WHERE vl_visible.video_id = v.id
+              AND vl_visible.locale = ${locale}
+              AND vl_visible.status = 'published'
+              AND vl_visible.deleted_at IS NULL
+          )
+        ),
+        transcript_source AS (
+          SELECT *
+          FROM visible_semantic_candidates
+          ORDER BY source_score DESC, start_seconds ASC NULLS LAST, evidence_id ASC
+          LIMIT ${candidateLimit}
+        ),
+        requested_language AS MATERIALIZED (
+          SELECT id
+          FROM language
+          WHERE bcp47 = ${locale}
+        )
+        SELECT
+          ts.video_id                      AS video_id,
+          ts.video_core_id                 AS video_core_id,
+          ts.video_slug                    AS video_slug,
+          display_locale.title             AS video_title,
+          COALESCE(vi.mobile_cinematic_high, vi.url) AS image_url,
+          ts.evidence_id                   AS evidence_id,
+          ts.evidence_source               AS evidence_source,
+          ts.scene_description             AS scene_description,
+          ts.start_seconds                 AS start_seconds,
+          dub_mux.playback_id              AS playback_id,
+          ts.source_score                  AS source_score,
+          vtc_final.embedding::text        AS embedding_text
+        FROM transcript_source ts
+        LEFT JOIN video_transcript_chunk vtc_final
+          ON vtc_final.id = ts.evidence_id
+        JOIN LATERAL (
+          SELECT vl_display.title
+          FROM video_locale vl_display
+          WHERE vl_display.video_id = ts.video_id
+            AND vl_display.locale = ${locale}
+            AND vl_display.status = 'published'
+            AND vl_display.deleted_at IS NULL
+          ORDER BY
+            vl_display.language_core_id ASC NULLS LAST,
+            vl_display.language_slug ASC NULLS LAST,
+            vl_display.id ASC
+          LIMIT 1
+        ) display_locale ON true
+        LEFT JOIN LATERAL (
+          SELECT mv.playback_id
+          FROM video_dub vd
+          LEFT JOIN mux_video mv ON mv.id = vd.mux_video_id
+          WHERE vd.video_edition_id = ts.video_edition_id
+            AND vd.deleted_at IS NULL
+            AND vd.language_id IN (SELECT id FROM requested_language)
+          ORDER BY vd.published DESC NULLS LAST, vd.updated_at DESC
+          LIMIT 1
+        ) dub_mux ON true
+        LEFT JOIN LATERAL (
+          SELECT vi2.mobile_cinematic_high, vi2.url
+          FROM video_image vi2
+          WHERE vi2.video_id = ts.video_id
+            AND vi2.deleted_at IS NULL
+          ORDER BY vi2.mobile_cinematic_high IS NULL, vi2.created_at
+          LIMIT 1
+        ) vi ON true
+      `,
+      )
+    },
+    {
+      maxWait: 5_000,
+      timeout: VIDEO_SEMANTIC_HNSW_TRANSACTION_TIMEOUT_MS,
+    },
+  )
+
+  return mapVideoSemanticEvidenceRows(evidenceRows, limit)
 }
 
 /**

--- a/apps/admin/src/services/hybrid-search-timing.ts
+++ b/apps/admin/src/services/hybrid-search-timing.ts
@@ -4,6 +4,7 @@ export type SearchTimingPipelineMode =
   | "hybrid"
   | "keyword-first"
   | "semantic-only"
+  | "semantic-hnsw-prototype"
 
 export type SearchTimingStatus = "fulfilled" | "rejected" | "skipped"
 

--- a/apps/admin/src/services/hybrid-search.bible-project.test.ts
+++ b/apps/admin/src/services/hybrid-search.bible-project.test.ts
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("./hybrid-search-retrievers", () => ({
   searchVideoSemantic: vi.fn(),
+  searchVideoSemanticHnswPrototype: vi.fn(),
   searchVideoKeyword: vi.fn(),
   searchExperienceSemantic: vi.fn(),
   searchExperienceKeyword: vi.fn(),

--- a/apps/admin/src/services/hybrid-search.debug.test.ts
+++ b/apps/admin/src/services/hybrid-search.debug.test.ts
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("./hybrid-search-retrievers", () => ({
   searchVideoSemantic: vi.fn(),
+  searchVideoSemanticHnswPrototype: vi.fn(),
   searchVideoKeyword: vi.fn(),
   searchExperienceSemantic: vi.fn(),
   searchExperienceKeyword: vi.fn(),

--- a/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
+++ b/apps/admin/src/services/hybrid-search.dilution-cap.test.ts
@@ -321,6 +321,7 @@ describe("applyDilutionCap", () => {
 
 vi.mock("./hybrid-search-retrievers", () => ({
   searchVideoSemantic: vi.fn(),
+  searchVideoSemanticHnswPrototype: vi.fn(),
   searchVideoKeyword: vi.fn(),
   searchExperienceSemantic: vi.fn(),
   searchExperienceKeyword: vi.fn(),

--- a/apps/admin/src/services/hybrid-search.keyword-first.test.ts
+++ b/apps/admin/src/services/hybrid-search.keyword-first.test.ts
@@ -20,6 +20,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("./hybrid-search-retrievers", () => ({
   searchVideoSemantic: vi.fn(),
+  searchVideoSemanticHnswPrototype: vi.fn(),
   searchVideoKeyword: vi.fn(),
   searchExperienceSemantic: vi.fn(),
   searchExperienceKeyword: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock("./hybrid-search-keyword-first-retrievers", () => {
 
 import {
   searchVideoSemantic,
+  searchVideoSemanticHnswPrototype,
   searchVideoKeyword,
   searchExperienceSemantic,
   searchExperienceKeyword,
@@ -98,6 +100,7 @@ async function delayMs(ms: number): Promise<void> {
 
 function setupAllRetrieversEmpty() {
   vi.mocked(searchVideoSemantic).mockResolvedValue([])
+  vi.mocked(searchVideoSemanticHnswPrototype).mockResolvedValue([])
   vi.mocked(searchVideoKeyword).mockResolvedValue([])
   vi.mocked(searchExperienceSemantic).mockResolvedValue([])
   vi.mocked(searchExperienceKeyword).mockResolvedValue([])
@@ -157,6 +160,8 @@ describe("HybridSearchService keyword-first branch", () => {
       },
       expect.any(Object),
     )
+    expect(searchVideoSemantic).toHaveBeenCalled()
+    expect(searchVideoSemanticHnswPrototype).not.toHaveBeenCalled()
   })
 
   it("starts keyword-first lexical retrievers while query embedding is pending", async () => {
@@ -185,6 +190,7 @@ describe("HybridSearchService keyword-first branch", () => {
     await searchPromise
 
     expect(searchVideoSemantic).toHaveBeenCalled()
+    expect(searchVideoSemanticHnswPrototype).not.toHaveBeenCalled()
   })
 
   it("does not charge embedding wait time to db retrieval timing", async () => {

--- a/apps/admin/src/services/hybrid-search.regression.test.ts
+++ b/apps/admin/src/services/hybrid-search.regression.test.ts
@@ -29,6 +29,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("./hybrid-search-retrievers", () => ({
   searchVideoSemantic: vi.fn(),
+  searchVideoSemanticHnswPrototype: vi.fn(),
   searchVideoKeyword: vi.fn(),
   searchExperienceSemantic: vi.fn(),
   searchExperienceKeyword: vi.fn(),

--- a/apps/admin/src/services/hybrid-search.service.test.ts
+++ b/apps/admin/src/services/hybrid-search.service.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("./hybrid-search-retrievers", () => ({
   searchVideoSemantic: vi.fn(),
+  searchVideoSemanticHnswPrototype: vi.fn(),
   searchVideoKeyword: vi.fn(),
   searchExperienceSemantic: vi.fn(),
   searchExperienceKeyword: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock("./embeddings.service", () => ({
 import { generateExperienceEmbedding } from "./embeddings.service"
 import {
   searchVideoSemantic,
+  searchVideoSemanticHnswPrototype,
   searchVideoKeyword,
   searchExperienceSemantic,
   searchExperienceKeyword,
@@ -101,6 +103,7 @@ function failingEmbedder(error = new Error("provider down")): QueryEmbedder {
 
 function setupDefaultRetrievers() {
   vi.mocked(searchVideoSemantic).mockResolvedValue([])
+  vi.mocked(searchVideoSemanticHnswPrototype).mockResolvedValue([])
   vi.mocked(searchVideoKeyword).mockResolvedValue([])
   vi.mocked(searchExperienceSemantic).mockResolvedValue([])
   vi.mocked(searchExperienceKeyword).mockResolvedValue([])
@@ -526,6 +529,36 @@ describe("HybridSearchService", () => {
 
     expect(searchVideoSemantic).toHaveBeenCalled()
     expect(searchVideoKeyword).toHaveBeenCalled()
+    expect(searchExperienceSemantic).not.toHaveBeenCalled()
+    expect(searchExperienceKeyword).not.toHaveBeenCalled()
+  })
+
+  it("dispatches the HNSW prototype only for internal semantic eval mode", async () => {
+    const service = new HybridSearchService({
+      prisma: mockPrisma,
+      embedder: successEmbedder(),
+      logger,
+    })
+
+    await service.search({
+      query: "test",
+      locale: "en",
+      mode: "semantic-hnsw-prototype",
+      allowInternalEvalModes: true,
+      contentTypes: ["video"],
+    })
+
+    expect(searchVideoSemanticHnswPrototype).toHaveBeenCalledWith(
+      mockPrisma,
+      {
+        queryEmbedding: "[0.1,0.2,0.3]",
+        locale: "en",
+        limit: 60,
+      },
+      expect.any(Object),
+    )
+    expect(searchVideoSemantic).not.toHaveBeenCalled()
+    expect(searchVideoKeyword).not.toHaveBeenCalled()
     expect(searchExperienceSemantic).not.toHaveBeenCalled()
     expect(searchExperienceKeyword).not.toHaveBeenCalled()
   })
@@ -1205,11 +1238,30 @@ describe("normalizeMode", () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it("recognizes 'semantic-hnsw-prototype' only for internal eval callers", () => {
+    const warn = vi.fn()
+    expect(
+      normalizeMode(
+        "semantic-hnsw-prototype",
+        { warn },
+        { allowInternalEvalModes: true },
+      ),
+    ).toBe("semantic-hnsw-prototype")
+    expect(warn).not.toHaveBeenCalled()
+  })
+
   it("treats public 'semantic-only' as unknown and falls back to hybrid", () => {
     const warn = vi.fn()
     expect(normalizeMode("semantic-only", { warn })).toBe("hybrid")
     expect(warn).toHaveBeenCalledTimes(1)
     expect(warn.mock.calls[0]![0]).toContain("mode=semantic-only")
+  })
+
+  it("treats public 'semantic-hnsw-prototype' as unknown and falls back to hybrid", () => {
+    const warn = vi.fn()
+    expect(normalizeMode("semantic-hnsw-prototype", { warn })).toBe("hybrid")
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain("mode=semantic-hnsw-prototype")
   })
 
   it("is case-sensitive — 'HYBRID' / 'Keyword-First' are unknown", () => {

--- a/apps/admin/src/services/hybrid-search.service.ts
+++ b/apps/admin/src/services/hybrid-search.service.ts
@@ -32,6 +32,7 @@ import {
 import { recordAttempt, recordFailure } from "./hybrid-search-health"
 import {
   searchVideoSemantic,
+  searchVideoSemanticHnswPrototype,
   searchVideoKeyword,
   searchExperienceSemantic,
   searchExperienceKeyword,
@@ -167,7 +168,11 @@ export type SearchResultDebug = {
  * stays a nullable string so `normalizeMode` can warn-and-fall-back on
  * unknown values without breaking clients on rollouts of new modes.
  */
-export type SearchPipelineMode = "hybrid" | "keyword-first" | "semantic-only"
+export type SearchPipelineMode =
+  | "hybrid"
+  | "keyword-first"
+  | "semantic-only"
+  | "semantic-hnsw-prototype"
 
 /**
  * Sanitizer for user-supplied values that get interpolated into
@@ -203,6 +208,12 @@ export function normalizeMode(
   if (raw === "keyword-first") return "keyword-first"
   if (raw === "semantic-only" && options.allowInternalEvalModes === true) {
     return "semantic-only"
+  }
+  if (
+    raw === "semantic-hnsw-prototype" &&
+    options.allowInternalEvalModes === true
+  ) {
+    return "semantic-hnsw-prototype"
   }
   logger.warn(
     `[search] event=search_unknown_mode mode=${sanitizeForLog(raw)} falling_back=hybrid`,
@@ -865,7 +876,9 @@ export class HybridSearchService {
     const pipelineMode = normalizeMode(params.mode, this.logger, {
       allowInternalEvalModes: params.allowInternalEvalModes,
     })
-    const semanticOnly = pipelineMode === "semantic-only"
+    const semanticOnly =
+      pipelineMode === "semantic-only" ||
+      pipelineMode === "semantic-hnsw-prototype"
     const limit = Math.min(
       Math.max(1, params.limit ?? DEFAULT_LIMIT),
       MAX_LIMIT,
@@ -1063,7 +1076,9 @@ export class HybridSearchService {
             ? timedRetrieval(
                 "semantic-video",
                 () =>
-                  searchVideoSemantic(
+                  (pipelineMode === "semantic-hnsw-prototype"
+                    ? searchVideoSemanticHnswPrototype
+                    : searchVideoSemantic)(
                     this.prisma,
                     {
                       queryEmbedding: queryEmbeddingText,

--- a/docs/plans/2026-06-28-001-perf-admin-search-hnsw-prototype-plan.md
+++ b/docs/plans/2026-06-28-001-perf-admin-search-hnsw-prototype-plan.md
@@ -1,0 +1,255 @@
+---
+title: "perf: Prototype Admin semantic HNSW retrieval"
+type: "perf"
+date: "2026-06-28"
+execution: "code"
+---
+
+# perf: Prototype Admin semantic HNSW retrieval
+
+## Summary
+
+Add an internal-only Admin search mode that evaluates an HNSW-first transcript
+retrieval path against the current exact semantic-video query. The default
+keyword-first and hybrid search paths must remain unchanged until production
+timing, top-result parity, and distinct-video recall prove the prototype is safe.
+
+---
+
+## Problem Frame
+
+The current semantic-video query preserves exact best transcript chunk per video
+behavior by scanning the eligible transcript corpus, collapsing to one chunk per
+video, and only then limiting visible candidates. That shape protects quality,
+but it blocks the database from using the existing
+`video_transcript_chunk_embedding_hnsw*` indexes for the expensive nearest-neighbor
+part of the query.
+
+Production timing now shows the safe pool and fan-out changes brought Admin
+search into sub-second median service times for the representative canaries, but
+the roadmap still keeps HNSW-first retrieval as the next larger optimization.
+This plan implements it as a gated prototype so speed can be measured without
+silently degrading semantic recall.
+
+---
+
+## Requirements
+
+- R1. Public search callers must not be able to select the prototype mode; unknown
+  public `mode` values still warn and fall back to `hybrid`.
+- R2. The default `semantic-video` retriever must keep its exact no-pre-window
+  query shape, timing label, result mapping, and public response behavior.
+- R3. The prototype must use an HNSW-first nearest transcript chunk window before
+  collapsing to one candidate per video, with DB timing separated from the
+  default query.
+- R4. The prototype must preserve existing provenance, language, visibility,
+  display hydration, image hydration, dub lookup, and row-mapping rules after its
+  candidate window.
+- R5. A parity harness must compare the default semantic path and the prototype
+  path by result IDs, order, scores, snippets, timecodes, and distinct-video
+  count before the prototype can be considered for promotion.
+- R6. Focused tests must prove the prototype is internal-only and that the
+  default path has not gained HNSW-first behavior.
+
+---
+
+## Key Technical Decisions
+
+- **Gate as an internal Search Pipeline Mode:** Add a literal internal mode that
+  `normalizeMode` accepts only when `allowInternalEvalModes` is true. This
+  matches the existing `semantic-only` diagnostic boundary and avoids GraphQL or
+  Web contract changes.
+- **Compare against semantic-only first:** Route the prototype as a semantic
+  diagnostic path, not as the new keyword-first default. This isolates the
+  algorithmic change in video semantic retrieval before mixing it with lexical
+  rankers.
+- **Keep default SQL exact:** Leave `searchVideoSemantic` as the source of truth
+  for current best-evidence-per-video behavior. Add a sibling retriever for the
+  prototype so tests can assert both shapes independently.
+- **Use transaction-scoped pgvector tuning:** Apply `SET LOCAL hnsw.ef_search`
+  and bounded iterative-scan settings inside the same Prisma transaction as the
+  prototype query, following the existing pgvector transaction rule.
+- **Start with conservative prototype constants:** Use a nearest-row window of
+  `max(limit * 20, 1000)` bounded to `5000`, `hnsw.ef_search = 200`, and
+  `hnsw.max_scan_tuples = 20000`. These values are prototype defaults for
+  parity measurement, not public search tuning.
+- **Make parity measurable, not implied:** Add a small script that can call the
+  internal eval-search route for both modes and emit compact timing and signature
+  comparisons. Promotion remains a later decision after production measurements.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["internal eval request"] --> B{"mode"}
+  B -->|"semantic-only"| C["exact searchVideoSemantic"]
+  B -->|"semantic-hnsw-prototype"| D["HNSW nearest chunk window"]
+  D --> E["best chunk per video from window"]
+  E --> F["published locale visibility"]
+  F --> G["bounded display/image/dub hydration"]
+  C --> H["parity harness"]
+  G --> H
+  H --> I["timing and result signature report"]
+```
+
+The prototype intentionally moves the first `LIMIT` earlier than the default
+query. That is the performance lever and the relevance risk, so the default
+path and the parity harness must make the difference visible.
+
+---
+
+## Implementation Units
+
+### U1. Add the internal prototype mode boundary
+
+- **Goal:** Allow authenticated internal eval callers to request the prototype
+  while keeping public search mode behavior unchanged.
+- **Requirements:** R1, R6
+- **Dependencies:** none
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+  - `apps/admin/src/services/hybrid-search.keyword-first.test.ts`
+  - `apps/admin/src/app/api/internal/search-eval/search/route.test.ts`
+- **Approach:** Extend `SearchPipelineMode` with an internal-only prototype
+  literal. Update `normalizeMode` so it accepts the literal only when
+  `allowInternalEvalModes` is true, mirroring `semantic-only`. Keep public
+  unknown-mode fallback and warning behavior unchanged.
+- **Patterns to follow:** Existing `semantic-only` internal eval mode handling in
+  `apps/admin/src/services/hybrid-search.service.ts`.
+- **Test scenarios:**
+  - `normalizeMode` accepts the prototype mode only with
+    `allowInternalEvalModes: true`.
+  - Public `normalizeMode` calls treat the prototype mode as unknown and fall
+    back to `hybrid` with one warning.
+  - The internal eval route continues passing `allowInternalEvalModes: true`.
+  - Keyword-first tests prove the prototype does not run on normal
+    `keyword-first` requests.
+- **Verification:** Focused search service and internal eval route tests prove
+  the mode gate.
+
+### U2. Add the HNSW-first semantic video retriever
+
+- **Goal:** Implement a sibling retriever that can measure HNSW-first transcript
+  retrieval without modifying the default semantic-video path.
+- **Requirements:** R2, R3, R4, R6
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search-retrievers.ts`
+  - `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+  - `apps/admin/src/services/transcript-embedding-ingest.contract.test.ts`
+- **Approach:** Add a `searchVideoSemanticHnswPrototype` function that selects a
+  bounded nearest transcript chunk window ordered by vector distance, collapses
+  that window to one chunk per video, then reuses the same visibility and
+  hydration rules as the default query. Run the `SET LOCAL` statements and query
+  inside one Prisma transaction, use the documented prototype constants, and
+  record a prototype-specific DB timing label.
+- **Patterns to follow:** `searchVideoSemantic` for row mapping and visibility;
+  `apps/admin/src/services/experience.search.ts` for transaction-scoped
+  `SET LOCAL hnsw.ef_search`.
+- **Test scenarios:**
+  - Default `searchVideoSemantic` still has no `nearest_transcript_chunks` CTE
+    and no pre-collapse `LIMIT`.
+  - Prototype SQL contains a nearest chunk CTE ordered by
+    `vtc.embedding <=> qe.embedding` with a pre-collapse limit.
+  - Prototype SQL keeps language, embedding non-null, provider, model,
+    dimensions, native dimensions, transform-version, and published locale gates.
+  - Prototype SQL applies visibility before the final candidate limit and
+    display/image/dub hydration after the final candidate limit.
+  - Prototype execution records a distinct DB timing label so production logs can
+    compare it with `semantic-video.query`.
+- **Verification:** Focused retriever tests pass and prove the default path did
+  not change.
+
+### U3. Wire the prototype into internal eval search and add parity reporting
+
+- **Goal:** Let operators run production canaries against both semantic modes and
+  compare speed plus result signatures.
+- **Requirements:** R3, R5, R6
+- **Dependencies:** U2
+- **Files:**
+  - `apps/admin/src/services/hybrid-search.service.ts`
+  - `apps/admin/src/services/hybrid-search.service.test.ts`
+  - `apps/admin/src/scripts/search-hnsw-parity.ts`
+  - `apps/admin/package.json`
+- **Approach:** When the internal prototype mode is requested, dispatch the new
+  retriever under a semantic diagnostic branch and skip lexical retrievers. Add a
+  script that calls the internal eval-search endpoint for `semantic-only` and
+  the prototype mode across supplied queries, then emits per-query timing and
+  result signature comparisons.
+- **Patterns to follow:** Internal eval route contract in
+  `apps/admin/src/app/api/internal/search-eval/search/route.ts`; production
+  timing log fields in `apps/admin/src/services/hybrid-search-timing.ts`.
+- **Test scenarios:**
+  - Prototype mode dispatches the HNSW retriever for video content.
+  - Prototype mode does not dispatch keyword, title, or hybrid keyword
+    retrievers.
+  - Existing `semantic-only` behavior still dispatches the default semantic
+    video retriever.
+  - The parity script rejects missing endpoint or auth configuration with a
+    clear error.
+- **Verification:** Focused search service tests pass, and the script can run
+  against a configured internal eval-search endpoint after deployment.
+
+### U4. Preserve the evaluation gate in docs
+
+- **Goal:** Keep the roadmap honest that HNSW-first is still a prototype until
+  parity and speed measurements pass.
+- **Requirements:** R5
+- **Dependencies:** U3
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+  - `docs/solutions/performance-issues/`
+- **Approach:** Update the roadmap and solution note after implementation to
+  record the prototype mode, its parity harness, and the rule that it cannot
+  become default without production result-parity and distinct-video evidence.
+- **Patterns to follow:** `docs/solutions/performance-issues/admin-semantic-db-retrieval-visible-candidate-window.md`.
+- **Test scenarios:** Test expectation: none -- this unit documents the rollout
+  gate rather than runtime behavior.
+- **Verification:** The docs name the prototype as gated follow-up work, not the
+  next default.
+
+---
+
+## Scope Boundaries
+
+- Public Web search, GraphQL input typing, ranking weights, RRF constants,
+  dilution cap behavior, and default `keyword-first` retrieval are out of scope.
+- New indexes and index rebuilds are out of scope because the transcript chunk
+  HNSW indexes already exist.
+- Promotion of HNSW-first to default is out of scope until production parity and
+  distinct-video recall pass.
+- Trace write optimization remains out of scope so timing observability stays
+  available during this experiment.
+
+---
+
+## Risks & Dependencies
+
+- **Recall risk:** A nearest chunk window can contain many chunks from one long
+  video, reducing distinct videos before the per-video collapse.
+- **Planner risk:** HNSW usage still needs production-shaped `EXPLAIN` evidence;
+  SQL shape alone does not prove the planner chose the partial index.
+- **Timing variance:** Production canaries need repeated runs and result
+  signatures so embedding-provider waits and cache effects do not masquerade as
+  database gains.
+- **Internal contract risk:** The internal eval-search route is used for search
+  evaluation tooling, so the prototype mode name must be literal and documented
+  enough for repeatable experiments.
+
+---
+
+## Sources / Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-25-003-perf-admin-search-semantic-db-retrieval-plan.md`
+- `docs/plans/2026-06-25-004-perf-admin-search-pool-fanout-plan.md`
+- `docs/solutions/performance-issues/admin-semantic-db-retrieval-visible-candidate-window.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `docs/solutions/database-issues/set-local-requires-transaction-for-pgvector-search.md`
+- `docs/solutions/platform/admin-transcript-embeddings-vector-reuse-pattern.md`
+- `apps/admin/src/services/hybrid-search-retrievers.ts`
+- `apps/admin/src/services/hybrid-search.service.ts`
+- `apps/admin/src/app/api/internal/search-eval/search/route.ts`

--- a/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
+++ b/docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md
@@ -71,12 +71,17 @@ diversity while losing recall, and degrade semantic relevance.
 - [ ] Close this ticket if the safe slice meets the agreed user-visible latency
       target and preserves result quality; only move to HNSW-first work if the
       timing logs show semantic SQL remains the dominant bottleneck.
+- [ ] Evaluate the internal `semantic-hnsw-prototype` mode against
+      `semantic-only` with repeated production canaries before considering any
+      default-path change.
 
 ## Deferred Follow-Up
 
-- [ ] Prototype HNSW-first transcript windows only with a recall, diversity,
-      and duplicate-heavy Mastra no-regression proof against the current
-      default path.
+- [x] Add an internal-only HNSW-first transcript-window prototype plus a parity
+      harness; keep it out of public/default search modes.
+- [ ] Promote HNSW-first transcript windows only with recall, diversity, and
+      duplicate-heavy Mastra no-regression proof against the current default
+      path.
 - [ ] Prove any HNSW-first rewrite uses HNSW on production-shaped data with
       `EXPLAIN (ANALYZE, BUFFERS)` and end-to-end Admin GraphQL timing under
       representative cold/warm cache states.

--- a/docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md
+++ b/docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md
@@ -1,0 +1,63 @@
+---
+title: "Admin semantic HNSW prototype parity gate"
+date: "2026-06-28"
+category: "performance-issues"
+module: "apps/admin"
+problem_type: "performance_issue"
+component: "search"
+root_cause: "query_shape"
+resolution_type: "prototype"
+severity: "medium"
+tags:
+  - "admin-search"
+  - "semantic-video"
+  - "pgvector"
+  - "hnsw"
+  - "result-parity"
+---
+
+# Admin Semantic HNSW Prototype Parity Gate
+
+## Problem
+
+The exact `semantic-video` query chooses the best transcript chunk per video
+across the full eligible transcript corpus before applying the candidate window.
+That protects recall and diversity, but it prevents pgvector from using the
+existing transcript chunk HNSW indexes as the first retrieval step.
+
+An HNSW-first window can be faster, but it changes which chunks are allowed to
+compete before `DISTINCT ON (video_id)`. One long video can contribute many of
+the nearest chunks and leave too few distinct videos after collapse.
+
+## Solution
+
+Keep the default query exact and add `semantic-hnsw-prototype` as an
+internal-only Search Pipeline Mode. Public callers cannot select it; only
+internal eval search calls with `allowInternalEvalModes: true` can run it.
+
+The prototype:
+
+- uses a nearest transcript chunk window before the per-video collapse;
+- keeps the existing transcript provenance, language, visibility, display,
+  image, dub, and row-mapping rules after that window;
+- records a distinct `semantic-video-hnsw.query` DB timing label;
+- uses transaction-scoped pgvector settings so `SET LOCAL` applies to the query;
+- ships with a parity script that compares `semantic-only` and
+  `semantic-hnsw-prototype` result signatures through the internal eval-search
+  route.
+
+## Promotion Gate
+
+Do not make HNSW-first the default unless production-shaped evidence shows:
+
+- top result signatures match, or any difference is accepted through search eval;
+- distinct-video count stays high enough for duplicate-heavy transcript cases;
+- service and DB timing improve under repeated cold and warm canaries;
+- `EXPLAIN` confirms the HNSW index is used on production-shaped data.
+
+## Related Issues
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/solutions/performance-issues/admin-semantic-db-retrieval-visible-candidate-window.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`
+- `docs/solutions/database-issues/set-local-requires-transaction-for-pgvector-search.md`


### PR DESCRIPTION
## Summary
- add internal-only `semantic-hnsw-prototype` Admin search mode
- add HNSW-first semantic-video retriever behind the internal eval gate
- add parity script for semantic-only vs HNSW prototype result/timing comparisons
- document the promotion gate and keep default search unchanged

## Validation
- `pnpm --filter @forge/admin test -- src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search.service.test.ts src/services/hybrid-search.keyword-first.test.ts src/app/api/internal/search-eval/search/route.test.ts`
- `pnpm --filter @forge/admin test -- src/services/hybrid-search.debug.test.ts src/services/hybrid-search.regression.test.ts src/services/hybrid-search.bible-project.test.ts src/services/hybrid-search.dilution-cap.test.ts`
- `pnpm --filter @forge/admin lint -- src/scripts/search-hnsw-parity.ts src/services/hybrid-search-retrievers.ts src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search.service.ts src/services/hybrid-search.service.test.ts src/services/hybrid-search.keyword-first.test.ts src/services/hybrid-search-timing.ts src/app/api/internal/search-eval/search/route.test.ts`
- `git diff --check`

## Notes
- public callers cannot select the prototype mode
- HNSW prototype uses tagged ``; no `` remains in the prototype retriever
- typecheck is blocked locally by missing Datadog package types in this workspace