### PR TITLE
fix(admin): repair HNSW pgvector settings

### DIFF
--- a/apps/admin/src/services/hybrid-search-retrievers.test.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.test.ts
@@ -88,6 +88,17 @@ function sqlBetween(sql: string, start: string, end: string): string {
   return sql.slice(startIndex, endIndex)
 }
 
+function mockHnswPrototypeQueryRows(
+  prisma: ReturnType<typeof mockPrisma>,
+  rows: unknown[],
+) {
+  prisma.$queryRaw
+    .mockResolvedValueOnce([{ set_config: "200" }])
+    .mockResolvedValueOnce([{ set_config: "relaxed_order" }])
+    .mockResolvedValueOnce([{ set_config: "20000" }])
+    .mockResolvedValueOnce(rows)
+}
+
 describe("searchVideoSemantic", () => {
   let prisma: ReturnType<typeof mockPrisma>
 
@@ -502,7 +513,7 @@ describe("searchVideoSemanticHnswPrototype", () => {
   })
 
   it("returns the same RankedItem-shaped rows as the default semantic retriever", async () => {
-    prisma.$queryRaw.mockResolvedValueOnce([
+    mockHnswPrototypeQueryRows(prisma, [
       {
         video_id: "vid-hnsw",
         video_core_id: "core-hnsw",
@@ -543,7 +554,7 @@ describe("searchVideoSemanticHnswPrototype", () => {
   })
 
   it("records a prototype-specific semantic-video DB timing", async () => {
-    prisma.$queryRaw.mockResolvedValueOnce([])
+    mockHnswPrototypeQueryRows(prisma, [])
     const timing = new SearchTimingRecorder()
 
     await searchVideoSemanticHnswPrototype(
@@ -567,7 +578,7 @@ describe("searchVideoSemanticHnswPrototype", () => {
   })
 
   it("sets HNSW scan knobs inside the transaction before querying", async () => {
-    prisma.$queryRaw.mockResolvedValueOnce([])
+    mockHnswPrototypeQueryRows(prisma, [])
 
     await searchVideoSemanticHnswPrototype(prisma, {
       queryEmbedding: "[0.1,0.2]",
@@ -580,20 +591,37 @@ describe("searchVideoSemanticHnswPrototype", () => {
       expect.objectContaining({ maxWait: 5000, timeout: 20_000 }),
     )
     expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled()
-    expect(prisma.$executeRaw).toHaveBeenCalledTimes(3)
-    expect(prisma.$executeRaw.mock.calls[0]?.[1]).toBe(
-      VIDEO_SEMANTIC_HNSW_EF_SEARCH,
-    )
-    expect(prisma.$executeRaw.mock.calls[1]?.[0].join("")).toContain(
-      "SET LOCAL hnsw.iterative_scan = relaxed_order",
-    )
-    expect(prisma.$executeRaw.mock.calls[2]?.[1]).toBe(
-      VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES,
-    )
+    expect(prisma.$executeRaw).not.toHaveBeenCalled()
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(4)
+
+    const settingCalls = prisma.$queryRaw.mock.calls.slice(0, 3) as Array<
+      [TemplateStringsArray, string, string]
+    >
+    expect(settingCalls).toHaveLength(3)
+    expect(
+      settingCalls.map((call) => (call[0] as TemplateStringsArray).join("")),
+    ).toEqual([
+      expect.stringContaining("SELECT set_config("),
+      expect.stringContaining("SELECT set_config("),
+      expect.stringContaining("SELECT set_config("),
+    ])
+    for (const call of settingCalls) {
+      expect(call[0].join("")).toContain("true")
+    }
+    expect(settingCalls.map((call) => call[1])).toEqual([
+      "hnsw.ef_search",
+      "hnsw.iterative_scan",
+      "hnsw.max_scan_tuples",
+    ])
+    expect(settingCalls.map((call) => call[2])).toEqual([
+      String(VIDEO_SEMANTIC_HNSW_EF_SEARCH),
+      "relaxed_order",
+      String(VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES),
+    ])
   })
 
   it("uses an HNSW-first transcript window before per-video collapse", async () => {
-    prisma.$queryRaw.mockResolvedValueOnce([])
+    mockHnswPrototypeQueryRows(prisma, [])
 
     await searchVideoSemanticHnswPrototype(prisma, {
       queryEmbedding: "[0.1,0.2]",
@@ -630,7 +658,7 @@ describe("searchVideoSemanticHnswPrototype", () => {
   })
 
   it("keeps default semantic gates and bounded hydration in the prototype SQL", async () => {
-    prisma.$queryRaw.mockResolvedValueOnce([])
+    mockHnswPrototypeQueryRows(prisma, [])
 
     await searchVideoSemanticHnswPrototype(prisma, {
       queryEmbedding: "[0.1,0.2]",

--- a/apps/admin/src/services/hybrid-search-retrievers.ts
+++ b/apps/admin/src/services/hybrid-search-retrievers.ts
@@ -62,6 +62,18 @@ export const VIDEO_SEMANTIC_HNSW_EF_SEARCH = 200
 export const VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES = 20_000
 export const VIDEO_SEMANTIC_HNSW_TRANSACTION_TIMEOUT_MS = 20_000
 
+type PgSetConfigRow = { set_config: string }
+
+async function setLocalHnswConfig(
+  tx: Pick<Prisma.TransactionClient, "$queryRaw">,
+  name: string,
+  value: string,
+): Promise<void> {
+  await tx.$queryRaw<PgSetConfigRow[]>`
+    SELECT set_config(${name}, ${value}, true)
+  `
+}
+
 export function calculateVideoSemanticMixedScore(
   sourceScores: readonly number[],
 ): number {
@@ -499,9 +511,17 @@ export async function searchVideoSemanticHnswPrototype(
 
   const evidenceRows = await prisma.$transaction(
     async (tx) => {
-      await tx.$executeRaw`SET LOCAL hnsw.ef_search = ${VIDEO_SEMANTIC_HNSW_EF_SEARCH}`
-      await tx.$executeRaw`SET LOCAL hnsw.iterative_scan = relaxed_order`
-      await tx.$executeRaw`SET LOCAL hnsw.max_scan_tuples = ${VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES}`
+      await setLocalHnswConfig(
+        tx,
+        "hnsw.ef_search",
+        String(VIDEO_SEMANTIC_HNSW_EF_SEARCH),
+      )
+      await setLocalHnswConfig(tx, "hnsw.iterative_scan", "relaxed_order")
+      await setLocalHnswConfig(
+        tx,
+        "hnsw.max_scan_tuples",
+        String(VIDEO_SEMANTIC_HNSW_MAX_SCAN_TUPLES),
+      )
 
       return recordSearchDbTiming(
         timing,

--- a/docs/plans/2026-06-28-002-fix-admin-hnsw-set-config-plan.md
+++ b/docs/plans/2026-06-28-002-fix-admin-hnsw-set-config-plan.md
@@ -1,0 +1,157 @@
+---
+title: "fix: Repair Admin HNSW prototype pgvector settings"
+type: "fix"
+date: "2026-06-28"
+execution: "code"
+---
+
+# fix: Repair Admin HNSW prototype pgvector settings
+
+## Summary
+
+Repair the internal Admin `semantic-hnsw-prototype` path so its transaction-local
+pgvector settings are applied through parameter-safe SQL before the HNSW query
+runs. The default semantic, keyword-first, and hybrid search paths remain
+unchanged while the production parity harness rechecks speed and result quality.
+
+---
+
+## Problem Frame
+
+The production parity run for PR 1407 showed apparent HNSW speed, but the
+prototype returned zero results because the retriever failed before the real
+query. Postgres rejected Prisma's tagged `$executeRaw` form for `SET LOCAL`
+utility statements with placeholders, producing `syntax error at or near "$1"`.
+The fix must keep the earlier security improvement of avoiding
+`$executeRawUnsafe` while allowing the prototype query to reach the database.
+
+---
+
+## Requirements
+
+- R1. The HNSW prototype must apply `hnsw.ef_search`,
+  `hnsw.iterative_scan`, and `hnsw.max_scan_tuples` within the same transaction
+  as the prototype query.
+- R2. The implementation must avoid `$executeRawUnsafe` and avoid placeholder
+  use in unsupported `SET LOCAL` utility statements.
+- R3. The default `semantic-video` query and public search modes must remain
+  behaviorally unchanged.
+- R4. Focused tests must fail on the old `SET LOCAL $1` shape and prove the
+  HNSW DB timing records the real prototype query.
+- R5. After merge and deploy, production parity canaries must compare exact
+  semantic and HNSW prototype result signatures plus timing.
+
+---
+
+## Key Technical Decisions
+
+- **Use `set_config` instead of `SET LOCAL`:** PostgreSQL exposes
+  `set_config(name, value, is_local)` as a normal expression, so Prisma can
+  parameterize the setting name and value safely. Passing `true` for `is_local`
+  preserves the transaction-local behavior that `SET LOCAL` was meant to give.
+- **Keep the prototype internal-only:** This is a repair of the eval path, not a
+  promotion of HNSW-first retrieval. Public modes and the default exact semantic
+  retriever stay untouched.
+- **Make tests inspect the setting calls:** The mock-Prisma tests should assert
+  the first three transaction queries are `set_config` calls and the last query
+  is the timed `semantic-video-hnsw.query` retrieval.
+
+---
+
+## Implementation Units
+
+### U1. Replace failing `SET LOCAL` calls with transaction-local `set_config`
+
+- **Goal:** Let the HNSW prototype apply pgvector settings safely and reach its
+  retrieval SQL.
+- **Requirements:** R1, R2, R3
+- **Dependencies:** none
+- **Files:**
+  - `apps/admin/src/services/hybrid-search-retrievers.ts`
+- **Approach:** Change the HNSW transaction setup to call parameterized
+  `SELECT set_config(...)` statements before the existing timed raw query. Keep
+  the existing prototype constants, transaction timeout, timing label, and SQL
+  retrieval shape.
+- **Patterns to follow:** Existing transaction-scoped HNSW setting intent in
+  `searchVideoSemanticHnswPrototype`; existing DB timing wrapper in
+  `recordSearchDbTiming`.
+- **Test scenarios:**
+  - The prototype transaction issues three `set_config` statements before the
+    retrieval query.
+  - The setting values match the existing HNSW constants.
+  - `$executeRawUnsafe` and `SET LOCAL` are not used by the prototype.
+- **Verification:** Focused retriever tests prove the transaction setup and
+  timing label.
+
+### U2. Update the HNSW retriever tests for the repaired query flow
+
+- **Goal:** Catch this specific Prisma/Postgres utility-statement failure in
+  future changes.
+- **Requirements:** R2, R4
+- **Dependencies:** U1
+- **Files:**
+  - `apps/admin/src/services/hybrid-search-retrievers.test.ts`
+- **Approach:** Add a helper that mocks the three `set_config` calls before the
+  final HNSW query result. Update the scan-knob test to inspect `set_config`
+  query text and parameters instead of `$executeRaw`.
+- **Patterns to follow:** Existing `latestRawSqlWithFragments` helpers and
+  HNSW prototype SQL-shape assertions.
+- **Test scenarios:**
+  - The DB timing test still records one fulfilled
+    `semantic-video-hnsw.query` timing for the retrieval query.
+  - HNSW SQL-shape tests continue reading the final raw query, not the setting
+    calls.
+  - The scan-knob test proves all settings are local and parameterized.
+- **Verification:** Focused retriever test suite passes.
+
+### U3. Merge, deploy, and rerun production parity canaries
+
+- **Goal:** Confirm whether the repaired HNSW prototype is a real speed
+  improvement and whether results match the exact path closely enough to keep
+  evaluating.
+- **Requirements:** R3, R5
+- **Dependencies:** U1, U2
+- **Files:**
+  - `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+  - `docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md`
+- **Approach:** Merge the fix after validation, wait for the Admin production
+  deployment, rerun the existing parity script for `the bible project`,
+  `jesus`, and `hope when life is hard`, and compare client timings, service
+  timings, result counts, top result IDs, and parity flags against the failing
+  run.
+- **Patterns to follow:** Prior production HNSW parity run artifacts under
+  `/tmp/prod-search-hnsw-parity-20260628*` and the roadmap's eval gate.
+- **Test scenarios:** Test expectation: none -- this unit is operational
+  validation after deploy rather than repo behavior.
+- **Verification:** The final report includes deployment status, timing
+  comparison, and result-parity outcome.
+
+---
+
+## Scope Boundaries
+
+- Do not promote `semantic-hnsw-prototype` to a public or default search mode.
+- Do not change ranking weights, row-window constants, RRF behavior, trace
+  writes, or DB pool settings in this fix.
+- Do not treat faster zero-result failure as a speed win; only successful HNSW
+  retrievals count.
+
+---
+
+## Risks & Dependencies
+
+- **Result-quality risk:** Once the prototype actually runs, it may still fail
+  parity because HNSW-first windowing can reduce distinct videos.
+- **Planner risk:** A successful query does not prove the HNSW index is chosen;
+  production `EXPLAIN` remains a separate promotion gate.
+- **Deployment dependency:** The parity rerun depends on the Admin production
+  deployment completing after merge.
+
+---
+
+## Sources & Research
+
+- `docs/roadmap/content-discovery/feat-175-admin-semantic-search-latency.md`
+- `docs/plans/2026-06-28-001-perf-admin-search-hnsw-prototype-plan.md`
+- `docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md`
+- `docs/solutions/performance-issues/pgvector-hnsw-index-bypass-with-where-filter-20260415.md`

--- a/docs/solutions/database-issues/set-local-requires-transaction-for-pgvector-search.md
+++ b/docs/solutions/database-issues/set-local-requires-transaction-for-pgvector-search.md
@@ -1,49 +1,103 @@
 ---
-title: "PostgreSQL SET LOCAL has no effect outside a transaction — wrap with $transaction for pgvector ef_search tuning"
+title: "PostgreSQL SET LOCAL with Prisma requires transaction scope and set_config for dynamic values"
 category: database-issues
 date: 2026-04-14
+last_updated: 2026-06-28
+module: apps/admin
+problem_type: database_issue
+component: database
+symptoms:
+  - "SET LOCAL outside an explicit Prisma transaction expires before the search query"
+  - "Parameterized SET LOCAL through Prisma can fail with syntax error at or near $1"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
 tags:
   - postgresql
   - pgvector
   - prisma
   - admin
-problem_type: runtime_error
-component: apps/admin/src/services/experience.search.ts
 ---
+
+# PostgreSQL SET LOCAL with Prisma requires transaction scope and set_config for dynamic values
 
 ## Problem
 
-The pgvector search service set `hnsw.ef_search` (recall tuning) via a
-separate Prisma call before the search query:
+PostgreSQL session settings for pgvector search have two Prisma-specific
+failure modes. First, `SET LOCAL` only affects the current transaction, so a
+standalone Prisma call expires before the following search query. Second,
+Postgres utility statements such as `SET LOCAL hnsw.ef_search = $1` do not
+accept bind placeholders in the value position, so Prisma tagged templates can
+turn a transaction-scoped fix into a syntax error.
+
+## Symptoms
+
+- A pgvector setting call before the search query appears to succeed, but the
+  following query runs without the intended setting.
+- The Admin HNSW prototype returned zero results and logged
+  `ERROR: syntax error at or near "$1"` before the timed retrieval query ran.
+- Timing reports can look fast when the retriever rejected early; count those as
+  failed retrievals, not search speed wins.
+
+## What Didn't Work
+
+### Standalone `SET LOCAL`
+
+The original pgvector search service set `hnsw.ef_search` via a separate Prisma
+call before the search query:
 
 ```ts
 await this.prisma.$executeRawUnsafe(`SET LOCAL hnsw.ef_search = 40`)
 await this.prisma.$queryRaw`SELECT ... ORDER BY embedding <=> ...`
 ```
 
-This silently did nothing. `SET LOCAL` only persists within an explicit
-transaction block. Outside a transaction, each Prisma call runs in its
-own auto-committed implicit transaction, and the SET LOCAL expired
-immediately. The two calls also ran on potentially different pooled
-connections.
+This silently did nothing because each Prisma call runs in its own
+auto-committed implicit transaction and may use a different pooled connection.
+
+### Parameterized `SET LOCAL` inside the transaction
+
+Wrapping the calls in an interactive transaction fixed the connection and
+transaction scope, but this shape can still fail:
+
+```ts
+await tx.$executeRaw`SET LOCAL hnsw.ef_search = ${safeEfSearch}`
+```
+
+Prisma binds the interpolated value as a placeholder, producing a utility
+statement shape like `SET LOCAL hnsw.ef_search = $1`. Postgres rejects that
+shape with `syntax error at or near "$1"`.
 
 ## Root cause
 
-PostgreSQL docs: "SET LOCAL can only be used inside a transaction block;
-otherwise it has no effect, since the transaction would end immediately."
-
-Prisma's `$executeRaw` and `$queryRaw` each acquire a connection from the
-pool, run one statement, then release. Without an explicit `$transaction`,
-the SET LOCAL's scope is a single auto-committed statement.
+PostgreSQL local settings are transaction-scoped, while Prisma raw-query calls
+outside `$transaction` are separate statements on pooled connections. For
+dynamic values, Prisma's safe interpolation creates bind placeholders, but
+PostgreSQL does not support placeholders in the `SET LOCAL` utility statement
+position used for pgvector settings.
 
 ## Solution
 
-Wrap both the SET LOCAL and the search query in a Prisma interactive
-transaction:
+Wrap the setting calls and the search query in one Prisma interactive
+transaction. When the setting value is dynamic or you want to stay fully
+parameterized, use PostgreSQL's `set_config(name, value, is_local)` function
+instead of `SET LOCAL`:
 
 ```ts
-const hits = await this.prisma.$transaction(async (tx) => {
-  await tx.$executeRaw`SET LOCAL hnsw.ef_search = ${safeEfSearch}`
+type PgSetConfigRow = { set_config: string }
+
+async function setLocalHnswConfig(
+  tx: Pick<Prisma.TransactionClient, "$queryRaw">,
+  name: string,
+  value: string,
+): Promise<void> {
+  await tx.$queryRaw<PgSetConfigRow[]>`
+    SELECT set_config(${name}, ${value}, true)
+  `
+}
+
+const hits = await prisma.$transaction(async (tx) => {
+  await setLocalHnswConfig(tx, "hnsw.ef_search", String(safeEfSearch))
+
   return tx.$queryRaw<SearchHit[]>`
     SELECT el.id, el.embedding <=> ${pgVector}::vector AS distance
     FROM experience_locale el
@@ -54,20 +108,30 @@ const hits = await this.prisma.$transaction(async (tx) => {
 })
 ```
 
-The interactive transaction ensures both statements run on the same
-connection within the same transaction block, so SET LOCAL applies to the
-search query.
+The interactive transaction ensures the setting and query share one connection
+and transaction. `set_config(..., true)` gives the same local lifetime as
+`SET LOCAL`, while still allowing Prisma to bind the setting name and value
+safely.
 
 ## Prevention
 
 Any time you need a PostgreSQL session-level setting to apply to a
-subsequent query (SET LOCAL, SET search_path, SET statement_timeout):
+subsequent query (`SET LOCAL`, `SET search_path`, `SET statement_timeout`, or
+pgvector HNSW knobs):
 
 - Always wrap both statements in `prisma.$transaction(async (tx) => ...)`
-- Never rely on separate `$executeRaw` + `$queryRaw` calls outside a
-  transaction — they may not even hit the same connection
+- For dynamic setting values, prefer `SELECT set_config(${name}, ${value}, true)`
+  over interpolated `SET LOCAL ... = ${value}`
+- Reserve literal `SET LOCAL` strings for fully static, trusted statements
+- Add tests that assert the setting call is inside the transaction and that the
+  timed query actually runs after the setting calls
+- Treat fast zero-result timing from a rejected retriever as a failed
+  experiment, not a performance improvement
 
 ## Related
 
 - `apps/admin/src/services/experience.search.ts` — the fixed search
-- PostgreSQL docs on SET LOCAL
+- `apps/admin/src/services/hybrid-search-retrievers.ts` — HNSW prototype uses
+  transaction-local `set_config` for pgvector tuning
+- `docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md`
+- PostgreSQL docs on `SET LOCAL` and `set_config`

--- a/docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md
+++ b/docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md
@@ -41,7 +41,8 @@ The prototype:
 - keeps the existing transcript provenance, language, visibility, display,
   image, dub, and row-mapping rules after that window;
 - records a distinct `semantic-video-hnsw.query` DB timing label;
-- uses transaction-scoped pgvector settings so `SET LOCAL` applies to the query;
+- uses transaction-scoped `set_config(..., true)` pgvector settings so Prisma can
+  bind values safely and keep them local to the query transaction;
 - ships with a parity script that compares `semantic-only` and
   `semantic-hnsw-prototype` result signatures through the internal eval-search
   route.


### PR DESCRIPTION
## Summary

The HNSW prototype now reaches its real retrieval query instead of failing during pgvector setup. Prisma was binding interpolated `SET LOCAL` values into a utility statement shape Postgres rejects, so the transaction setup now uses `SELECT set_config(name, value, true)` for the HNSW knobs.

This keeps the prototype internal-only and leaves the default semantic, keyword-first, and hybrid search paths unchanged. The docs now capture the sharper Prisma/Postgres lesson: transaction scope is necessary, and dynamic local settings should use `set_config` rather than parameterized `SET LOCAL`.

## Validation

- `pnpm --filter @forge/admin test -- src/services/hybrid-search-retrievers.test.ts src/services/hybrid-search.service.test.ts src/services/hybrid-search.keyword-first.test.ts src/app/api/internal/search-eval/search/route.test.ts`
- `pnpm --filter @forge/admin lint -- src/services/hybrid-search-retrievers.ts src/services/hybrid-search-retrievers.test.ts`
- `git diff --check`
- `python3 .../validate-frontmatter.py docs/solutions/database-issues/set-local-requires-transaction-for-pgvector-search.md`
- `python3 .../validate-frontmatter.py docs/solutions/performance-issues/admin-semantic-hnsw-prototype-parity-gate.md`

`pnpm --filter @forge/admin typecheck` is blocked in this local workspace by missing Datadog packages: `@datadog/browser-rum`, `@datadog/browser-rum-react`, and `dd-trace`.

## Post-Deploy Monitoring & Validation

- Run the internal HNSW parity canaries in production for `the bible project`, `jesus`, and `hope when life is hard`, comparing `semantic-only` against `semantic-hnsw-prototype`.
- Watch Railway/Admin logs for `[search] event=search_timing`, `semantic-video.query`, `semantic-video-hnsw.query`, retriever rejection/degraded outcomes, and `search] semantic-video retrieval failed` messages.
- Healthy signals: HNSW result counts are nonzero, `semantic-video-hnsw.query` DB timings are present, no `syntax error at or near "$1"`, and result signatures are close enough for the parity gate to continue.
- Failure signals: HNSW returns zero results, retriever status is rejected/degraded, parity collapses on top IDs/snippets, or DB timing disappears. Because the mode is internal-only, mitigation is to keep default search unchanged and not promote the prototype; code rollback is available if the internal eval path blocks further testing.
- Validation window/owner: immediately after the Admin production deployment succeeds; owner is this follow-up evaluation run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
