### PR TITLE
docs(ai-chat): re-scope feat-202 seeker RAG runtime hardening

### DIFF
--- a/docs/brainstorms/2026-06-29-seeker-rag-runtime-hardening-requirements.md
+++ b/docs/brainstorms/2026-06-29-seeker-rag-runtime-hardening-requirements.md
@@ -1,0 +1,221 @@
+# Seeker RAG runtime hardening (feat-202) — requirements
+
+**Date:** 2026-06-29
+**Ticket:** `docs/roadmap/ai-chat/feat-202-seeker-rag-runtime-hardening.md`
+**Status of this doc:** scoping decided; ready for `ce-plan`.
+**Worktree:** `feat/seeker-rag-runtime-hardening`
+
+## Problem
+
+The feat-198/feat-199 seeker skeleton shipped clean for a Studio-only,
+release-gated prototype. A code review surfaced three latent defense-in-depth
+gaps. An investigation against the live code (2026-06-29) reshaped the ticket:
+build the RAG byte-cap (①) and a default agent step budget + routing-convention
+note (③); defer the in-memory eviction (②) to feat-208, where moving to Postgres
+eliminates its underlying risk. This doc records that scoping so planning builds
+the small, correct version rather than the ticket's original three-item,
+two-client shape.
+
+Context that bounds urgency: the RAG upstream is a trusted, host-allowlisted,
+bearer-authed first-party service; the seeker is Studio-only and reachable only
+behind the `apps/mastra-gateway` + Railway network boundary. None of the three
+items is a live, externally-triggerable bug today.
+
+## Decisions
+
+### Build now — ① byte-cap the RAG response body (RAG client only)
+
+`apps/mastra/src/services/jesusfilm-rag-client.ts` reads `await response.json()`
+on both the success body (`:217`, before the `.slice(0, RAG_TOP_K)` at `:235`)
+and the error path (`readUpstreamReason`, `:123`) with no size guard. The whole
+upstream body is buffered into the heap **before** any slicing applies; the
+file's header comment claims protection against "huge bodies" that only holds
+post-parse. A misbehaving (not necessarily hostile) upstream returning a
+multi-GB body — or a fast large body inside the 5s timeout — can OOM the single
+Node process that runs **every** Mastra agent and workflow.
+
+This is the keeper because, unlike the other two, its value is **independent of
+the seeker's exposure level**: even Studio-only, a buggy RAG response can OOM the
+shared process. It also doesn't get superseded by any other ticket.
+
+Requirements:
+
+- Bound the buffered read at a max-bytes ceiling, applied to **both** uncapped
+  read sites — the success body (`:217`) and the error path (`readUpstreamReason`,
+  `:123`) — since a multi-GB _error_ body OOMs the shared process identically to a
+  success body. Stream the body with a byte counter rather than trusting
+  `Content-Length` alone (the header can be absent or wrong).
+- A body over the cap maps to the **existing** graceful failure
+  (`parse_error` → agent surfaces `unavailable`), never a throw — the typed
+  no-throw result-union contract and the `{ status, sources, message? }` tool
+  shape are unchanged.
+- Default ceiling: a sane low single-digit MB. Any new env knob is `.optional()`
+  with a runtime fallback — **zero** new required-at-boot env vars (the skeleton
+  added none; a required var with no default bricks Railway deploys).
+
+### Deferred — ② in-memory `Memory` eviction (superseded by feat-208)
+
+`getSeekerMemory()` (`apps/mastra/src/mastra/memory.ts:84`) is an unbounded
+process-lifetime `InMemoryStore` singleton — no `lastMessages` cap, no TTL.
+Sustained traffic across many `threadId`s grows heap until a restart.
+
+**Not built here, and not ported into feat-208.** feat-208 moves seeker memory
+from RAM to Postgres along the path the same file already proves for
+experience-chat (`buildExperienceChatMemory`, `memory.ts:293`); the seeker's own
+header calls this module _"the single-responsibility seam where the eventual
+in-memory → Postgres/PgVector swap lands later."_ Once memory lives in Postgres,
+the specific risk #2 guards against — RAM growing until the shared process OOMs —
+**is eliminated, not relocated**: history lives on disk, not the Node heap.
+
+What survives is milder and native to feat-208: unbounded growth downgrades to
+_more rows in a table_ (disk + query cost), a routine retention concern handled
+with an ordinary TTL/prune policy when designing the persistent store — **not** a
+port of in-memory eviction code. Note also that Mastra's `lastMessages` cap
+bounds per-thread context, not thread _count_, so it wouldn't even fully address
+the stated thread-count risk; Postgres retention is the right home.
+
+Interim risk is low but not zero. ③ notes any _in-network_ caller can reach the
+agent — so the store isn't strictly "operator test threads only" — but the seeker
+is still network-gated (not public) and the `InMemoryStore` is wiped on every
+deploy, so threads accumulate only within a single deploy window and only from
+first-party/dogfooding traffic. No stopgap is built.
+
+**Deferral precondition + tripwire.** Deferring ② is safe only if feat-208 both
+(a) lands and (b) keeps conversation history off the Node heap (the Postgres
+move). The observable trigger to revisit an interim in-memory guard is exposure
+change, not a traffic metric (the store is wiped every deploy, so there is no
+persistent counter to watch): revisit if feat-208 is not in-progress by the time
+feat-202 ships, **or** if the seeker is promoted beyond Studio/dogfooding
+exposure — whichever comes first.
+
+> **Hand-off to feat-208:** when designing the Postgres-backed seeker memory,
+> decide _whether_ a retention/prune policy is needed at all (thread TTL and/or
+> per-thread message cap) — keeping all conversations indefinitely is a valid
+> choice. Non-binding; the heap-OOM risk is gone with Postgres, leaving only
+> ordinary table growth. This is the only residue of feat-202 #2.
+
+### Build now — ③ default step budget on the agent + a routing convention note
+
+`seeker-agent.ts` has no `maxSteps` on the `Agent` constructor. The
+production-shaped path already enforces a ceiling — `/forge-seeker`
+(`seeker-route.ts:272,198`) sets `maxSteps: STEP_CAPS.toolCallingTurn` (8) +
+`budgetMs = TIME_BUDGET_MS.chatTurn` (90s), and `JESUSFILM_RAG_TIMEOUT_MS`
+defaults to 5s (`.max(30_000)`), so 5s ≪ 90s holds — but that budget lives at the
+_route call site_, not on the agent.
+
+The gap (corrected framing): Mastra's built-in `/api/agents/seekerAgent` surface
+is **code-unauthenticated** (`seeker-route.ts:19` calls `/forge-seeker` _"MORE
+locked down than Mastra's built-in unauthenticated `/api/agents/_`"*) and carries
+**no budget**. The only thing gating it is network reachability to the Mastra
+runtime — and our own apps already have that (the chat app calls `/forge-seeker`
+on the same runtime). So **any in-network caller** could call the agent directly
+and bypass the route's budget, not just Studio operators. That is worth a default
+floor.
+
+Two pieces:
+
+1. **A code floor** — set `defaultOptions: { maxSteps: STEP_CAPS.toolCallingTurn }`
+   on the seeker `Agent` constructor, reusing the **same** shared constant the
+   route uses (one source of truth; the two paths can't diverge).
+2. **A routing convention** — a short note in `apps/mastra/CLAUDE.md` (next to the
+   seeker "Containment" / "Service route" sections): apps and services must call
+   the bearer-gated `/forge-seeker` route, **never** the built-in
+   `/api/agents/seekerAgent` surface, which is unauthenticated and unbudgeted.
+
+Neither piece is an _enforcement_ control: the floor is overridable (below) and
+the note is honor-system. They do not close the unauthenticated surface — the
+binding containment is and stays the network/gateway boundary; these are
+defense-in-depth and drift-prevention on top of it. (A CI grep asserting no
+first-party caller references `/api/agents/seekerAgent` could harden the
+convention into a real check; deferred, not built here.)
+
+Verified the floor is not cosmetic (against installed `@mastra/core@1.36.0` +
+`@mastra/server@1.36.0`): the built-in vNext handlers call `agent.stream()` /
+`agent.generate()` (distinct from the `*Legacy` variants), and core's
+`stream()`/`generate()` both `deepMerge(getDefaultOptions(), perCallOptions)`
+with the per-call value winning — so a call that omits `maxSteps` inherits the
+constructor default. Two qualifications:
+
+- It is a **default floor, not an un-overridable ceiling**: deep-merge lets an
+  explicit per-call `maxSteps` win, so a caller that _explicitly_ sends a huge
+  value still overrides it. This protects the realistic case (Studio, or an app
+  that bypasses the route without thinking), the same property the route's budget
+  has — not a hard cap against a determined caller on the open path.
+- Set it on **`defaultOptions`** (the vNext field the seeker's `.stream()` uses),
+  **not** `defaultStreamOptionsLegacy` (which feeds only the unused legacy routes).
+
+This covers the step (runaway-loop) dimension only. The direct `/api/agents/*`
+path retains **no wall-clock bound**: the 90s budget is composed per-request at
+the route call site and can't ride on a constructor default, and the per-tool
+`JESUSFILM_RAG_TIMEOUT_MS` (5s default, `.max(30_000)` — so even the worst case
+is well under 90s) bounds only the RAG **tool legs**, _not_ the LLM-generation
+turns between them, which stay uncapped on this path. So step-capping does **not**
+make the direct path time-bounded — a slow or stalled model turn within 8 steps
+can hold the shared process past 90s. The step floor is defense-in-depth against
+runaway loops, not a latency guard; the binding containment on the direct path
+remains the network/gateway boundary (see the routing convention below).
+
+### firecrawl-client's identical gap — noted, no separate ticket
+
+`apps/mastra/src/services/firecrawl-client.ts` has the same uncapped
+`await response.json()` (`:212`, `:329`). It is **deliberately not touched** by
+feat-202: firecrawl is out of the AI-chat lane, its work is unrelated, and the
+shared helpers (`endpoint` / `safeReason` / `readUpstreamReason`) were
+intentionally duplicated, not extracted (rag client header, `:27`). Extracting
+them into a shared module would couple an out-of-lane client into chat-lane work
+for no chat-lane benefit — the wrong abstraction. Recorded here as a known
+residual per the owner's choice; no follow-up ticket created.
+
+To be explicit about the risk (not just the ownership): the firecrawl OOM
+exposure is **real and identical to ①'s** — exposure-independent, against the
+same shared Node process — so this is _not_ a claim that firecrawl is safe. It is
+a scope decision. The build/accept split here is **organizational, not
+risk-tiered**: firecrawl carries an identical risk and would equally merit a cap —
+it is left to its owners purely because cross-lane scope expansion costs more than
+the chat lane should absorb, _not_ because its risk is lower. So the risk is
+consciously **accepted and left to the firecrawl owners**, not feat-202's to fix:
+feat-202 deliberately neither caps nor extracts firecrawl and opens no ticket on
+another lane's behalf; the observation is flagged here so it isn't lost (the
+original feat-202 ticket already noted the shared "fix both clients" pattern, so
+the owners have prior awareness).
+
+## Scope boundaries
+
+**In scope:** byte-cap on `jesusfilm-rag-client.ts` only; a default
+`maxSteps` (`defaultOptions`, shared `STEP_CAPS.toolCallingTurn`) on the seeker
+`Agent`; a `/forge-seeker`-not-`/api/agents` routing-convention note in
+`apps/mastra/CLAUDE.md`; tests for the oversized-body → `unavailable` path and a
+confirm-the-default test for `maxSteps`.
+
+**Out of scope:** any change to `firecrawl-client.ts`; extracting shared HTTP
+helpers; in-memory memory eviction; a per-request wall-clock budget on the
+direct `/api/agents/*` path; any new required env var; any change to the
+no-throw result-union or tool-result shape.
+
+## Verification
+
+- `pnpm --filter @forge/mastra test` — add cases where an oversized body maps to
+  the graceful `unavailable` path on **both** the success body and the error path
+  (`readUpstreamReason`). Test against the real over-cap behavior, not just a
+  mocked branch.
+- `pnpm --filter @forge/mastra typecheck && pnpm --filter @forge/mastra lint`.
+- Grep `response.json()` in `apps/mastra/src/services/jesusfilm-rag-client.ts`
+  and confirm every call site is byte-bounded.
+- **`maxSteps` default takes effect:** invoke the seeker agent with no per-call
+  `maxSteps` and assert the constructor default applies (confirm-expected-pass —
+  the production server is re-bundled at `mastra build`, so verify against the
+  built path, not just the installed dist).
+- Confirm `apps/mastra/CLAUDE.md` carries the `/forge-seeker`-not-`/api/agents`
+  routing-convention note (③'s second deliverable), next to the seeker
+  Containment / Service route sections.
+- Confirm no new entry in the production `missing` env list in
+  `assertMastraRuntimeEnv` (no new boot requirement).
+
+## Outstanding questions
+
+- **Streamed read vs `Content-Length` + bounded read** — left to planning; lean
+  streamed-with-byte-counter since the header is absent/spoofable.
+- **Exact default cap** (e.g. 2–5 MB) — pick a concrete number in planning, sized
+  comfortably above a _measured or contract-derived_ upper bound for a legitimate
+  `topK=5` passage payload (≈ max passage text × 5 + citation overhead), not
+  chosen by intuition — so the cap can't reject valid retrievals as `unavailable`.

--- a/docs/roadmap/ai-chat/README.md
+++ b/docs/roadmap/ai-chat/README.md
@@ -11,12 +11,12 @@ from the main DS Year 1 roadmap.
 > index, and nothing regenerates or overwrites it. See `CLAUDE.md` in this
 > folder for the maintenance rules and why the lane is unregistered.
 
-## Status (June 26, 2026)
+## Status (June 29, 2026)
 
 - **Total tickets:** 12
 - ✅ **Complete:** 8
-- 🟡 **In progress:** 0
-- 🔵 **Not started:** 3
+- 🟡 **In progress:** 1
+- 🔵 **Not started:** 2
 - 🔴 **Blocked:** 1
 
 ## Feature Index
@@ -27,7 +27,7 @@ from the main DS Year 1 roadmap.
 | [feat-199](feat-199-seeker-rag-retrieval-connection.md)      | Seeker Agent RAG Retrieval Connection                       | jian wei | P2       | 2026-06-10 | 3    | ✅ complete    | #1279   |
 | [feat-200](feat-200-chat-app-scaffold.md)                    | Chat app scaffold with stubbed agent                        | jian wei | P1       | 2026-06-10 | 3    | ✅ complete    | #1276   |
 | [feat-201](feat-201-chat-app-vigil-reskin.md)                | Chat app Vigil re-skin + conversation shell                 | jian wei | P1       | 2026-06-15 | 1    | ✅ complete    | #1276   |
-| [feat-202](feat-202-seeker-rag-runtime-hardening.md)         | Seeker RAG runtime hardening                                | jian wei | P2       | 2026-06-18 | 2    | 🔵 not-started | —       |
+| [feat-202](feat-202-seeker-rag-runtime-hardening.md)         | Seeker RAG runtime hardening                                | jian wei | P2       | 2026-06-18 | 1    | 🟡 in-progress | —       |
 | [feat-203](feat-203-chat-sidebar-component-extraction.md)    | Chat sidebar component + behavior extraction                | jian wei | P2       | 2026-07-01 | 2    | ✅ complete    | #1368   |
 | [feat-204](feat-204-expose-seeker-mastra-service-route.md)   | Expose Seeker agent via internal Mastra SSE service route   | jian wei | P2       | 2026-06-24 | 3    | ✅ complete    | #1371   |
 | [feat-205](feat-205-chat-wire-seeker-route.md)               | Wire chat app to the Seeker Mastra route                    | jian wei | P1       | 2026-06-27 | 3    | ✅ complete    | #1384   |

--- a/docs/roadmap/ai-chat/feat-202-seeker-rag-runtime-hardening.md
+++ b/docs/roadmap/ai-chat/feat-202-seeker-rag-runtime-hardening.md
@@ -1,11 +1,11 @@
 ---
 id: "feat-202"
-title: "Seeker RAG runtime hardening — body byte-cap, memory eviction, agent step/timeout budget"
+title: "Seeker RAG runtime hardening — RAG response byte-cap + agent step-budget floor"
 owner: "jian wei"
 priority: "P2"
-status: "not-started"
+status: "in-progress"
 start_date: "2026-06-18"
-duration: 2
+duration: 1
 depends_on: []
 blocks: []
 tags:
@@ -16,101 +16,109 @@ tags:
 ## Problem
 
 The feat-198/feat-199 seeker skeleton (PR #1279) shipped clean for a Studio-only,
-release-gated prototype, but a code review surfaced three latent
-defense-in-depth gaps in the runtime path. None blocks the skeleton, none is
-externally triggerable today (the RAG upstream is a trusted, host-allowlisted,
-bearer-authed first-party service and the agent is network-gated), but all three
-should be closed before the seeker is promoted toward a real, higher-traffic, or
-public surface. Tracking them together so they aren't lost.
+release-gated prototype, but a code review surfaced three latent defense-in-depth
+gaps. A scoping investigation (2026-06-29) reshaped the ticket — see
+`docs/brainstorms/2026-06-29-seeker-rag-runtime-hardening-requirements.md` for the
+full rationale and the two-round doc review behind it. Net:
 
-1. **Unbounded response-body ingress (shared with firecrawl-client).** Both
-   single-service HTTP clients call `await response.json()` with no
-   `Content-Length` / max-bytes guard — the full upstream body is buffered into
-   the heap _before_ `RAG_TOP_K`/`MAX_PASSAGE_CODEPOINTS` slicing applies. A
-   misbehaving (not necessarily hostile) upstream returning a multi-GB body, or
-   a fast large body inside the 5s timeout, can OOM the single Node process that
-   runs **every** Mastra agent and workflow. The client header comment claims
-   protection against "huge bodies" that only holds post-parse.
+1. **Build now — RAG response byte-cap.** Both reads in
+   `jesusfilm-rag-client.ts` (`await response.json()`) buffer the full upstream
+   body into the heap before slicing. A misbehaving (not hostile) upstream
+   returning a multi-GB body can OOM the single Node process that runs **every**
+   Mastra agent and workflow — a risk independent of the seeker's exposure level,
+   so worth closing now.
+2. **Deferred to feat-208 — in-memory `Memory` eviction.** `getSeekerMemory()` is
+   an unbounded process-lifetime `InMemoryStore`, but feat-208 moves seeker memory
+   to Postgres, which **eliminates** the heap-OOM risk rather than relocating it.
+   Building in-memory eviction now would be throwaway. Not built here; see the
+   retention note on feat-208.
+3. **Build now — agent step-budget floor.** The `/forge-seeker` route already
+   sets `maxSteps`/budget, but the code-unauthenticated built-in
+   `/api/agents/seekerAgent` surface (reachable by any in-network caller) runs the
+   agent with no default ceiling. A constructor-level default closes that gap.
 
-2. **Process-lifetime in-memory `Memory` with no eviction.** `getSeekerMemory()`
-   is a process-lifetime `InMemoryStore` singleton with no `lastMessages` cap,
-   thread TTL, or per-resource eviction. Sustained traffic across many
-   `threadId`s grows heap monotonically until a Railway restart — same shared
-   blast radius as (1).
-
-3. **Caller-budget rule rests on an undeclared ceiling.** `JESUSFILM_RAG_TIMEOUT_MS`
-   is schema-capped at 30s and documented (config/env.ts:192-203) to stay
-   strictly below the Mastra agent tool-call budget, but `seeker-agent.ts` sets
-   no explicit `maxSteps` / per-tool timeout, so the upstream ceiling is a
-   `@mastra/core` runtime default rather than a code-visible constant. A 30s
-   override paired with a tight future runtime budget lets the inner call
-   outlive the caller while the (currently dead) `retryable` flags invite the
-   retry-storm shape the team's own learning warns about.
+**Out of scope:** `firecrawl-client.ts` (identical risk, but out-of-lane —
+consciously accepted and left to its owners, no ticket); extracting the shared
+HTTP helpers; in-memory eviction; a per-request wall-clock budget on the direct
+`/api/agents/*` path.
 
 ## Entry Points — Read These First
 
-1. `apps/mastra/src/services/jesusfilm-rag-client.ts` — `readUpstreamReason`
-   (`response.json()`), `searchJesusfilmRag` success-body `await response.json()`
-   before the `.slice(0, RAG_TOP_K)`. The `endpoint`/`safeReason`/
-   `readUpstreamReason` helpers are byte-identical twins of firecrawl-client.ts
-   (currently duplicated, not extracted — see the convention doc's note), so a
-   byte-cap helper should be shared the same way.
-2. `apps/mastra/src/services/firecrawl-client.ts` — same uncapped
-   `await response.json()` pattern (two call sites). Fix both clients together.
-3. `apps/mastra/src/mastra/memory.ts` — `getSeekerMemory()` singleton +
-   `InMemoryStore`; this is where a `lastMessages` cap / TTL lands.
-4. `apps/mastra/src/mastra/agents/seeker-agent.ts` — the `Agent` constructor has
-   no `maxSteps` / per-tool timeout today.
-5. `apps/mastra/src/config/env.ts` (lines 192-203) — the `JESUSFILM_RAG_TIMEOUT_MS`
-   caller-budget comment that this work makes code-enforced rather than asserted.
-6. `docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md`
-   — the governing learning for (3).
-7. `docs/solutions/conventions/single-service-http-client-result-union-convention.md`
-   — the convention both clients follow; a shared byte-cap belongs here.
+1. `docs/brainstorms/2026-06-29-seeker-rag-runtime-hardening-requirements.md` —
+   the authoritative scope + rationale for this ticket. Read first.
+2. `apps/mastra/src/services/jesusfilm-rag-client.ts` — the two uncapped reads:
+   success body `await response.json()` (`:217`, before `.slice(0, RAG_TOP_K)` at
+   `:235`) and the error path `readUpstreamReason` (`:123`). Both get the byte-cap.
+3. `apps/mastra/src/mastra/agents/seeker-agent.ts` — the `Agent` constructor has
+   no `defaultOptions`/`maxSteps` today; the step-budget floor lands here.
+4. `apps/mastra/src/mastra/agents/seeker-route.ts` — `STEP_CAPS.toolCallingTurn`
+   (`:272`) is the shared constant the constructor floor must reuse; `:19` documents
+   the built-in surface as "unauthenticated".
+5. `apps/mastra/src/config/env.ts` — `JESUSFILM_RAG_TIMEOUT_MS` (5s default,
+   `.max(30_000)`); the byte-cap's optional env knob follows the same discipline.
+6. `apps/mastra/CLAUDE.md` — the seeker "Containment" / "Service route" sections,
+   where the `/forge-seeker`-not-`/api/agents` routing-convention note lands.
 
 ## Grep These
 
-- `response.json()` in `apps/mastra/src/services/` — every uncapped ingress.
-- `InMemoryStore` / `getSeekerMemory` — memory construction.
-- `maxSteps` / `maxOutputTokens` across `apps/mastra/src/mastra/agents/` — should
-  be absent today; verifies the gap.
-- `JESUSFILM_RAG_TIMEOUT_MS` — the cap whose ceiling this makes explicit.
+- `response.json()` in `apps/mastra/src/services/jesusfilm-rag-client.ts` — the
+  two uncapped ingress sites (RAG client only; do not touch firecrawl).
+- `STEP_CAPS` / `TIME_BUDGET_MS` in `apps/mastra/src/mastra/` — the shared budget
+  constants; the constructor floor reuses `STEP_CAPS.toolCallingTurn`.
+- `defaultOptions` / `maxSteps` in `apps/mastra/src/mastra/agents/` — absent on the
+  seeker agent today; verifies the gap.
 
 ## What To Build
 
-- A shared max-bytes guard for the HTTP-client body read (read the stream with a
-  byte ceiling, or check `Content-Length` and bound the buffered read), applied
-  to **both** `jesusfilm-rag-client.ts` and `firecrawl-client.ts`. A body over
-  the cap maps to the existing graceful failure (`parse_error` / equivalent →
-  `unavailable`), never a throw. Pick a sane default (e.g. low single-digit MB)
-  with an `.optional()` env override per the env-var discipline.
-- A bound on the seeker `Memory`: a `lastMessages` cap and/or thread/TTL eviction
-  so heap can't grow without limit. Keep it in-memory (Postgres persistence stays
-  deferred per the skeleton's scope).
-- An explicit `maxSteps` / per-tool timeout on the seeker agent (or an asserted,
-  code-visible upstream ceiling constant) so the RAG timeout cap is _provably_
-  below the caller budget. Consider lowering the 30s schema cap if the chosen
-  runtime budget is tighter.
+- **Byte-cap the RAG response body**, applied to **both** read sites in
+  `jesusfilm-rag-client.ts` — success (`:217`) and error path (`readUpstreamReason`,
+  `:123`), since a multi-GB error body OOMs the shared process identically. Stream
+  the body with a byte counter (don't trust `Content-Length` alone — absent/wrong);
+  on hitting the cap, **cancel/abort the underlying stream** (not merely stop
+  reading) so the socket can't keep filling. A body over the cap maps to the
+  existing `parse_error → unavailable` path, never a throw. Default ceiling: a low
+  single-digit MB, sized above a measured/contract-derived legitimate `topK=5`
+  payload (≈ max passage text × 5 + citation overhead), with an `.optional()` env
+  override.
+- **A step-budget floor on the seeker agent**: set
+  `defaultOptions: { maxSteps: STEP_CAPS.toolCallingTurn }` on the `Agent`
+  constructor (the vNext field, NOT `defaultStreamOptionsLegacy`), reusing the
+  route's shared constant so the two paths can't diverge. This is a default floor
+  (deep-merge lets an explicit per-call value win), not an un-overridable ceiling.
+- **A routing-convention note** in `apps/mastra/CLAUDE.md`: apps/services must call
+  the bearer-gated `/forge-seeker` route, never the built-in
+  `/api/agents/seekerAgent` surface (unauthenticated, unbudgeted). State plainly
+  it's an honor-system note, not enforcement — the binding containment is the
+  network/gateway boundary.
 
 ## Constraints
 
-- **Do not** add any required-at-boot env var — all new knobs are `.optional()`
-  with runtime fallback (the skeleton added zero required vars; keep it so).
+- **Do not** touch `firecrawl-client.ts`, and **do not** extract the shared HTTP
+  helpers (`endpoint`/`safeReason`/`readUpstreamReason`) into a common module —
+  the duplication is deliberate; extraction would couple an out-of-lane client into
+  chat-lane work (the wrong abstraction).
+- **Do not** add any required-at-boot env var — new knobs are `.optional()` with
+  runtime fallback (the skeleton added zero required vars; keep it so).
 - **Do not** change the typed no-throw result-union contract or the
-  `{ status, sources, message? }` tool shape — these are hardening additions, not
-  a redesign.
-- The byte-cap is a natural moment to extract the shared helpers
-  (`endpoint`/`safeReason`/`readUpstreamReason`) into one module rather than add a
-  third copy — see the convention doc's note on duplication-vs-extraction.
-- In-memory only — do not introduce Postgres-persisted memory here.
+  `{ status, sources, message? }` tool shape — hardening additions, not a redesign.
+- **Do not** introduce Postgres-persisted memory or in-memory eviction here
+  (deferred to feat-208).
+- The constructor floor covers the step dimension only; the direct `/api/agents/*`
+  path keeps no wall-clock bound (out of scope) — its containment is the network
+  boundary.
 
 ## Verification
 
 - `pnpm --filter @forge/mastra test` — add cases: an oversized body maps to the
-  graceful unavailable path (both clients); memory growth across many threads
-  stays bounded; the agent exposes an explicit step/timeout budget.
+  graceful `unavailable` path on **both** the success body and the error path
+  (`readUpstreamReason`), tested against real over-cap behavior (not a mocked
+  branch); and the seeker agent's `maxSteps` default takes effect when no per-call
+  value is passed (verify against the `mastra build` output path, since the server
+  is re-bundled at build).
 - `pnpm --filter @forge/mastra typecheck && pnpm --filter @forge/mastra lint`.
-- Grep `response.json()` in `apps/mastra/src/services/` and confirm every call
-  site is byte-bounded.
+- Grep `response.json()` in `apps/mastra/src/services/jesusfilm-rag-client.ts` and
+  confirm both call sites are byte-bounded.
+- Confirm `apps/mastra/CLAUDE.md` carries the `/forge-seeker`-not-`/api/agents`
+  routing-convention note next to the seeker Containment / Service route sections.
 - Confirm no new entry in the production `missing` env list in
   `assertMastraRuntimeEnv` (no new boot requirement).

--- a/docs/roadmap/ai-chat/feat-208-seeker-postgres-memory.md
+++ b/docs/roadmap/ai-chat/feat-208-seeker-postgres-memory.md
@@ -47,6 +47,13 @@ a documented deferred release gate in `apps/mastra/CLAUDE.md` and feat-204.
   boundaries unchanged.
 - Genuinely useful only once `resourceId = userId` exists — pairs with feat-207
   (auth), though it can land technically under the shared default resource first.
+- **Consider (non-binding):** decide whether seeker memory needs a retention/prune
+  policy at all (thread TTL and/or per-thread message cap) — or whether we simply
+  keep all conversations indefinitely, which is a valid choice. This is the residue
+  of feat-202's deferred in-memory eviction (item ②): moving to Postgres eliminates
+  the heap-OOM risk, leaving only ordinary table growth. Not a release gate — flag
+  the question for this ticket's own brainstorm. See
+  `docs/brainstorms/2026-06-29-seeker-rag-runtime-hardening-requirements.md`.
 
 ## Verification
 


### PR DESCRIPTION
## What

Re-scopes **feat-202 (Seeker RAG runtime hardening)** from its original three-item, two-client form into the small, correct version, and adds the authoritative scoping brainstorm behind it.

A 2026-06-29 investigation against the live code reshaped the ticket:

- **Build now — ① RAG response byte-cap** (`jesusfilm-rag-client.ts` only). Both `await response.json()` reads (success body + `readUpstreamReason` error path) buffer the full upstream body into the heap before slicing — a misbehaving upstream can OOM the shared Node process. Risk is exposure-independent, so it stays in scope.
- **Build now — ③ agent step-budget floor + routing-convention note.** `defaultOptions: { maxSteps: STEP_CAPS.toolCallingTurn }` on the seeker `Agent` (reusing the route's constant), plus an honor-system `/forge-seeker`-not-`/api/agents` note in `apps/mastra/CLAUDE.md`.
- **Defer — ② in-memory `Memory` eviction → feat-208.** Moving seeker memory to Postgres *eliminates* (not relocates) the heap-OOM risk, so building in-memory eviction now would be throwaway. Adds a non-binding retention-policy hand-off note to feat-208.
- **Out of scope:** `firecrawl-client.ts` (identical risk, consciously accepted and left to its owners), extracting the shared HTTP helpers, and a per-request wall-clock budget on the direct `/api/agents/*` path.

## Files

- `docs/brainstorms/2026-06-29-seeker-rag-runtime-hardening-requirements.md` (new) — authoritative scope + rationale
- `docs/roadmap/ai-chat/feat-202-...md` — re-scoped body, status → in-progress, duration 2 → 1
- `docs/roadmap/ai-chat/feat-208-...md` — non-binding retention-policy hand-off note
- `docs/roadmap/ai-chat/README.md` — lane status counters

## Notes

Docs-only change — no runtime behavior changes. The implementation (① + ③) follows in a separate PR. Disclosure was reviewed: the security posture described here (Mastra has no public domain; `/api/agents/*` is private-network-only) is already documented in committed plan docs and source, so this adds no internet-reachable exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)