### PR TITLE
ci: run format check before commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 pnpm exec lint-staged
+pnpm run format:check


### PR DESCRIPTION
## Summary
- run the repo-wide Prettier check from the Husky pre-commit hook after lint-staged
- catch files that staged-file formatting misses before CI/deploy gates see them

## Verification
- pre-commit hook ran during commit
- pnpm run format:check passed in a clean worktree