### PR TITLE
docs(roadmap): capture transcript search follow-ups

### DIFF
--- a/docs/roadmap/content-discovery/feat-193-remove-legacy-scene-embedding-pipeline.md
+++ b/docs/roadmap/content-discovery/feat-193-remove-legacy-scene-embedding-pipeline.md
@@ -8,6 +8,7 @@ start_date: "2026-06-24"
 duration: 3
 depends_on:
   - "feat-192"
+  - "feat-198"
 blocks: []
 tags:
   - "admin"
@@ -21,14 +22,16 @@ tags:
 
 ## Scope
 
-After enriched transcript search has passed eval and production backfill
-coverage is healthy, remove the legacy scene embedding pipeline that is no
-longer consumed by semantic search or recommendation lists.
+After enriched transcript search has passed the transcript-only eval guardrail
+and keyword-first relevance is no longer relying on scene evidence, remove the
+legacy scene embedding pipeline that is no longer consumed by semantic search
+or recommendation lists.
 
 This is the deletion follow-up for feat-192. feat-192 stops scene embedding
 consumption while leaving the old code in place; this ticket deletes the dead
 scene-embedding path and cleans up naming/docs that still imply scene retrieval
-is active.
+is active. This is intentionally a code cleanup slice, not a database-retention
+or embedding-backfill-operations slice; those stay in `feat-199`.
 
 ## Cleanup Targets
 
@@ -50,7 +53,10 @@ is active.
 
 ## Acceptance Criteria
 
-- Enriched transcript semantic search eval has passed the agreed promotion gate.
+- Enriched transcript semantic search eval has passed the agreed promotion gate,
+  using the completed transcript-only eval work as the guardrail.
+- `feat-198` has removed the remaining search-quality reason to keep scene code
+  available as a fallback.
 - No production search or recommendation path calls scene embedding retrieval,
   scene embedding ingestion, or scene embedding backfill code.
 - Dead scene embedding code and tests are removed, not merely bypassed.
@@ -58,3 +64,5 @@ is active.
   or is removed in the same cleanup.
 - Operator docs, roadmap notes, and code comments describe transcript-backed
   search/recommendations without implying scene embeddings are still active.
+- Historical `video_scene` / `video_scene_locale` rows remain in place unless a
+  separately approved retention migration exists.

--- a/docs/roadmap/content-discovery/feat-198-keyword-first-brand-entity-search.md
+++ b/docs/roadmap/content-discovery/feat-198-keyword-first-brand-entity-search.md
@@ -1,6 +1,6 @@
 ---
 id: "feat-198"
-title: "Keyword-first brand and entity search ranking"
+title: "Keyword-first transcript relevance and entity search ranking"
 owner: "nisal"
 priority: "P1"
 status: "in-progress"
@@ -15,7 +15,6 @@ tags:
   - "search"
   - "keyword-first"
   - "semantic-search"
-  - "evals"
   - "embeddings"
   - "launch-readiness"
 ---
@@ -28,12 +27,21 @@ can mutate that live signal while they run. For brand/entity queries such as
 `Bible Project`, generic fusion can let unrelated lexical matches combine with
 semantic hits and outrank the known BibleProject corpus.
 
-The observed culprit is that `Bible` + `Project` in a description can be
+The observed brand/entity culprit is that `Bible` + `Project` in a description can be
 treated too strongly. For example, "Rescue Project" rows can satisfy the token
 shape lexically while BibleProject rows whose titles do not literally say
 BibleProject depend on slug, core id, description, collection, or source
 membership evidence. The ranker needs to understand BibleProject as a
 source/corpus entity, not only as title text.
+
+The second relevance gap is transcript signal quality for theological and felt
+need queries. Enriched transcript chunks already store and embed felt needs,
+Bible verses, content summary, tone, demographics, and spiritual context, but
+`spiritualContext` is currently deterministic: it becomes `["Bible reference"]`
+only when the chunk has an explicit Bible citation. This ticket owns the
+vertical search-quality slice: improve the ranking behavior and the
+transcript-grounded signals search relies on. Backfill operations, versioned
+promotion, and source coverage are split into `feat-199`.
 
 ## Evidence
 
@@ -53,6 +61,12 @@ source/corpus entity, not only as title text.
   retriever SQL is in `apps/admin/src/services/hybrid-search-retrievers.ts`.
 - BibleProject videos often have identifying slug/core id/description/source
   evidence even when the visible title does not say `BibleProject`.
+- Transcript-only keyword-first evals for BibleProject/entity behavior were
+  completed in a separate branch. This ticket should consume that report as an
+  input guardrail instead of recreating the eval work from scratch.
+- Current enriched transcript planning sets `spiritualContext` in
+  `apps/mastra/src/mastra/workflows/transcript-embedding.ts` from explicit
+  Bible-verse extraction only.
 
 ## What To Build
 
@@ -71,12 +85,15 @@ source/corpus entity, not only as title text.
    semantic contribution when entity evidence fires, or only allow semantic
    reranking inside the matched entity set before appending generic semantic
    fill results.
-6. Add keyword-first eval cases for `Bible Project`, `the Bible project`,
-   `BibleProject`, and agreed aliases. These evals must run against the
-   keyword-first production-like path, not only broad `hybrid` mode.
-7. Design the staged/versioned embedding promotion path needed before future
-   relevance-affecting backfills. Search should not automatically read a new
-   embedding generation before eval passes and an active generation is switched.
+6. Use the existing transcript-only keyword-first eval branch/report for
+   `Bible Project`, `the Bible project`, `BibleProject`, and agreed aliases as
+   the guardrail for this ranking change. Only add new eval cases here if the
+   report has an obvious coverage hole.
+7. Improve transcript-grounded `spiritualContext` beyond the current explicit
+   Bible-reference flag. Keep it subtitle/transcript-grounded, store it as
+   structured metadata, and fold it into `embeddingInputText` so theological
+   and discipleship queries can retrieve the right transcript chunks without
+   reintroducing scene embeddings.
 
 ## Entry Points - Read These First
 
@@ -93,10 +110,21 @@ source/corpus entity, not only as title text.
   existing retriever assertions.
 - `apps/web/src/lib/search.ts` - Watch/Web caller that requests
   `keyword-first`.
+- `apps/mastra/src/mastra/workflows/transcript-embedding.ts` - enriched
+  transcript chunk planning, felt needs, demographics, Bible-verse extraction,
+  and current deterministic `spiritualContext` behavior.
+- `apps/admin/src/services/transcript-embedding.service.ts` and
+  `apps/admin/src/services/transcript-embedding-ingest.service.ts` - Admin
+  persistence of structured transcript metadata and vector payloads.
 - `docs/search-eval-baselines/temporary/prod-seed-baseline-2026-06-02-export.json`
   - baseline evidence for `seed-bible-project`.
 - `docs/search-eval-reports/2026-06-03-local-english-post-batch-search-eval.json`
   - broad hybrid eval report that missed this brand/entity regression.
+- `docs/solutions/architecture-patterns/admin-semantic-video-transcript-evidence-pattern.md`
+  - feat-192 contract for transcript-backed semantic evidence.
+- `docs/solutions/architecture-patterns/transcript-demographics-signal-shape.md`
+  - structured metadata plus embedded-text signal shape to follow for new
+    spiritual-context behavior.
 
 ## Grep These
 
@@ -104,6 +132,7 @@ source/corpus entity, not only as title text.
 - `rg -n "BibleProject|Bible Project|Rescue Project|seed-bible-project" docs apps/admin/src`
 - `rg -n "reciprocal|RRF|fuse|weighted" apps/admin/src/services/hybrid-search*`
 - `rg -n "collection|source|slug|core_id|description" apps/admin/src/services/hybrid-search* apps/admin/prisma/schema.prisma`
+- `rg -n "spiritualContext|spiritual_context|bibleVerses|feltNeeds|demographics" apps/mastra/src apps/admin/src`
 
 ## Constraints
 
@@ -113,11 +142,14 @@ source/corpus entity, not only as title text.
   family name, but its evidence should remain transcript-backed after feat-192.
 - Brand/entity exactness should outrank description-only token coincidence, but
   generic semantic fill should still work after the entity set is exhausted.
-- Add eval coverage that runs the keyword-first path specifically; broad
-  `hybrid` eval passing is not sufficient.
-- Treat staged/versioned embedding promotion as a relevance safety requirement.
-  If not implemented in this ticket, file or link the follow-up before another
-  relevance-affecting production backfill.
+- Do not reopen the already-completed transcript-only eval branch unless this
+  implementation finds a specific missing case. Use its report as the
+  acceptance guardrail.
+- Do not handle staged/versioned embedding promotion here. That operational
+  slice is `feat-199`.
+- Keep spiritual-context extraction grounded in subtitle/transcript text and
+  the allowed video-level context already passed to transcript embedding. Do
+  not silently infer broad theology from unrelated catalog metadata.
 
 ## Acceptance Criteria
 
@@ -135,16 +167,24 @@ source/corpus entity, not only as title text.
   the fix.
 - The eval report names the exact search mode, data source, and retriever
   strategy under test.
-- A staged/versioned embedding promotion plan exists before the next
-  relevance-affecting backfill, either implemented here or captured as a
-  separate follow-up ticket with this ticket depending on it.
+- Transcript chunks with obvious theological context can expose richer
+  `spiritualContext` values than `["Bible reference"]`, and those values are
+  both stored structurally and included in the embedded text.
+- A search for theological/felt-need language benefits from transcript-backed
+  metadata without any production path calling scene retrieval.
+- `feat-199` exists as the separate operational safety ticket for versioned
+  backfills and active-generation promotion.
 
 ## Verification
 
 - Add focused Admin service tests around entity detection, retriever weighting,
   and fusion behavior.
-- Add or update Mastra/search eval fixtures so brand/entity queries are judged
-  in keyword-first mode.
+- Reuse the completed transcript-only keyword-first eval branch/report and add
+  only the missing fixtures needed for this implementation.
+- Add focused Mastra transcript-planning tests for richer `spiritualContext`
+  extraction and embedding input text.
+- Add Admin ingest/service tests proving the richer structured metadata still
+  persists and is not dropped during transcript embedding writes.
 - Run a production-like eval before and after the ranking change and compare
   BibleProject/Rescue Project ordering.
 - Confirm the Watch frontend continues to call the same search API contract;

--- a/docs/roadmap/content-discovery/feat-199-transcript-embedding-operations-promotion.md
+++ b/docs/roadmap/content-discovery/feat-199-transcript-embedding-operations-promotion.md
@@ -1,0 +1,174 @@
+---
+id: "feat-199"
+title: "Transcript embedding operations, promotion, and source coverage"
+owner: "nisal"
+priority: "P0"
+status: "not-started"
+start_date: "2026-06-30"
+duration: 5
+depends_on:
+  - "feat-192"
+blocks: []
+tags:
+  - "admin"
+  - "mastra"
+  - "manager"
+  - "search"
+  - "embeddings"
+  - "operator-tools"
+  - "content-discovery"
+  - "reliability"
+---
+
+## Problem
+
+Feat-192 moved semantic-video retrieval to enriched transcript chunks and the
+all-language replacement backfill completed, but the production workflow is
+still too fragile for the next relevance-affecting backfill.
+
+Search currently reads the live transcript rows matching provider/model, so a
+backfill can change production ranking while it is still running. Operators can
+trigger the GraphQL mutation, but there is no broad surface that safely starts,
+resumes, pauses/cancels, monitors, promotes, or cleans up a full-library,
+all-language transcript embedding generation. Source gaps such as
+`dub_without_timed_text` and `subtitle_missing` are reported, but they do not
+yet roll into a clear source-coverage workflow. Transient Manager artifact read
+errors such as `Request is canceled` can also fan out across a batch instead of
+isolating to the affected target.
+
+This ticket is the operational vertical slice: from source resolution, through
+all-language backfill execution, to staged promotion and cleanup.
+
+## What To Build
+
+1. Add an explicit transcript embedding generation model.
+   - Every backfill run writes rows with a generation identity such as
+     `generationId` / `backfillRunId` plus provider, model, dimensions,
+     source hash, and transcript enrichment version.
+   - Search reads only the active generation for a provider/model contract.
+   - New generations can be written and evaluated without becoming
+     search-visible.
+   - Promotion switches the active generation atomically after eval/review.
+   - Rollback can restore the previous active generation without re-embedding.
+2. Build an operator surface for full-library transcript embedding backfills.
+   - Trigger the full default scope: all eligible videos, editions, and
+     languages. Do not silently scope to a single `coreId` or language unless
+     the operator chooses an explicit filter.
+   - Show run id, generation id, mode, provider/model, started/completed/failed
+     counts, source gaps, skips, retryable failures, and current throughput.
+   - Support resume/retry from the latest known failure point without
+     re-embedding completed targets in the same generation.
+   - Support cancel/pause semantics that leave completed targets durable and
+     resumable.
+3. Make cleanup a first-class operation.
+   - Provide a dry-run summary before deleting or archiving superseded
+     transcript rows/chunks.
+   - Delete only generations that are not active, not the rollback generation,
+     and older than the approved retention window.
+   - If legacy provider/model rows exist in a future run, report exact counts
+     before cleanup. The 2026-06-29 completion audit documented zero legacy
+     OpenAI transcript parents/chunks, so this is a future safety path rather
+     than an immediate destructive task.
+4. Close source coverage gaps.
+   - Keep the source order from feat-192: Admin/Core subtitles first, Manager
+     transcript artifacts second.
+   - For dubs with no usable timed text, check Manager transcript enrichment
+     before skipping.
+   - Report `dub_without_timed_text`, `subtitle_missing`,
+     `manager_artifact_missing`, and related gaps with enough identifiers for
+     an operator to trigger Manager enrichment separately.
+   - Do not auto-trigger costly Manager enrichment as a side effect of a
+     backfill. The surface can prepare/export the trigger list, but automatic
+     dispatch remains a separate decision.
+5. Isolate Manager artifact read failures per target.
+   - A single `readManagerArtifact(assetId, "transcript", "json")` cancellation
+     or transient network error should log and retry/fail the affected target,
+     not poison every target sharing the same batch.
+   - Shared artifact caching/memoization must not cache rejected/canceled
+     promises in a way that cascades failures.
+   - Retryable artifact read failures should use bounded retries with sanitized
+     operator-visible reasons.
+6. Persist an audit trail.
+   - Store enough run state to answer: what generation was produced, what rows
+     were written, what source gaps remain, what failed, what was retried, what
+     was promoted, and what was cleaned up.
+   - Keep logs safe to paste: no subtitle URLs, bearer tokens, vector literals,
+     raw provider responses, or database URLs.
+
+## Entry Points - Read These First
+
+- `apps/admin/src/graphql/mutations/transcript-embedding.ts` - current
+  GraphQL trigger for transcript embedding backfills.
+- `apps/admin/src/workflows/transcriptEmbeddingBackfill.ts` - full backfill
+  orchestration, source gaps, reports, and completion accounting.
+- `apps/admin/src/workflows/_steps/process-transcript-embedding-group.ts` -
+  per-group launch/confirm/failure boundaries.
+- `apps/admin/src/services/mastra-transcript-embedding-client.ts` - Admin to
+  Mastra launch client.
+- `apps/mastra/src/mastra/workflows/transcript-embedding.ts` - target planning,
+  chunk enrichment, embedding generation, and Admin ingest submission.
+- `apps/admin/src/services/transcript-embedding.service.ts` - transcript row
+  and chunk writes.
+- `apps/admin/src/services/manager-artifacts.service.ts` - Manager artifact
+  read boundary and error classification.
+- `apps/admin/src/scripts/run-embeds.ts` - existing operator script behavior to
+  either preserve or replace with the new surface.
+- `docs/solutions/workflow-issues/transcript-embedding-backfill-cancel-and-resume-operations.md`
+  - completed backfill audit and known operational failure shapes.
+- `docs/solutions/architecture-patterns/admin-semantic-video-transcript-evidence-pattern.md`
+  - transcript-backed semantic-video contract.
+
+## Grep These
+
+- `rg -n "triggerTranscriptEmbeddingBackfill|runTranscriptEmbeddingBackfill|TranscriptEmbeddingBackfill" apps/admin/src`
+- `rg -n "generationMode|MODEL_UPGRADE|IDEMPOTENT|backfillRunId|callerRunId|sourceHash" apps/admin/src apps/mastra/src`
+- `rg -n "sourceGap|dub_without_timed_text|subtitle_missing|manager_artifact" apps/admin/src`
+- `rg -n "readManagerArtifact|Request is canceled|artifact_missing|artifact_read_failed" apps/admin/src`
+- `rg -n "provider|model|dimensions|active generation|embedding generation" apps/admin/prisma apps/admin/src docs`
+
+## Constraints
+
+- Do not re-enable scene retrieval or scene embedding backfills.
+- Do not make search read a staged generation before explicit promotion.
+- Do not start a full re-embed from scratch when a resumable generation exists.
+- Do not delete active or rollback transcript embeddings.
+- Do not auto-trigger Manager enrichment as an implicit side effect of
+  embedding backfill.
+- Preserve the existing GraphQL trigger until the operator surface fully
+  replaces it; scripts and existing callers must keep working during migration.
+- Keep frontend search APIs unchanged. This is an Admin/Mastra/operator
+  workflow slice.
+
+## Acceptance Criteria
+
+- Operators can start a full-library, all-language transcript embedding run
+  from a supported surface and see durable progress without using ad hoc
+  GraphQL calls.
+- A stopped or failed run can resume idempotently from completed target state
+  for the same generation.
+- Search reads only the active transcript embedding generation.
+- A newly completed generation can be evaluated, promoted atomically, and
+  rolled back without re-embedding.
+- Cleanup can dry-run and then remove only approved superseded generations.
+- Source gap reporting distinguishes missing subtitles/timed text from missing
+  Manager artifacts and exports the identifiers needed for a separate Manager
+  enrichment trigger.
+- A single canceled/transient Manager artifact read does not fail an entire
+  batch of unrelated targets.
+- Production logs and stored run state are safe to paste and sufficient for an
+  operator to know what remains.
+
+## Verification
+
+- Unit tests cover generation selection, active-generation search filtering,
+  promotion, rollback, and cleanup guards.
+- Workflow tests cover full-scope default enumeration, explicit filters,
+  idempotent resume, cancel/pause, source gap reporting, and per-target
+  artifact failure isolation.
+- Operator-surface tests cover trigger, progress polling, retry, cancel, dry
+  cleanup, and promotion flows.
+- A production-like dry run shows all-language/full-library scope before
+  dispatch.
+- A small scoped generation is written staged, verified invisible to search,
+  promoted, observed by search, rolled back, and then cleaned up after dry-run
+  confirmation.

--- a/docs/search-eval-reports/2026-06-29-bibleproject-keyword-first-post-backfill.md
+++ b/docs/search-eval-reports/2026-06-29-bibleproject-keyword-first-post-backfill.md
@@ -43,99 +43,99 @@ The `Thanks to BibleProject` alias was discovered from current BibleProject corp
 
 ### `Bible Project`
 
-| Rank | Title | Slug | Score | BP evidence | Rescue evidence |
-| ---: | --- | --- | ---: | --- | --- |
-| 1 | The BibleProject Collection | `the-bibleproject-collection` | 0.750 | yes | no |
-| 2 | Jesus Fulfills the Law | `jesus-fulfills-the-law` | 0.473 | yes | no |
-| 3 | Advent Series | `advent-series` | 0.470 | yes | no |
-| 4 | The Lord's Prayer | `the-lord-prayer-bp` | 0.464 | yes | no |
-| 5 | Intro to Sermon on the Mount | `intro-to-sermon-on-the-mount` | 0.459 | yes | no |
+| Rank | Title                        | Slug                           | Score | BP evidence | Rescue evidence |
+| ---: | ---------------------------- | ------------------------------ | ----: | ----------- | --------------- |
+|    1 | The BibleProject Collection  | `the-bibleproject-collection`  | 0.750 | yes         | no              |
+|    2 | Jesus Fulfills the Law       | `jesus-fulfills-the-law`       | 0.473 | yes         | no              |
+|    3 | Advent Series                | `advent-series`                | 0.470 | yes         | no              |
+|    4 | The Lord's Prayer            | `the-lord-prayer-bp`           | 0.464 | yes         | no              |
+|    5 | Intro to Sermon on the Mount | `intro-to-sermon-on-the-mount` | 0.459 | yes         | no              |
 
 Pass note: collection and known BibleProject rows dominate the top slots. Leakage note: Rescue Project rows still appear at ranks 14, 15, 17, and 18, above a later known BibleProject row at rank 16.
 
 ### `the Bible project`
 
-| Rank | Title | Slug | Score | BP evidence | Rescue evidence |
-| ---: | --- | --- | ---: | --- | --- |
-| 1 | The BibleProject Collection | `the-bibleproject-collection` | 0.750 | yes | no |
-| 2 | Relationship Trumps Fame | `relationship-trumps-fame` | 0.441 | no | no |
-| 3 | Gospel Part 4 - Call to Repentance | `gospel-part-4-call-to-repentance` | 0.392 | no | yes |
-| 4 | Gospel Part 2 - Jesus | `gospel-part-2-jesus` | 0.386 | no | yes |
-| 5 | The Lord's Prayer | `the-lord-prayer-bp` | 0.246 | yes | no |
+| Rank | Title                              | Slug                               | Score | BP evidence | Rescue evidence |
+| ---: | ---------------------------------- | ---------------------------------- | ----: | ----------- | --------------- |
+|    1 | The BibleProject Collection        | `the-bibleproject-collection`      | 0.750 | yes         | no              |
+|    2 | Relationship Trumps Fame           | `relationship-trumps-fame`         | 0.441 | no          | no              |
+|    3 | Gospel Part 4 - Call to Repentance | `gospel-part-4-call-to-repentance` | 0.392 | no          | yes             |
+|    4 | Gospel Part 2 - Jesus              | `gospel-part-2-jesus`              | 0.386 | no          | yes             |
+|    5 | The Lord's Prayer                  | `the-lord-prayer-bp`               | 0.246 | yes         | no              |
 
 Fail note: the collection is first, but Rescue Project rows at ranks 3 and 4 outrank known BibleProject corpus rows starting at rank 5.
 
 ### `BibleProject`
 
-| Rank | Title | Slug | Score | BP evidence | Rescue evidence |
-| ---: | --- | --- | ---: | --- | --- |
-| 1 | The BibleProject Collection | `the-bibleproject-collection` | 0.667 | yes | no |
-| 2 | The Lord's Prayer | `the-lord-prayer-bp` | 0.328 | yes | no |
-| 3 | Jesus Fulfills the Law | `jesus-fulfills-the-law` | 0.323 | yes | no |
-| 4 | The Choice | `the-choice` | 0.318 | yes | no |
-| 5 | Wealth and Worry | `wealth-and-worry` | 0.313 | yes | no |
+| Rank | Title                       | Slug                          | Score | BP evidence | Rescue evidence |
+| ---: | --------------------------- | ----------------------------- | ----: | ----------- | --------------- |
+|    1 | The BibleProject Collection | `the-bibleproject-collection` | 0.667 | yes         | no              |
+|    2 | The Lord's Prayer           | `the-lord-prayer-bp`          | 0.328 | yes         | no              |
+|    3 | Jesus Fulfills the Law      | `jesus-fulfills-the-law`      | 0.323 | yes         | no              |
+|    4 | The Choice                  | `the-choice`                  | 0.318 | yes         | no              |
+|    5 | Wealth and Worry            | `wealth-and-worry`            | 0.313 | yes         | no              |
 
 Pass note: joined CamelCase brand intent is strong. No Rescue Project rows appeared in the top 20.
 
 ### `BibleProject Collection`
 
-| Rank | Title | Slug | Score | BP evidence | Rescue evidence |
-| ---: | --- | --- | ---: | --- | --- |
-| 1 | The BibleProject Collection | `the-bibleproject-collection` | 0.667 | yes | no |
-| 2 | StoryClubs: Jesus Calms the Storm | `storyclubs-jesus-calms-the-storm` | 0.167 | no | no |
-| 3 | Finding A Video | `finding-a-video` | 0.164 | no | no |
-| 4 | Getting Started Is Easy | `getting-started-is-easy` | 0.161 | no | no |
-| 5 | Jesus Vision - John | `jesus-vision-john` | 0.159 | no | no |
+| Rank | Title                             | Slug                               | Score | BP evidence | Rescue evidence |
+| ---: | --------------------------------- | ---------------------------------- | ----: | ----------- | --------------- |
+|    1 | The BibleProject Collection       | `the-bibleproject-collection`      | 0.667 | yes         | no              |
+|    2 | StoryClubs: Jesus Calms the Storm | `storyclubs-jesus-calms-the-storm` | 0.167 | no          | no              |
+|    3 | Finding A Video                   | `finding-a-video`                  | 0.164 | no          | no              |
+|    4 | Getting Started Is Easy           | `getting-started-is-easy`          | 0.161 | no          | no              |
+|    5 | Jesus Vision - John               | `jesus-vision-john`                | 0.159 | no          | no              |
 
 Mixed note: exact collection alias ranks the collection first, but generic semantic fill starts immediately at rank 2 instead of continuing with BibleProject children.
 
 ### `The BibleProject Collection`
 
-| Rank | Title | Slug | Score | BP evidence | Rescue evidence |
-| ---: | --- | --- | ---: | --- | --- |
-| 1 | The BibleProject Collection | `the-bibleproject-collection` | 0.667 | yes | no |
-| 2 | The Story of the Bible (Episode 2) | `bp-story-of-bible-episode-2` | 0.328 | yes | no |
-| 3 | StoryClubs: Jesus Calms the Storm | `storyclubs-jesus-calms-the-storm` | 0.167 | no | no |
-| 4 | Jesus Vision - John | `jesus-vision-john` | 0.164 | no | no |
-| 5 | Venia | `venia` | 0.159 | no | no |
+| Rank | Title                              | Slug                               | Score | BP evidence | Rescue evidence |
+| ---: | ---------------------------------- | ---------------------------------- | ----: | ----------- | --------------- |
+|    1 | The BibleProject Collection        | `the-bibleproject-collection`      | 0.667 | yes         | no              |
+|    2 | The Story of the Bible (Episode 2) | `bp-story-of-bible-episode-2`      | 0.328 | yes         | no              |
+|    3 | StoryClubs: Jesus Calms the Storm  | `storyclubs-jesus-calms-the-storm` | 0.167 | no          | no              |
+|    4 | Jesus Vision - John                | `jesus-vision-john`                | 0.164 | no          | no              |
+|    5 | Venia                              | `venia`                            | 0.159 | no          | no              |
 
 Mixed note: the collection and one known child lead, but generic semantic fill starts at rank 3.
 
 ### `Thanks to BibleProject`
 
-| Rank | Title | Slug | Score | BP evidence | Rescue evidence |
-| ---: | --- | --- | ---: | --- | --- |
-| 1 | StoryClubs: Jesus Calms the Storm | `storyclubs-jesus-calms-the-storm` | 0.500 | no | no |
-| 2 | The BibleProject Collection | `the-bibleproject-collection` | 0.500 | yes | no |
-| 3 | Jesus Vision - John | `jesus-vision-john` | 0.492 | no | no |
-| 4 | The Lord's Prayer | `the-lord-prayer-bp` | 0.492 | yes | no |
-| 5 | Jesus Fulfills the Law | `jesus-fulfills-the-law` | 0.484 | yes | no |
+| Rank | Title                             | Slug                               | Score | BP evidence | Rescue evidence |
+| ---: | --------------------------------- | ---------------------------------- | ----: | ----------- | --------------- |
+|    1 | StoryClubs: Jesus Calms the Storm | `storyclubs-jesus-calms-the-storm` | 0.500 | no          | no              |
+|    2 | The BibleProject Collection       | `the-bibleproject-collection`      | 0.500 | yes         | no              |
+|    3 | Jesus Vision - John               | `jesus-vision-john`                | 0.492 | no          | no              |
+|    4 | The Lord's Prayer                 | `the-lord-prayer-bp`               | 0.492 | yes         | no              |
+|    5 | Jesus Fulfills the Law            | `jesus-fulfills-the-law`           | 0.484 | yes         | no              |
 
 Fail note: a source-credit alias still lets an unrelated semantic hit tie and sort above the collection.
 
 ### `Bible Project videos`
 
-| Rank | Title | Slug | Score | BP evidence | Rescue evidence |
-| ---: | --- | --- | ---: | --- | --- |
-| 1 | Getting Started Is Easy | `getting-started-is-easy` | 0.333 | no | no |
-| 2 | Meod / Strength | `meod-strength` | 0.333 | yes | no |
-| 3 | The BibleProject Collection | `the-bibleproject-collection` | 0.333 | yes | no |
-| 4 | Finding A Video | `finding-a-video` | 0.328 | no | no |
-| 5 | Seeing Opportunities | `seeing-opportunities` | 0.323 | no | no |
+| Rank | Title                       | Slug                          | Score | BP evidence | Rescue evidence |
+| ---: | --------------------------- | ----------------------------- | ----: | ----------- | --------------- |
+|    1 | Getting Started Is Easy     | `getting-started-is-easy`     | 0.333 | no          | no              |
+|    2 | Meod / Strength             | `meod-strength`               | 0.333 | yes         | no              |
+|    3 | The BibleProject Collection | `the-bibleproject-collection` | 0.333 | yes         | no              |
+|    4 | Finding A Video             | `finding-a-video`             | 0.328 | no          | no              |
+|    5 | Seeing Opportunities        | `seeing-opportunities`        | 0.323 | no          | no              |
 
 Fail note: brand-plus-modifier intent is not protected. Generic "videos/app usage" results outrank the collection.
 
 ## Pass/Fail Summary
 
-| Case | Result |
-| --- | --- |
-| `Bible Project` | Pass for top slot and top-12 corpus dominance; fail for later Rescue interleaving above a known BibleProject row. |
-| `the Bible project` | Fail. Collection is first, but Rescue Project rows outrank known BibleProject corpus rows. |
-| `BibleProject` | Pass. |
-| `BibleProject Collection` | Mixed. Collection is first; entity set is not filled before generic semantic results. |
-| `The BibleProject Collection` | Mixed. Collection and one known child lead; generic semantic fill starts too early. |
-| `Thanks to BibleProject` | Fail. Unrelated semantic result ties and sorts above the collection. |
-| `Bible Project videos` | Fail. Generic video/app results outrank the collection. |
+| Case                          | Result                                                                                                            |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `Bible Project`               | Pass for top slot and top-12 corpus dominance; fail for later Rescue interleaving above a known BibleProject row. |
+| `the Bible project`           | Fail. Collection is first, but Rescue Project rows outrank known BibleProject corpus rows.                        |
+| `BibleProject`                | Pass.                                                                                                             |
+| `BibleProject Collection`     | Mixed. Collection is first; entity set is not filled before generic semantic results.                             |
+| `The BibleProject Collection` | Mixed. Collection and one known child lead; generic semantic fill starts too early.                               |
+| `Thanks to BibleProject`      | Fail. Unrelated semantic result ties and sorts above the collection.                                              |
+| `Bible Project videos`        | Fail. Generic video/app results outrank the collection.                                                           |
 
 ## Concrete Relevance Issues
 


### PR DESCRIPTION
## Summary

- Compress the remaining transcript-only search follow-ups into three roadmap slices: relevance, operations/source coverage, and scene deletion.
- Update `feat-198` to consume the already-completed transcript-only eval work instead of duplicating it, and add the richer `spiritualContext` relevance work there.
- Add `feat-199` for staged embedding generation promotion, operator backfill controls, cleanup, source-gap closure, and Manager artifact failure isolation.

## Validation

- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
