### PR TITLE
Fix watch carousel outline layering

### DIFF
--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -306,10 +306,10 @@ export function SiblingCarousel({
               "group relative block aspect-video cursor-pointer overflow-hidden rounded-lg bg-stone-900 transition shadow-[0_2px_6px_rgba(0,0,0,0.35),0_14px_32px_-12px_rgba(0,0,0,0.6)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80",
               isActive
                 ? "opacity-100"
-                : "opacity-70 hover:outline-4 hover:outline-offset-[-4px] hover:outline-brand-red hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
+                : "opacity-70 hover:opacity-100 hover:shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
               isPending &&
                 !isActive &&
-                "opacity-100 outline-4 outline-offset-[-4px] outline-brand-red shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
+                "opacity-100 shadow-[0_4px_10px_rgba(0,0,0,0.4),0_22px_44px_-14px_rgba(0,0,0,0.7)]",
             )
 
             // Card contents are identical whether the card is a routable
@@ -409,9 +409,20 @@ export function SiblingCarousel({
 
                 <div
                   aria-hidden="true"
+                  data-testid="sibling-carousel-hover-outline"
+                  className={cn(
+                    "pointer-events-none absolute inset-0 z-50 rounded-lg border-4 border-brand-red opacity-0 transition-opacity duration-200",
+                    !isActive &&
+                      "group-hover:opacity-100 group-focus-visible:opacity-100",
+                    isPending && "opacity-100",
+                  )}
+                />
+
+                <div
+                  aria-hidden="true"
                   data-testid="sibling-carousel-active-outline"
                   className={cn(
-                    "pointer-events-none absolute inset-0 z-50 rounded-lg border-4 border-white transition-[opacity,transform] duration-300 ease-out",
+                    "pointer-events-none absolute inset-0 z-[60] rounded-lg border-4 border-white transition-[opacity,transform] duration-300 ease-out",
                     isActive
                       ? "scale-100 opacity-100 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.45)]"
                       : "scale-[0.985] opacity-0",

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -411,12 +411,17 @@ export function SiblingCarousel({
                   aria-hidden="true"
                   data-testid="sibling-carousel-hover-outline"
                   className={cn(
-                    "pointer-events-none absolute inset-0 z-50 rounded-lg bg-[linear-gradient(135deg,rgba(239,68,68,0.95)_0%,rgba(255,255,255,0.7)_42%,rgba(239,68,68,0.95)_100%)] p-[4px] opacity-0 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.2),0_0_22px_rgba(239,68,68,0.35)] transition-opacity duration-200 [mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] [mask-composite:exclude] [-webkit-mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] [-webkit-mask-composite:xor]",
+                    "pointer-events-none absolute inset-0 z-50 rounded-lg opacity-0 shadow-[0_0_22px_rgba(239,68,68,0.32)] transition-opacity duration-200",
                     !isActive &&
                       "group-hover:opacity-100 group-focus-visible:opacity-100",
                     isPending && "opacity-100",
                   )}
-                />
+                >
+                  <span className="absolute inset-x-0 top-0 h-[4px] rounded-t-lg bg-brand-red" />
+                  <span className="absolute inset-y-0 left-0 w-[4px] rounded-l-lg bg-[linear-gradient(to_bottom,rgba(239,68,68,0.96)_0%,rgba(239,68,68,0.96)_48%,rgba(120,20,20,0.88)_78%,rgba(0,0,0,0.92)_100%)]" />
+                  <span className="absolute inset-y-0 right-0 w-[4px] rounded-r-lg bg-[linear-gradient(to_bottom,rgba(239,68,68,0.96)_0%,rgba(239,68,68,0.96)_48%,rgba(120,20,20,0.88)_78%,rgba(0,0,0,0.92)_100%)]" />
+                  <span className="absolute inset-x-0 bottom-0 h-[4px] rounded-b-lg bg-black/90" />
+                </div>
 
                 <div
                   aria-hidden="true"

--- a/apps/web/src/components/watch/SiblingCarousel.tsx
+++ b/apps/web/src/components/watch/SiblingCarousel.tsx
@@ -411,7 +411,7 @@ export function SiblingCarousel({
                   aria-hidden="true"
                   data-testid="sibling-carousel-hover-outline"
                   className={cn(
-                    "pointer-events-none absolute inset-0 z-50 rounded-lg border-4 border-brand-red opacity-0 transition-opacity duration-200",
+                    "pointer-events-none absolute inset-0 z-50 rounded-lg bg-[linear-gradient(135deg,rgba(239,68,68,0.95)_0%,rgba(255,255,255,0.7)_42%,rgba(239,68,68,0.95)_100%)] p-[4px] opacity-0 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.2),0_0_22px_rgba(239,68,68,0.35)] transition-opacity duration-200 [mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] [mask-composite:exclude] [-webkit-mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] [-webkit-mask-composite:xor]",
                     !isActive &&
                       "group-hover:opacity-100 group-focus-visible:opacity-100",
                     isPending && "opacity-100",

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -358,10 +358,17 @@ describe("SiblingCarousel — happy path", () => {
       "[data-testid='sibling-carousel-hover-outline']",
     )
     expect(hoverOutline?.className).toContain("z-50")
-    expect(hoverOutline?.className).toContain("bg-[linear-gradient")
-    expect(hoverOutline?.className).toContain("p-[4px]")
-    expect(hoverOutline?.className).toContain("[mask-composite:exclude]")
+    expect(hoverOutline?.className).toContain("rounded-lg")
     expect(hoverOutline?.className).toContain("group-hover:opacity-100")
+    const outlineSegments = hoverOutline?.querySelectorAll("span")
+    expect(outlineSegments).toHaveLength(4)
+    expect(outlineSegments?.[0]?.className).toContain("h-[4px]")
+    expect(outlineSegments?.[0]?.className).toContain("bg-brand-red")
+    expect(outlineSegments?.[1]?.className).toContain(
+      "bg-[linear-gradient(to_bottom",
+    )
+    expect(outlineSegments?.[1]?.className).toContain("rgba(0,0,0,0.92)_100%")
+    expect(outlineSegments?.[3]?.className).toContain("bg-black/90")
 
     const label = container.querySelector(
       "[data-testid='sibling-carousel-label']",

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -288,7 +288,7 @@ describe("SiblingCarousel — happy path", () => {
     expect(activeOutline).not.toBeNull()
     expect(activeOutline?.className).toContain("absolute")
     expect(activeOutline?.className).toContain("inset-0")
-    expect(activeOutline?.className).toContain("z-50")
+    expect(activeOutline?.className).toContain("z-[60]")
     expect(activeOutline?.className).toContain("border-4")
     expect(activeOutline?.className).toContain("border-white")
     expect(activeOutline?.className).toContain("transition-[opacity,transform]")
@@ -353,8 +353,13 @@ describe("SiblingCarousel — happy path", () => {
     )
     expect(inactive?.className).not.toContain("border-transparent")
     expect(inactive?.className).toContain("opacity-70")
-    expect(inactive?.className).toContain("hover:outline-brand-red")
     expect(inactive?.className).toContain("hover:opacity-100")
+    const hoverOutline = inactive?.querySelector(
+      "[data-testid='sibling-carousel-hover-outline']",
+    )
+    expect(hoverOutline?.className).toContain("z-50")
+    expect(hoverOutline?.className).toContain("border-brand-red")
+    expect(hoverOutline?.className).toContain("group-hover:opacity-100")
 
     const label = container.querySelector(
       "[data-testid='sibling-carousel-label']",

--- a/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
+++ b/apps/web/src/components/watch/__tests__/SiblingCarousel.test.tsx
@@ -358,7 +358,9 @@ describe("SiblingCarousel — happy path", () => {
       "[data-testid='sibling-carousel-hover-outline']",
     )
     expect(hoverOutline?.className).toContain("z-50")
-    expect(hoverOutline?.className).toContain("border-brand-red")
+    expect(hoverOutline?.className).toContain("bg-[linear-gradient")
+    expect(hoverOutline?.className).toContain("p-[4px]")
+    expect(hoverOutline?.className).toContain("[mask-composite:exclude]")
     expect(hoverOutline?.className).toContain("group-hover:opacity-100")
 
     const label = container.querySelector(


### PR DESCRIPTION
## Summary
- Move the carousel hover/pending outline above the thumbnail image
- Keep the outline border-only with a red-to-black vertical fade
- Update SiblingCarousel coverage for the foreground segmented border

## Validation
- pnpm --filter @forge/web test -- SiblingCarousel.test.tsx
- pnpm --filter @forge/web lint