### PR TITLE
feat(yt-video-mapper): expire abandoned queued match jobs

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -92,6 +92,23 @@ The worker is intentionally bounded: it handles one Match Job at a time in a
 service process, preserving the durable queue semantics without adding an
 external queue service.
 
+### Expired Match Job
+
+A Match Job that remained queued past the yt-video-mapper queue expiry window
+without being claimed by a worker or operator.
+
+An Expired Match Job is terminal: its raw upload is removed, but its lightweight
+job row remains pollable until normal result retention so callers can distinguish
+queue expiry from an unknown job.
+
+### Match Job Cleaner
+
+The yt-video-mapper cleanup process that expires abandoned queued Match Jobs and
+removes their raw uploads independently of client polling.
+
+The cleaner owns queue-age expiry only; running-job recovery remains the Match
+Job Worker's stale-running reclaim path.
+
 ### Match Candidate
 
 A ranked possible attribution produced by a Match Job, pairing a source Video with its likely Dub and a confidence judgment.

--- a/apps/yt-video-mapper-backend/README.md
+++ b/apps/yt-video-mapper-backend/README.md
@@ -76,6 +76,18 @@ more work. Set `MATCH_JOB_WORKER_ENABLED=false` to disable the loop for an
 operator session, and tune `MATCH_JOB_WORKER_POLL_INTERVAL_MS` only when the
 default 1 second idle poll is too chatty or too slow.
 
+The server also starts a Match Job Cleaner. It runs every minute, expires
+queued jobs that have remained unclaimed for 30 minutes, deletes their raw
+uploads, and keeps the lightweight job row pollable as:
+
+```json
+{ "jobId": "job-id", "status": "expired", "errorCode": "job_expired" }
+```
+
+Running jobs are not expired by the cleaner; stale running jobs remain owned by
+the worker reclaim path. The manual process endpoint can still rescue an
+overdue queued job until the cleaner marks it `expired`.
+
 Before production smoke tests can return non-empty candidates, run:
 
 ```sh

--- a/apps/yt-video-mapper-backend/docs/railway-deployment.md
+++ b/apps/yt-video-mapper-backend/docs/railway-deployment.md
@@ -50,7 +50,14 @@ Required for production:
 - `JOB_RESULT_RETENTION_HOURS=168`
 - `JOB_RUNNING_STALE_MINUTES=30`
 - `MATCH_JOB_WORKER_ENABLED=true`
+- `MATCH_JOB_CLEANER_ENABLED=true`
 - `MATCH_JOB_WORKER_POLL_INTERVAL_MS=1000`
+
+The Match Job Cleaner has fixed timing policy rather than production tuning
+knobs: it runs every minute and expires queued jobs that have remained
+unclaimed for 30 minutes. `MATCH_JOB_CLEANER_ENABLED=false` is an operational
+kill switch for rollout or incident response only; it should not be used to
+change expiry behavior.
 
 Required when running catalog sync:
 
@@ -91,6 +98,54 @@ Expected results:
 - `POST /match-jobs` with the valid mapper token returns `202` and a `jobId`.
 - With `MATCH_JOB_WORKER_ENABLED=true`, polling that job should leave
   `queued` without a manual `/process` call.
+- If a job remains queued for 30 minutes, a cleaner tick marks it terminal and
+  polling returns `{ "jobId": "...", "status": "expired", "errorCode":
+"job_expired" }`.
+
+Verify the schema migration and cleaner state through Railway Postgres:
+
+```sql
+SELECT enumlabel
+FROM pg_enum
+WHERE enumtypid = 'match_job_status'::regtype
+ORDER BY enumsortorder;
+
+SELECT indexname
+FROM pg_indexes
+WHERE tablename = 'mapper_match_job'
+  AND indexname IN (
+    'mapper_match_job_status_queued_at_idx',
+    'mapper_match_job_expired_upload_cleanup_idx'
+  )
+ORDER BY indexname;
+
+SELECT status, count(*) AS jobs
+FROM mapper_match_job
+GROUP BY status
+ORDER BY status;
+
+SELECT count(*) AS overdue_queued_jobs
+FROM mapper_match_job
+WHERE status = 'queued'
+  AND queued_at <= now() - interval '30 minutes';
+
+SELECT count(*) AS expired_jobs_with_uploads
+FROM mapper_match_job
+WHERE status = 'expired'
+  AND (
+    upload_storage_key IS NOT NULL
+    OR upload_content_type IS NOT NULL
+    OR upload_byte_length IS NOT NULL
+  );
+
+SELECT name, locked_until, owner_token IS NOT NULL AS has_owner_token
+FROM mapper_match_job_cleaner_lease;
+```
+
+Expected migration checks: `expired` is present in `match_job_status`; both
+queue-cleaner indexes exist; `overdue_queued_jobs` trends to zero while the
+cleaner is enabled; `expired_jobs_with_uploads` trends to zero unless storage
+cleanup is failing.
 
 ## Catalog Sync
 
@@ -166,15 +221,43 @@ or large media payloads into tickets or commits.
 
 ## Queue Cleanup
 
-The worker is the primary queue cleanup path. After deploying or restarting a
-build with `MATCH_JOB_WORKER_ENABLED=true`, it claims queued jobs and stale
-running jobs through the same durable repository path used by the manual
+The worker is the primary processing path. After deploying or restarting a
+build with `MATCH_JOB_WORKER_ENABLED=true`, it claims fresh queued jobs and
+stale running jobs through the same durable repository path used by the manual
 process endpoint.
+
+The Match Job Cleaner is the abandoned-queue cleanup path. It starts
+independently from `MATCH_JOB_WORKER_ENABLED` when
+`MATCH_JOB_CLEANER_ENABLED=true`, runs every minute, and expires queued jobs
+that have stayed unclaimed for 30 minutes. Existing queued rows that are
+already overdue when a deploy lands are expired on the first cleaner pass. Each
+expired row keeps its job ID and returns the explicit `job_expired` polling
+response, but the cleaner removes raw upload bytes and clears upload fields
+after deletion succeeds.
+
+Cleaner logs use safe counters:
+
+- `event=cleaner_tick expiredJobs=... uploadCleanupSucceeded=...
+uploadCleanupFailed=... expiredUploadRetries=...
+remainingExpiredUploads=...`
+- `event=upload_cleanup_failed ...` indicates expired rows still have upload
+  fields and need the retry path or operator inspection.
+- `event=repeated_cleanup_failures ...` should be treated as an alert signal
+  during deploy smoke or incident review.
 
 If the backlog must be inspected or discarded instead of processed, use
 authenticated Railway/Postgres access to query `mapper_match_job` by `status`.
 The public API does not expose a queue listing endpoint, so a bearer token alone
 can process only known `jobId` values.
+
+Forward-only rollback for cleaner incidents:
+
+- Set `MATCH_JOB_CLEANER_ENABLED=false` and redeploy if cleaner ticks must stop.
+- Leave the `expired` enum value and cleaner lease table in place; Postgres enum
+  removal is not part of rollback.
+- Keep the worker enabled only if fresh queued jobs should continue processing.
+- Re-enable `MATCH_JOB_CLEANER_ENABLED=true` once logs and SQL checks show the
+  cleaner can safely resume.
 
 ## 2026-06-09 Provisioning Notes
 

--- a/apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql
+++ b/apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql
@@ -1,0 +1,26 @@
+-- Expire abandoned queued match jobs without removing their lightweight job rows.
+ALTER TYPE "match_job_status" ADD VALUE 'expired';
+
+-- Support cleaner scans for queued jobs crossing the expiry threshold.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_status_queued_at_idx"
+ON "mapper_match_job"("status", "queued_at");
+
+-- Support sparse retries for expired rows whose raw upload cleanup failed.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"
+ON "mapper_match_job"("queued_at", "id")
+WHERE "status" = 'expired'
+  AND (
+    "upload_storage_key" IS NOT NULL
+    OR "upload_content_type" IS NOT NULL
+    OR "upload_byte_length" IS NOT NULL
+  );
+
+-- Coordinate cleaner passes across app instances without adding an external queue.
+CREATE TABLE "mapper_match_job_cleaner_lease" (
+  "name" TEXT NOT NULL,
+  "locked_until" TIMESTAMP(3) NOT NULL,
+  "owner_token" TEXT NOT NULL,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "mapper_match_job_cleaner_lease_pkey" PRIMARY KEY ("name")
+);

--- a/apps/yt-video-mapper-backend/prisma/schema.prisma
+++ b/apps/yt-video-mapper-backend/prisma/schema.prisma
@@ -39,6 +39,7 @@ enum MatchJobStatus {
   RUNNING  @map("running")
   COMPLETE @map("complete")
   FAILED   @map("failed")
+  EXPIRED  @map("expired")
 
   @@map("match_job_status")
 }
@@ -204,8 +205,18 @@ model MatchJob {
   evidence   MatchEvidence[]
 
   @@index([status, createdAt])
+  @@index([status, queuedAt])
   @@index([retentionExpiresAt])
   @@map("mapper_match_job")
+}
+
+model MatchJobCleanerLease {
+  name        String   @id
+  lockedUntil DateTime @map("locked_until")
+  ownerToken  String   @map("owner_token")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@map("mapper_match_job_cleaner_lease")
 }
 
 model MatchCandidate {

--- a/apps/yt-video-mapper-backend/src/cleaner.test.ts
+++ b/apps/yt-video-mapper-backend/src/cleaner.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { startMatchJobCleaner } from "./cleaner.js"
+import type {
+  MatchJobCleanerSummary,
+  MatchJobService,
+} from "./services/match-job.service.js"
+import {
+  MATCH_JOB_CLEANER_INTERVAL_MS,
+  MATCH_JOB_CLEANER_PAGE_SIZE,
+} from "./services/match-job.service.js"
+
+describe("startMatchJobCleaner", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("runs immediately and then waits for the fixed interval", async () => {
+    vi.useFakeTimers()
+    const service = new StubCleanerService([summary(), summary(), summary()])
+    const cleaner = startMatchJobCleaner(service.asService(), {
+      intervalMs: 50,
+      logger: silentLogger(),
+    })
+
+    await vi.runOnlyPendingTimersAsync()
+    expect(service.calls).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(49)
+    expect(service.calls).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(service.calls).toBe(2)
+
+    cleaner.stop()
+  })
+
+  it("uses the production cleaner interval and page size by default", async () => {
+    vi.useFakeTimers()
+    const logger = silentLogger()
+    const calls: Array<{ pageSize?: number }> = []
+    const service = {
+      async cleanExpiredQueuedJobs(options: { pageSize?: number }) {
+        calls.push(options)
+        return summary()
+      },
+    }
+    const cleaner = startMatchJobCleaner(
+      service as unknown as MatchJobService,
+      { logger },
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(logger.log).toHaveBeenCalledWith(
+      `[yt-video-mapper-cleaner] event=cleaner_started intervalMs=${MATCH_JOB_CLEANER_INTERVAL_MS}`,
+    )
+    expect(calls).toEqual([{ pageSize: MATCH_JOB_CLEANER_PAGE_SIZE }])
+
+    cleaner.stop()
+  })
+
+  it("does not overlap ticks while cleanup is still running", async () => {
+    vi.useFakeTimers()
+    let resolveCleanup: (value: MatchJobCleanerSummary) => void = () => {}
+    const service = {
+      calls: 0,
+      async cleanExpiredQueuedJobs() {
+        this.calls += 1
+        return new Promise<MatchJobCleanerSummary>((resolve) => {
+          resolveCleanup = resolve
+        })
+      },
+    }
+    const cleaner = startMatchJobCleaner(
+      service as unknown as MatchJobService,
+      {
+        intervalMs: 25,
+        logger: silentLogger(),
+      },
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(service.calls).toBe(1)
+
+    resolveCleanup(summary())
+    await vi.advanceTimersByTimeAsync(25)
+    expect(service.calls).toBe(2)
+
+    cleaner.stop()
+  })
+
+  it("logs a skipped tick when another cleaner owns the lease", async () => {
+    vi.useFakeTimers()
+    const logger = silentLogger()
+    const service = new StubCleanerService([
+      summary({ skippedDueToLock: true }),
+    ])
+    const cleaner = startMatchJobCleaner(service.asService(), {
+      intervalMs: 25,
+      logger,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(logger.log).toHaveBeenCalledWith(
+      "[yt-video-mapper-cleaner] event=cleaner_skipped reason=lease",
+    )
+
+    cleaner.stop()
+  })
+
+  it("keeps polling when cleanup throws", async () => {
+    vi.useFakeTimers()
+    const logger = silentLogger()
+    const service = new StubCleanerService([
+      new Error("database unavailable"),
+      summary(),
+    ])
+    const cleaner = startMatchJobCleaner(service.asService(), {
+      intervalMs: 25,
+      logger,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(service.calls).toBe(1)
+    expect(logger.error).toHaveBeenCalledWith(
+      '[yt-video-mapper-cleaner] event=cleaner_error error="database unavailable"',
+    )
+
+    await vi.advanceTimersByTimeAsync(25)
+    expect(service.calls).toBe(2)
+
+    cleaner.stop()
+  })
+
+  it("logs stuck uploads and repeated cleanup failures", async () => {
+    vi.useFakeTimers()
+    const logger = silentLogger()
+    const service = new StubCleanerService([
+      summary({ uploadCleanupFailed: 2, remainingExpiredUploads: 5 }),
+      summary({ uploadCleanupFailed: 1, remainingExpiredUploads: 4 }),
+      summary({ uploadCleanupFailed: 1, remainingExpiredUploads: 3 }),
+      summary(),
+    ])
+    const cleaner = startMatchJobCleaner(service.asService(), {
+      intervalMs: 25,
+      logger,
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(25)
+    await vi.advanceTimersByTimeAsync(25)
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "[yt-video-mapper-cleaner] event=upload_cleanup_failed failed=2 remainingExpiredUploads=5",
+    )
+    expect(logger.error).toHaveBeenCalledWith(
+      "[yt-video-mapper-cleaner] event=repeated_cleanup_failures consecutiveFailureTicks=3",
+    )
+
+    await vi.advanceTimersByTimeAsync(25)
+    await vi.advanceTimersByTimeAsync(25)
+
+    expect(logger.error).not.toHaveBeenCalledWith(
+      "[yt-video-mapper-cleaner] event=repeated_cleanup_failures consecutiveFailureTicks=4",
+    )
+
+    cleaner.stop()
+  })
+
+  it("does not schedule more cleanup when stopped during a tick", async () => {
+    vi.useFakeTimers()
+    let resolveCleanup: (value: MatchJobCleanerSummary) => void = () => {}
+    const service = {
+      calls: 0,
+      async cleanExpiredQueuedJobs() {
+        this.calls += 1
+        return new Promise<MatchJobCleanerSummary>((resolve) => {
+          resolveCleanup = resolve
+        })
+      },
+    }
+    const cleaner = startMatchJobCleaner(
+      service as unknown as MatchJobService,
+      {
+        intervalMs: 25,
+        logger: silentLogger(),
+      },
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(service.calls).toBe(1)
+
+    cleaner.stop()
+    resolveCleanup(summary())
+    await vi.advanceTimersByTimeAsync(25)
+
+    expect(service.calls).toBe(1)
+  })
+})
+
+class StubCleanerService {
+  calls = 0
+
+  constructor(
+    private readonly outcomes: Array<MatchJobCleanerSummary | Error>,
+  ) {}
+
+  asService(): MatchJobService {
+    return this as unknown as MatchJobService
+  }
+
+  async cleanExpiredQueuedJobs(): Promise<MatchJobCleanerSummary> {
+    this.calls += 1
+    const outcome = this.outcomes.shift() ?? summary()
+    if (outcome instanceof Error) throw outcome
+    return outcome
+  }
+}
+
+function summary({
+  expiredJobs = 0,
+  uploadCleanupSucceeded = 0,
+  uploadCleanupFailed = 0,
+  expiredUploadRetries = 0,
+  remainingExpiredUploads = 0,
+  skippedDueToLock = false,
+}: Partial<MatchJobCleanerSummary> = {}): MatchJobCleanerSummary {
+  return {
+    expiredJobs,
+    uploadCleanupSucceeded,
+    uploadCleanupFailed,
+    expiredUploadRetries,
+    remainingExpiredUploads,
+    skippedDueToLock,
+  }
+}
+
+function silentLogger() {
+  return {
+    error: vi.fn(),
+    log: vi.fn(),
+  }
+}

--- a/apps/yt-video-mapper-backend/src/cleaner.ts
+++ b/apps/yt-video-mapper-backend/src/cleaner.ts
@@ -1,0 +1,92 @@
+import {
+  MATCH_JOB_CLEANER_INTERVAL_MS,
+  MATCH_JOB_CLEANER_PAGE_SIZE,
+  type MatchJobCleanerSummary,
+  type MatchJobService,
+} from "./services/match-job.service.js"
+
+type Timer = ReturnType<typeof setTimeout>
+
+export type MatchJobCleaner = {
+  stop(): void
+}
+
+export type StartMatchJobCleanerOptions = {
+  intervalMs?: number
+  pageSize?: number
+  logger?: Pick<Console, "error" | "log">
+}
+
+export function startMatchJobCleaner(
+  service: MatchJobService,
+  {
+    intervalMs = MATCH_JOB_CLEANER_INTERVAL_MS,
+    pageSize = MATCH_JOB_CLEANER_PAGE_SIZE,
+    logger = console,
+  }: StartMatchJobCleanerOptions = {},
+): MatchJobCleaner {
+  let stopped = false
+  let timer: Timer | undefined
+  let consecutiveFailureTicks = 0
+
+  function schedule(delayMs: number): void {
+    timer = setTimeout(() => {
+      void tick()
+    }, delayMs)
+  }
+
+  async function tick(): Promise<void> {
+    if (stopped) return
+
+    try {
+      const summary = await service.cleanExpiredQueuedJobs({ pageSize })
+      logSummary(summary)
+
+      if (summary.uploadCleanupFailed > 0) {
+        consecutiveFailureTicks += 1
+        logger.error(
+          `[yt-video-mapper-cleaner] event=upload_cleanup_failed failed=${summary.uploadCleanupFailed} remainingExpiredUploads=${summary.remainingExpiredUploads}`,
+        )
+      } else {
+        consecutiveFailureTicks = 0
+      }
+    } catch (error) {
+      consecutiveFailureTicks += 1
+      logger.error(
+        `[yt-video-mapper-cleaner] event=cleaner_error error=${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
+      )
+    }
+
+    if (consecutiveFailureTicks >= 3) {
+      logger.error(
+        `[yt-video-mapper-cleaner] event=repeated_cleanup_failures consecutiveFailureTicks=${consecutiveFailureTicks}`,
+      )
+    }
+
+    if (!stopped) schedule(intervalMs)
+  }
+
+  function logSummary(summary: MatchJobCleanerSummary): void {
+    if (summary.skippedDueToLock) {
+      logger.log("[yt-video-mapper-cleaner] event=cleaner_skipped reason=lease")
+      return
+    }
+
+    logger.log(
+      `[yt-video-mapper-cleaner] event=cleaner_tick expiredJobs=${summary.expiredJobs} uploadCleanupSucceeded=${summary.uploadCleanupSucceeded} uploadCleanupFailed=${summary.uploadCleanupFailed} expiredUploadRetries=${summary.expiredUploadRetries} remainingExpiredUploads=${summary.remainingExpiredUploads}`,
+    )
+  }
+
+  logger.log(
+    `[yt-video-mapper-cleaner] event=cleaner_started intervalMs=${intervalMs}`,
+  )
+  schedule(0)
+
+  return {
+    stop() {
+      stopped = true
+      if (timer) clearTimeout(timer)
+      logger.log("[yt-video-mapper-cleaner] event=cleaner_stopped")
+    },
+  }
+}

--- a/apps/yt-video-mapper-backend/src/config/env.test.ts
+++ b/apps/yt-video-mapper-backend/src/config/env.test.ts
@@ -8,6 +8,7 @@ const envKeys = [
   "ADMIN_SERVICE_BEARER_TOKEN",
   "MAPPER_API_TOKEN",
   "MATCH_JOB_WORKER_ENABLED",
+  "MATCH_JOB_CLEANER_ENABLED",
   "MATCH_JOB_WORKER_POLL_INTERVAL_MS",
   "MEDIA_SIGNATURE_ALGORITHM_VERSION",
   "MEDIA_INDEX_PAGE_SIZE",
@@ -77,6 +78,7 @@ describe("runtime env", () => {
   it("defaults media indexing settings and treats empty resume cursor as unset", async () => {
     const { env } = await loadEnv({
       MATCH_JOB_WORKER_ENABLED: "",
+      MATCH_JOB_CLEANER_ENABLED: "",
       MATCH_JOB_WORKER_POLL_INTERVAL_MS: "",
       MEDIA_SIGNATURE_ALGORITHM_VERSION: "",
       MEDIA_INDEX_PAGE_SIZE: "",
@@ -87,6 +89,7 @@ describe("runtime env", () => {
     })
 
     expect(env.MATCH_JOB_WORKER_ENABLED).toBe("true")
+    expect(env.MATCH_JOB_CLEANER_ENABLED).toBe("true")
     expect(env.MATCH_JOB_WORKER_POLL_INTERVAL_MS).toBe(1_000)
     expect(env.MEDIA_SIGNATURE_ALGORITHM_VERSION).toBe(
       "official-media-signature-v1",
@@ -98,13 +101,15 @@ describe("runtime env", () => {
     expect(env.MEDIA_INDEX_RESUME_AFTER_VARIANT_ID).toBeUndefined()
   })
 
-  it("parses worker settings without boolean coercion", async () => {
+  it("parses worker and cleaner settings without boolean coercion", async () => {
     const { env } = await loadEnv({
       MATCH_JOB_WORKER_ENABLED: "false",
+      MATCH_JOB_CLEANER_ENABLED: "false",
       MATCH_JOB_WORKER_POLL_INTERVAL_MS: "2500",
     })
 
     expect(env.MATCH_JOB_WORKER_ENABLED).toBe("false")
+    expect(env.MATCH_JOB_CLEANER_ENABLED).toBe("false")
     expect(env.MATCH_JOB_WORKER_POLL_INTERVAL_MS).toBe(2_500)
   })
 

--- a/apps/yt-video-mapper-backend/src/config/env.ts
+++ b/apps/yt-video-mapper-backend/src/config/env.ts
@@ -21,6 +21,10 @@ const envSchema = z.object({
     .enum(["true", "false"])
     .optional()
     .default("true"),
+  MATCH_JOB_CLEANER_ENABLED: z
+    .enum(["true", "false"])
+    .optional()
+    .default("true"),
   MATCH_JOB_WORKER_POLL_INTERVAL_MS: z.coerce
     .number()
     .int()
@@ -65,6 +69,9 @@ export const env = envSchema.parse({
   ),
   MATCH_JOB_WORKER_ENABLED: emptyToUndefined(
     process.env.MATCH_JOB_WORKER_ENABLED,
+  ),
+  MATCH_JOB_CLEANER_ENABLED: emptyToUndefined(
+    process.env.MATCH_JOB_CLEANER_ENABLED,
   ),
   MATCH_JOB_WORKER_POLL_INTERVAL_MS: emptyToUndefined(
     process.env.MATCH_JOB_WORKER_POLL_INTERVAL_MS,

--- a/apps/yt-video-mapper-backend/src/db/match-job.repository.test.ts
+++ b/apps/yt-video-mapper-backend/src/db/match-job.repository.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  MatchJobStatus as PrismaMatchJobStatus,
+  type MatchJob,
+  type PrismaClient,
+} from "../generated/prisma/index.js"
+import { JOB_EXPIRED_ERROR_CODE } from "../services/match-job.service.js"
+import { PrismaMatchJobRepository } from "./match-job.repository.js"
+
+describe("PrismaMatchJobRepository cleaner operations", () => {
+  it("expires queued jobs in a bounded batch and returns only transitioned rows", async () => {
+    const cutoff = new Date("2026-06-08T00:30:00.000Z")
+    const findMany = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: "job-a" }, { id: "job-b" }])
+      .mockResolvedValueOnce([
+        prismaJob({
+          id: "job-a",
+          status: PrismaMatchJobStatus.EXPIRED,
+          safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+        }),
+        prismaJob({
+          id: "job-b",
+          status: PrismaMatchJobStatus.EXPIRED,
+          safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+        }),
+      ])
+    const updateMany = vi.fn().mockResolvedValue({ count: 2 })
+    const repository = createRepository({
+      $transaction: async (
+        callback: (tx: unknown) => Promise<unknown>,
+      ): Promise<unknown> =>
+        callback({
+          matchJob: {
+            findMany,
+            updateMany,
+          },
+        }),
+    })
+
+    const result = await repository.expireQueuedBefore(cutoff, 2)
+
+    expect(findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          status: PrismaMatchJobStatus.QUEUED,
+          queuedAt: { lte: cutoff },
+        },
+        orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
+        take: 2,
+        select: { id: true },
+      }),
+    )
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["job-a", "job-b"] },
+        status: PrismaMatchJobStatus.QUEUED,
+        queuedAt: { lte: cutoff },
+      },
+      data: {
+        status: PrismaMatchJobStatus.EXPIRED,
+        safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+      },
+    })
+    expect(result).toMatchObject({
+      jobs: [
+        { id: "job-a", status: "expired" },
+        { id: "job-b", status: "expired" },
+      ],
+      scannedCount: 2,
+    })
+  })
+
+  it("uses cursor pagination when retrying expired upload cleanup", async () => {
+    const cursor = {
+      queuedAt: new Date("2026-06-08T00:00:00.000Z"),
+      id: "job-a",
+    }
+    const findMany = vi.fn().mockResolvedValue([
+      prismaJob({
+        id: "job-b",
+        status: PrismaMatchJobStatus.EXPIRED,
+        queuedAt: new Date("2026-06-08T00:01:00.000Z"),
+      }),
+    ])
+    const repository = createRepository({
+      matchJob: {
+        findMany,
+      },
+    })
+
+    const jobs = await repository.listExpiredWithUploads(50, cursor)
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        status: PrismaMatchJobStatus.EXPIRED,
+        AND: [
+          {
+            OR: [
+              { queuedAt: { gt: cursor.queuedAt } },
+              {
+                queuedAt: cursor.queuedAt,
+                id: { gt: cursor.id },
+              },
+            ],
+          },
+        ],
+        OR: [
+          { uploadStorageKey: { not: null } },
+          { uploadContentType: { not: null } },
+          { uploadByteLength: { not: null } },
+        ],
+      },
+      orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
+      take: 50,
+    })
+    expect(jobs).toMatchObject([{ id: "job-b", status: "expired" }])
+  })
+
+  it("clears upload fields only after a row is expired", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 })
+    const repository = createRepository({
+      matchJob: {
+        updateMany,
+      },
+    })
+
+    await repository.clearUploadFields("job-expired")
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "job-expired",
+        status: PrismaMatchJobStatus.EXPIRED,
+      },
+      data: {
+        uploadStorageKey: null,
+        uploadContentType: null,
+        uploadByteLength: null,
+      },
+    })
+  })
+
+  it("records and releases cleaner leases by owner token", async () => {
+    const now = new Date("2026-06-08T00:00:00.000Z")
+    const lockedUntil = new Date("2026-06-08T00:30:00.000Z")
+    const updateMany = vi
+      .fn()
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 })
+    const create = vi.fn().mockResolvedValue({})
+    const repository = createRepository({
+      matchJobCleanerLease: {
+        updateMany,
+        create,
+      },
+    })
+
+    await expect(
+      repository.tryAcquireCleanerLease(now, lockedUntil, "owner-a"),
+    ).resolves.toBe(true)
+    await repository.releaseCleanerLease(now, "owner-a")
+
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        name: "match_job_cleaner",
+        lockedUntil,
+        ownerToken: "owner-a",
+      },
+    })
+    expect(updateMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        name: "match_job_cleaner",
+        ownerToken: "owner-a",
+        lockedUntil: { gt: now },
+      },
+      data: { lockedUntil: now },
+    })
+  })
+})
+
+function createRepository(db: unknown): PrismaMatchJobRepository {
+  return new PrismaMatchJobRepository(db as PrismaClient)
+}
+
+function prismaJob({
+  id,
+  ...overrides
+}: Partial<MatchJob> & { id: string }): MatchJob {
+  const timestamp = new Date("2026-06-08T00:00:00.000Z")
+
+  return {
+    id,
+    status: PrismaMatchJobStatus.QUEUED,
+    uploadStorageKey: "upload-key",
+    uploadContentType: "video/mp4",
+    uploadByteLength: BigInt(10),
+    inputDurationMilliseconds: null,
+    resultLimit: 3,
+    safeErrorCode: null,
+    queuedAt: timestamp,
+    startedAt: null,
+    completedAt: null,
+    failedAt: null,
+    retentionExpiresAt: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...overrides,
+  }
+}

--- a/apps/yt-video-mapper-backend/src/db/match-job.repository.ts
+++ b/apps/yt-video-mapper-backend/src/db/match-job.repository.ts
@@ -6,14 +6,22 @@ import {
   type PrismaClient,
 } from "../generated/prisma/index.js"
 import type {
+  ExpiredUploadCursor,
+  ExpireQueuedJobsBatch,
+  MatchJobCleanerRepository,
   MatchJobRecord,
   MatchJobRepository,
   MatchJobStatus,
   StoredMatchCandidate,
 } from "../services/match-job.service.js"
+import { JOB_EXPIRED_ERROR_CODE } from "../services/match-job.service.js"
 import type { PublicMatchCandidate } from "../domain/match.js"
 
-export class PrismaMatchJobRepository implements MatchJobRepository {
+const MATCH_JOB_CLEANER_LEASE_NAME = "match_job_cleaner"
+
+export class PrismaMatchJobRepository
+  implements MatchJobRepository, MatchJobCleanerRepository
+{
   constructor(private readonly db: PrismaClient) {}
 
   async create(job: MatchJobRecord): Promise<MatchJobRecord> {
@@ -73,11 +81,12 @@ export class PrismaMatchJobRepository implements MatchJobRepository {
   async claimNextQueued(
     startedAt: Date,
     staleStartedBefore: Date,
+    queuedExpiresAt?: Date,
   ): Promise<MatchJobRecord | null> {
     return this.db.$transaction(async (tx) => {
       const candidate = await tx.matchJob.findFirst({
-        where: processableWhere(staleStartedBefore),
-        orderBy: [{ queuedAt: "asc" }, { createdAt: "asc" }],
+        where: processableWhere(staleStartedBefore, queuedExpiresAt),
+        orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
         select: { id: true },
       })
 
@@ -86,7 +95,7 @@ export class PrismaMatchJobRepository implements MatchJobRepository {
       const claimed = await tx.matchJob.updateMany({
         where: {
           id: candidate.id,
-          ...processableWhere(staleStartedBefore),
+          ...processableWhere(staleStartedBefore, queuedExpiresAt),
         },
         data: {
           status: PrismaMatchJobStatus.RUNNING,
@@ -99,6 +108,127 @@ export class PrismaMatchJobRepository implements MatchJobRepository {
 
       const job = await tx.matchJob.findUnique({ where: { id: candidate.id } })
       return job ? fromPrismaJob(job) : null
+    })
+  }
+
+  async expireQueuedBefore(
+    queuedAtOrBefore: Date,
+    limit: number,
+  ): Promise<ExpireQueuedJobsBatch> {
+    return this.db.$transaction(async (tx) => {
+      const candidates = await tx.matchJob.findMany({
+        where: queuedExpiredWhere(queuedAtOrBefore),
+        orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
+        take: limit,
+        select: { id: true },
+      })
+      const candidateIds = candidates.map(({ id }) => id)
+
+      if (candidateIds.length === 0) {
+        return {
+          jobs: [],
+          scannedCount: 0,
+        }
+      }
+
+      await tx.matchJob.updateMany({
+        where: {
+          id: { in: candidateIds },
+          ...queuedExpiredWhere(queuedAtOrBefore),
+        },
+        data: {
+          status: PrismaMatchJobStatus.EXPIRED,
+          safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+        },
+      })
+
+      const expiredJobs = await tx.matchJob.findMany({
+        where: {
+          id: { in: candidateIds },
+          status: PrismaMatchJobStatus.EXPIRED,
+          safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+        },
+        orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
+      })
+
+      return {
+        jobs: expiredJobs.map(fromPrismaJob),
+        scannedCount: candidates.length,
+      }
+    })
+  }
+
+  async listExpiredWithUploads(
+    limit: number,
+    after?: ExpiredUploadCursor,
+  ): Promise<MatchJobRecord[]> {
+    const jobs = await this.db.matchJob.findMany({
+      where: expiredWithUploadsWhere(after),
+      orderBy: [{ queuedAt: "asc" }, { id: "asc" }],
+      take: limit,
+    })
+
+    return jobs.map(fromPrismaJob)
+  }
+
+  async clearUploadFields(jobId: string): Promise<void> {
+    await this.db.matchJob.updateMany({
+      where: {
+        id: jobId,
+        status: PrismaMatchJobStatus.EXPIRED,
+      },
+      data: {
+        uploadStorageKey: null,
+        uploadContentType: null,
+        uploadByteLength: null,
+      },
+    })
+  }
+
+  async countExpiredWithUploads(): Promise<number> {
+    return this.db.matchJob.count({
+      where: expiredWithUploadsWhere(),
+    })
+  }
+
+  async tryAcquireCleanerLease(
+    now: Date,
+    lockedUntil: Date,
+    ownerToken: string,
+  ): Promise<boolean> {
+    const refreshed = await this.db.matchJobCleanerLease.updateMany({
+      where: {
+        name: MATCH_JOB_CLEANER_LEASE_NAME,
+        lockedUntil: { lte: now },
+      },
+      data: { lockedUntil, ownerToken },
+    })
+
+    if (refreshed.count > 0) return true
+
+    try {
+      await this.db.matchJobCleanerLease.create({
+        data: {
+          name: MATCH_JOB_CLEANER_LEASE_NAME,
+          lockedUntil,
+          ownerToken,
+        },
+      })
+      return true
+    } catch (error) {
+      if (isUniqueConstraintError(error)) return false
+      throw error
+    }
+  }
+
+  async releaseCleanerLease(now: Date, ownerToken: string): Promise<void> {
+    await this.db.matchJobCleanerLease.updateMany({
+      where: {
+        name: MATCH_JOB_CLEANER_LEASE_NAME,
+        ownerToken,
+        lockedUntil: { gt: now },
+      },
+      data: { lockedUntil: now },
     })
   }
 
@@ -148,14 +278,53 @@ export class PrismaMatchJobRepository implements MatchJobRepository {
   }
 }
 
-function processableWhere(staleStartedBefore: Date) {
+function processableWhere(
+  staleStartedBefore: Date,
+  queuedExpiresAt: Date | undefined,
+) {
   return {
     OR: [
-      { status: PrismaMatchJobStatus.QUEUED },
+      {
+        status: PrismaMatchJobStatus.QUEUED,
+        ...(queuedExpiresAt ? { queuedAt: { gt: queuedExpiresAt } } : {}),
+      },
       {
         status: PrismaMatchJobStatus.RUNNING,
         startedAt: { lte: staleStartedBefore },
       },
+    ],
+  }
+}
+
+function queuedExpiredWhere(queuedAtOrBefore: Date) {
+  return {
+    status: PrismaMatchJobStatus.QUEUED,
+    queuedAt: { lte: queuedAtOrBefore },
+  }
+}
+
+function expiredWithUploadsWhere(after?: ExpiredUploadCursor) {
+  return {
+    status: PrismaMatchJobStatus.EXPIRED,
+    ...(after
+      ? {
+          AND: [
+            {
+              OR: [
+                { queuedAt: { gt: after.queuedAt } },
+                {
+                  queuedAt: after.queuedAt,
+                  id: { gt: after.id },
+                },
+              ],
+            },
+          ],
+        }
+      : {}),
+    OR: [
+      { uploadStorageKey: { not: null } },
+      { uploadContentType: { not: null } },
+      { uploadByteLength: { not: null } },
     ],
   }
 }
@@ -214,6 +383,7 @@ function toPrismaStatus(status: MatchJobStatus): PrismaMatchJobStatus {
     running: PrismaMatchJobStatus.RUNNING,
     complete: PrismaMatchJobStatus.COMPLETE,
     failed: PrismaMatchJobStatus.FAILED,
+    expired: PrismaMatchJobStatus.EXPIRED,
   } satisfies Record<MatchJobStatus, PrismaMatchJobStatus>
 
   return map[status]
@@ -225,9 +395,19 @@ function fromPrismaStatus(status: PrismaMatchJobStatus): MatchJobStatus {
     [PrismaMatchJobStatus.RUNNING]: "running",
     [PrismaMatchJobStatus.COMPLETE]: "complete",
     [PrismaMatchJobStatus.FAILED]: "failed",
+    [PrismaMatchJobStatus.EXPIRED]: "expired",
   } satisfies Record<PrismaMatchJobStatus, MatchJobStatus>
 
   return map[status]
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2002"
+  )
 }
 
 function toPrismaStrength(

--- a/apps/yt-video-mapper-backend/src/db/schema.test.ts
+++ b/apps/yt-video-mapper-backend/src/db/schema.test.ts
@@ -5,6 +5,13 @@ const schema = readFileSync(
   new URL("../../prisma/schema.prisma", import.meta.url),
   "utf8",
 )
+const expiryMigration = readFileSync(
+  new URL(
+    "../../prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+)
 
 describe("mapper Prisma schema", () => {
   it("keeps the public Core identifiers unique in the catalog map", () => {
@@ -45,6 +52,31 @@ describe("mapper Prisma schema", () => {
       '@@unique([jobId, coreId, videoVariantId], map: "mapper_match_candidate_job_variant_key")',
     )
     expect(schema).toContain("@@index([coreId])")
+  })
+
+  it("supports expiring queued match jobs and coordinating cleaner passes", () => {
+    expect(schema).toContain('EXPIRED  @map("expired")')
+    expect(schema).toContain("@@index([status, queuedAt])")
+    expect(schema).toContain("model MatchJobCleanerLease")
+    expect(schema).toContain('ownerToken  String   @map("owner_token")')
+    expect(schema).toContain('@@map("mapper_match_job_cleaner_lease")')
+  })
+
+  it("keeps the queued-expiry migration deploy-safe and retry-friendly", () => {
+    expect(expiryMigration).toContain(
+      "ALTER TYPE \"match_job_status\" ADD VALUE 'expired'",
+    )
+    expect(expiryMigration).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_status_queued_at_idx"',
+    )
+    expect(expiryMigration).toContain(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"',
+    )
+    expect(expiryMigration).toContain("WHERE \"status\" = 'expired'")
+    expect(expiryMigration).toContain('"owner_token" TEXT NOT NULL')
+    expect(expiryMigration).not.toContain(
+      '"updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP',
+    )
   })
 
   it("keeps evidence internal and attached to jobs and candidates", () => {

--- a/apps/yt-video-mapper-backend/src/routes/match-jobs.test.ts
+++ b/apps/yt-video-mapper-backend/src/routes/match-jobs.test.ts
@@ -81,6 +81,38 @@ describe("match jobs route", () => {
     })
   })
 
+  it("polls expired jobs with the explicit expiry error code", async () => {
+    const repository = new InMemoryMatchJobRepository()
+    const storage = new InMemoryUploadStorage()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = new MatchJobService(
+      repository,
+      storage,
+      new StubExtractor({
+        visualHashes: ["frame-a"],
+        audioFingerprints: ["audio-a"],
+      }),
+      new StubMatcher([candidate]),
+      () => now,
+    )
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video"),
+      contentType: "video/mp4",
+    })
+    now = new Date("2026-06-08T00:31:00.000Z")
+    await service.cleanExpiredQueuedJobs()
+    const { request } = createHarness({ service })
+
+    await expect(request("GET", `/match-jobs/${job.id}`)).resolves.toEqual({
+      statusCode: 200,
+      body: {
+        jobId: job.id,
+        status: "expired",
+        errorCode: "job_expired",
+      },
+    })
+  })
+
   it("polls complete jobs with ranked public candidates", async () => {
     const { request, service } = createHarness()
     const created = await request("POST", "/match-jobs", Buffer.from("video"))
@@ -113,6 +145,40 @@ describe("match jobs route", () => {
       statusCode: 200,
       body: {
         candidates: [candidate],
+      },
+    })
+  })
+
+  it("returns the expired terminal payload from the manual process endpoint", async () => {
+    const repository = new InMemoryMatchJobRepository()
+    const storage = new InMemoryUploadStorage()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = new MatchJobService(
+      repository,
+      storage,
+      new StubExtractor({
+        visualHashes: ["frame-a"],
+        audioFingerprints: ["audio-a"],
+      }),
+      new StubMatcher([candidate]),
+      () => now,
+    )
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video"),
+      contentType: "video/mp4",
+    })
+    now = new Date("2026-06-08T00:31:00.000Z")
+    await service.cleanExpiredQueuedJobs()
+    const { request } = createHarness({ service })
+
+    await expect(
+      request("POST", `/match-jobs/${job.id}/process`),
+    ).resolves.toEqual({
+      statusCode: 200,
+      body: {
+        jobId: job.id,
+        status: "expired",
+        errorCode: "job_expired",
       },
     })
   })

--- a/apps/yt-video-mapper-backend/src/server.test.ts
+++ b/apps/yt-video-mapper-backend/src/server.test.ts
@@ -55,32 +55,61 @@ describe("handleRequest", () => {
 
   it("starts the match job worker with the route service", () => {
     const service = {} as MatchJobService
-    const stop = vi.fn()
-    const startedWith: MatchJobService[] = []
+    const stopWorker = vi.fn()
+    const stopCleaner = vi.fn()
+    const workerStartedWith: MatchJobService[] = []
+    const cleanerStartedWith: MatchJobService[] = []
 
     const runtime = createServerRuntime({
       matchJobService: service,
       workerEnabled: true,
       startMatchJobWorkerImpl: (matchJobService) => {
-        startedWith.push(matchJobService)
-        return { stop }
+        workerStartedWith.push(matchJobService)
+        return { stop: stopWorker }
+      },
+      startMatchJobCleanerImpl: (matchJobService) => {
+        cleanerStartedWith.push(matchJobService)
+        return { stop: stopCleaner }
       },
     })
 
-    expect(runtime.worker).toEqual({ stop })
-    expect(startedWith).toEqual([service])
+    expect(runtime.worker).toEqual({ stop: stopWorker })
+    expect(runtime.cleaner).toEqual({ stop: stopCleaner })
+    expect(workerStartedWith).toEqual([service])
+    expect(cleanerStartedWith).toEqual([service])
   })
 
-  it("can disable the match job worker", () => {
+  it("can disable the match job worker without disabling the cleaner", () => {
     const startMatchJobWorkerImpl = vi.fn()
+    const startMatchJobCleanerImpl = vi.fn(() => ({ stop: vi.fn() }))
 
     const runtime = createServerRuntime({
       matchJobService: {} as MatchJobService,
       workerEnabled: false,
       startMatchJobWorkerImpl,
+      startMatchJobCleanerImpl,
     })
 
     expect(runtime.worker).toBeNull()
+    expect(runtime.cleaner).toEqual({ stop: expect.any(Function) })
     expect(startMatchJobWorkerImpl).not.toHaveBeenCalled()
+    expect(startMatchJobCleanerImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it("can disable the match job cleaner without disabling the worker", () => {
+    const startMatchJobWorkerImpl = vi.fn(() => ({ stop: vi.fn() }))
+    const startMatchJobCleanerImpl = vi.fn()
+
+    const runtime = createServerRuntime({
+      matchJobService: {} as MatchJobService,
+      cleanerEnabled: false,
+      startMatchJobWorkerImpl,
+      startMatchJobCleanerImpl,
+    })
+
+    expect(runtime.worker).toEqual({ stop: expect.any(Function) })
+    expect(runtime.cleaner).toBeNull()
+    expect(startMatchJobWorkerImpl).toHaveBeenCalledTimes(1)
+    expect(startMatchJobCleanerImpl).not.toHaveBeenCalled()
   })
 })

--- a/apps/yt-video-mapper-backend/src/server.ts
+++ b/apps/yt-video-mapper-backend/src/server.ts
@@ -15,6 +15,7 @@ import {
 } from "./services/media-signature-matcher.js"
 import { FileSystemUploadStorage } from "./services/upload-storage.js"
 import { DeterministicUploadSignalExtractor } from "./services/upload-signal-extraction.js"
+import { startMatchJobCleaner, type MatchJobCleaner } from "./cleaner.js"
 import { startMatchJobWorker, type MatchJobWorker } from "./worker.js"
 
 export type ServerDependencies = {
@@ -26,7 +27,9 @@ export type ServerDependencies = {
 
 export type ServerRuntimeOptions = ServerDependencies & {
   workerEnabled?: boolean
+  cleanerEnabled?: boolean
   startMatchJobWorkerImpl?: typeof startMatchJobWorker
+  startMatchJobCleanerImpl?: typeof startMatchJobCleaner
 }
 
 export type ServerRuntime = {
@@ -35,6 +38,7 @@ export type ServerRuntime = {
     response: ServerResponse,
   ) => Promise<void>
   worker: MatchJobWorker | null
+  cleaner: MatchJobCleaner | null
 }
 
 export function createHandleRequest({
@@ -74,7 +78,9 @@ export const handleRequest = createHandleRequest()
 export function createServerRuntime({
   matchJobService = createDefaultMatchJobService(),
   workerEnabled = env.MATCH_JOB_WORKER_ENABLED === "true",
+  cleanerEnabled = env.MATCH_JOB_CLEANER_ENABLED === "true",
   startMatchJobWorkerImpl = startMatchJobWorker,
+  startMatchJobCleanerImpl = startMatchJobCleaner,
   ...dependencies
 }: ServerRuntimeOptions = {}): ServerRuntime {
   return {
@@ -83,6 +89,7 @@ export function createServerRuntime({
       matchJobService,
     }),
     worker: workerEnabled ? startMatchJobWorkerImpl(matchJobService) : null,
+    cleaner: cleanerEnabled ? startMatchJobCleanerImpl(matchJobService) : null,
   }
 }
 
@@ -96,7 +103,10 @@ export function startServer(port = env.PORT): void {
       sendJson(response, 500, { error: "internal_error" })
     })
   })
-    .on("close", () => runtime.worker?.stop())
+    .on("close", () => {
+      runtime.worker?.stop()
+      runtime.cleaner?.stop()
+    })
     .listen(port, () => {
       console.log(`yt-video-mapper-backend listening on :${port}`)
     })

--- a/apps/yt-video-mapper-backend/src/services/match-job.service.test.ts
+++ b/apps/yt-video-mapper-backend/src/services/match-job.service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import type { PublicMatchCandidate } from "../domain/match.js"
 import {
   InMemoryMatchJobRepository,
+  JOB_EXPIRED_ERROR_CODE,
   MatchJobService,
   SafeMatchJobError,
   type Matcher,
@@ -299,6 +300,421 @@ describe("MatchJobService", () => {
     })
   })
 
+  it("returns expired jobs as terminal results and does not reprocess them", async () => {
+    const repository = new InMemoryMatchJobRepository()
+    const matcher = new CountingMatcher([candidate])
+    const service = createService({ repository, matcher })
+    await repository.create({
+      id: "job-expired",
+      status: "expired",
+      resultLimit: 3,
+      safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+      queuedAt: new Date("2026-06-08T00:00:00.000Z"),
+    })
+
+    await service.processJob("job-expired")
+
+    expect(matcher.calls).toBe(0)
+    await expect(service.getJobResult("job-expired")).resolves.toEqual({
+      jobId: "job-expired",
+      status: "expired",
+      errorCode: "job_expired",
+    })
+  })
+
+  it("expires abandoned queued jobs, removes uploads, and keeps rows pollable", async () => {
+    const storage = new InMemoryUploadStorage()
+    const repository = new InMemoryMatchJobRepository()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = createService({
+      repository,
+      storage,
+      now: () => now,
+    })
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video-bytes"),
+      contentType: "video/mp4",
+    })
+
+    now = new Date("2026-06-08T00:31:00.000Z")
+
+    await expect(service.cleanExpiredQueuedJobs()).resolves.toEqual({
+      expiredJobs: 1,
+      uploadCleanupSucceeded: 1,
+      uploadCleanupFailed: 0,
+      expiredUploadRetries: 0,
+      remainingExpiredUploads: 0,
+      skippedDueToLock: false,
+    })
+
+    expect(storage.has(job.uploadStorageKey!)).toBe(false)
+    await expect(repository.get(job.id)).resolves.toMatchObject({
+      id: job.id,
+      status: "expired",
+      safeErrorCode: "job_expired",
+      uploadStorageKey: undefined,
+      uploadContentType: undefined,
+      uploadByteLength: undefined,
+    })
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      jobId: job.id,
+      status: "expired",
+      errorCode: "job_expired",
+    })
+  })
+
+  it("expires queued jobs at the 30 minute boundary but not before it", async () => {
+    const storage = new InMemoryUploadStorage()
+    const repository = new InMemoryMatchJobRepository()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = createService({
+      repository,
+      storage,
+      now: () => now,
+    })
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video-bytes"),
+      contentType: "video/mp4",
+    })
+
+    now = new Date("2026-06-08T00:29:59.000Z")
+
+    await expect(service.cleanExpiredQueuedJobs()).resolves.toMatchObject({
+      expiredJobs: 0,
+      remainingExpiredUploads: 0,
+    })
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      jobId: job.id,
+      status: "queued",
+    })
+
+    now = new Date("2026-06-08T00:30:00.000Z")
+
+    await expect(service.cleanExpiredQueuedJobs()).resolves.toMatchObject({
+      expiredJobs: 1,
+      remainingExpiredUploads: 0,
+    })
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      jobId: job.id,
+      status: "expired",
+      errorCode: "job_expired",
+    })
+  })
+
+  it("does not expire running jobs and still lets stale running jobs be reclaimed", async () => {
+    const storage = new InMemoryUploadStorage()
+    const storedUpload = await storage.put({
+      bytes: Buffer.from("stale-video"),
+      contentType: "video/mp4",
+    })
+    const repository = new InMemoryMatchJobRepository()
+    await repository.create({
+      id: "job-stale-running",
+      status: "running",
+      uploadStorageKey: storedUpload.key,
+      uploadContentType: storedUpload.contentType,
+      uploadByteLength: storedUpload.byteLength,
+      resultLimit: 3,
+      queuedAt: new Date("2026-06-08T00:00:00.000Z"),
+      startedAt: new Date("2026-06-08T00:00:00.000Z"),
+    })
+    const service = createService({
+      repository,
+      storage,
+      matcher: new StubMatcher([candidate]),
+      now: () => new Date("2026-06-08T00:45:00.000Z"),
+    })
+
+    await expect(service.cleanExpiredQueuedJobs()).resolves.toMatchObject({
+      expiredJobs: 0,
+      remainingExpiredUploads: 0,
+    })
+    await expect(service.processNextJob()).resolves.toMatchObject({
+      id: "job-stale-running",
+      status: "running",
+    })
+    await expect(service.getJobResult("job-stale-running")).resolves.toEqual({
+      candidates: [candidate],
+    })
+  })
+
+  it("lets manual processing rescue an overdue queued job before cleanup wins", async () => {
+    const repository = new InMemoryMatchJobRepository()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = createService({
+      repository,
+      matcher: new StubMatcher([candidate]),
+      now: () => now,
+    })
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video-bytes"),
+      contentType: "video/mp4",
+    })
+
+    now = new Date("2026-06-08T00:31:00.000Z")
+    await service.processJob(job.id)
+
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      candidates: [candidate],
+    })
+  })
+
+  it("does not auto-claim expiry-eligible queued jobs while draining", async () => {
+    const repository = new InMemoryMatchJobRepository()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = createService({
+      repository,
+      matcher: new StubMatcher([candidate]),
+      now: () => now,
+    })
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video-bytes"),
+      contentType: "video/mp4",
+    })
+
+    now = new Date("2026-06-08T00:31:00.000Z")
+
+    await expect(service.processNextJob()).resolves.toBeNull()
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      jobId: job.id,
+      status: "queued",
+    })
+
+    await service.cleanExpiredQueuedJobs()
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      jobId: job.id,
+      status: "expired",
+      errorCode: "job_expired",
+    })
+  })
+
+  it("drains all overdue queued jobs in bounded pages during one cleanup pass", async () => {
+    const repository = new InMemoryMatchJobRepository()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = createService({
+      repository,
+      now: () => now,
+    })
+
+    const jobs = await Promise.all(
+      ["first", "second", "third"].map((name) =>
+        service.createUploadJob({
+          bytes: Buffer.from(`${name}-video`),
+          contentType: "video/mp4",
+        }),
+      ),
+    )
+
+    now = new Date("2026-06-08T00:31:00.000Z")
+
+    await expect(
+      service.cleanExpiredQueuedJobs({ pageSize: 2 }),
+    ).resolves.toMatchObject({
+      expiredJobs: 3,
+      uploadCleanupSucceeded: 3,
+      remainingExpiredUploads: 0,
+    })
+
+    for (const job of jobs) {
+      await expect(service.getJobResult(job.id)).resolves.toMatchObject({
+        status: "expired",
+        errorCode: "job_expired",
+      })
+    }
+  })
+
+  it("retries upload cleanup for expired rows with leftover upload fields", async () => {
+    const storage = new FailingRemoveOnceUploadStorage()
+    const repository = new InMemoryMatchJobRepository()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = createService({
+      repository,
+      storage,
+      now: () => now,
+    })
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video-bytes"),
+      contentType: "video/mp4",
+    })
+
+    now = new Date("2026-06-08T00:31:00.000Z")
+
+    await expect(service.cleanExpiredQueuedJobs()).resolves.toMatchObject({
+      expiredJobs: 1,
+      uploadCleanupSucceeded: 0,
+      uploadCleanupFailed: 1,
+      remainingExpiredUploads: 1,
+    })
+    expect(storage.has(job.uploadStorageKey!)).toBe(true)
+
+    await expect(service.cleanExpiredQueuedJobs()).resolves.toMatchObject({
+      expiredJobs: 0,
+      uploadCleanupSucceeded: 1,
+      uploadCleanupFailed: 0,
+      expiredUploadRetries: 1,
+      remainingExpiredUploads: 0,
+    })
+    expect(storage.has(job.uploadStorageKey!)).toBe(false)
+    await expect(repository.get(job.id)).resolves.toMatchObject({
+      status: "expired",
+      uploadStorageKey: undefined,
+      uploadContentType: undefined,
+      uploadByteLength: undefined,
+    })
+  })
+
+  it("skips cleanup when another cleaner owns the lease", async () => {
+    const storage = new InMemoryUploadStorage()
+    const repository = new InMemoryMatchJobRepository()
+    let now = new Date("2026-06-08T00:00:00.000Z")
+    const service = createService({
+      repository,
+      storage,
+      now: () => now,
+    })
+    const job = await service.createUploadJob({
+      bytes: Buffer.from("video-bytes"),
+      contentType: "video/mp4",
+    })
+    await repository.tryAcquireCleanerLease(
+      now,
+      new Date("2026-06-08T00:40:00.000Z"),
+      "other-cleaner",
+    )
+    now = new Date("2026-06-08T00:31:00.000Z")
+
+    await expect(service.cleanExpiredQueuedJobs()).resolves.toEqual({
+      expiredJobs: 0,
+      uploadCleanupSucceeded: 0,
+      uploadCleanupFailed: 0,
+      expiredUploadRetries: 0,
+      remainingExpiredUploads: 0,
+      skippedDueToLock: true,
+    })
+
+    expect(storage.has(job.uploadStorageKey!)).toBe(true)
+    await expect(service.getJobResult(job.id)).resolves.toEqual({
+      jobId: job.id,
+      status: "queued",
+    })
+  })
+
+  it("does not let an expired cleaner release a newer cleaner lease", async () => {
+    const repository = new InMemoryMatchJobRepository()
+
+    await expect(
+      repository.tryAcquireCleanerLease(
+        new Date("2026-06-08T00:00:00.000Z"),
+        new Date("2026-06-08T00:30:00.000Z"),
+        "cleaner-a",
+      ),
+    ).resolves.toBe(true)
+    await expect(
+      repository.tryAcquireCleanerLease(
+        new Date("2026-06-08T00:31:00.000Z"),
+        new Date("2026-06-08T01:01:00.000Z"),
+        "cleaner-b",
+      ),
+    ).resolves.toBe(true)
+
+    await repository.releaseCleanerLease(
+      new Date("2026-06-08T00:32:00.000Z"),
+      "cleaner-a",
+    )
+
+    await expect(
+      repository.tryAcquireCleanerLease(
+        new Date("2026-06-08T00:33:00.000Z"),
+        new Date("2026-06-08T01:03:00.000Z"),
+        "cleaner-c",
+      ),
+    ).resolves.toBe(false)
+
+    await repository.releaseCleanerLease(
+      new Date("2026-06-08T00:34:00.000Z"),
+      "cleaner-b",
+    )
+    await expect(
+      repository.tryAcquireCleanerLease(
+        new Date("2026-06-08T00:35:00.000Z"),
+        new Date("2026-06-08T01:05:00.000Z"),
+        "cleaner-c",
+      ),
+    ).resolves.toBe(true)
+  })
+
+  it("only clears upload fields for expired rows", async () => {
+    const repository = new InMemoryMatchJobRepository()
+    await repository.create({
+      id: "job-queued",
+      status: "queued",
+      uploadStorageKey: "queued-key",
+      uploadContentType: "video/mp4",
+      uploadByteLength: 10,
+      resultLimit: 3,
+      queuedAt: new Date("2026-06-08T00:00:00.000Z"),
+    })
+    await repository.create({
+      id: "job-expired",
+      status: "expired",
+      uploadStorageKey: "expired-key",
+      uploadContentType: "video/mp4",
+      uploadByteLength: 10,
+      resultLimit: 3,
+      queuedAt: new Date("2026-06-08T00:00:00.000Z"),
+    })
+
+    await repository.clearUploadFields("job-queued")
+    await repository.clearUploadFields("job-expired")
+
+    await expect(repository.get("job-queued")).resolves.toMatchObject({
+      uploadStorageKey: "queued-key",
+      uploadContentType: "video/mp4",
+      uploadByteLength: 10,
+    })
+    await expect(repository.get("job-expired")).resolves.toMatchObject({
+      uploadStorageKey: undefined,
+      uploadContentType: undefined,
+      uploadByteLength: undefined,
+    })
+  })
+
+  it("caps expired upload cleanup retries to one page per cleaner tick", async () => {
+    const storage = new AlwaysFailingRemoveUploadStorage()
+    const repository = new InMemoryMatchJobRepository()
+    const service = createService({
+      repository,
+      storage,
+      now: () => new Date("2026-06-08T00:31:00.000Z"),
+    })
+
+    for (const id of ["job-1", "job-2", "job-3"]) {
+      const storedUpload = await storage.put({
+        bytes: Buffer.from(id),
+        contentType: "video/mp4",
+      })
+      await repository.create({
+        id,
+        status: "expired",
+        uploadStorageKey: storedUpload.key,
+        uploadContentType: storedUpload.contentType,
+        uploadByteLength: storedUpload.byteLength,
+        resultLimit: 3,
+        safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+        queuedAt: new Date("2026-06-08T00:00:00.000Z"),
+      })
+    }
+
+    await expect(
+      service.cleanExpiredQueuedJobs({ pageSize: 2 }),
+    ).resolves.toMatchObject({
+      expiredJobs: 0,
+      expiredUploadRetries: 2,
+      uploadCleanupFailed: 2,
+      remainingExpiredUploads: 3,
+    })
+  })
+
   it("rejects empty uploads before storing a job", async () => {
     const service = createService()
 
@@ -382,6 +798,25 @@ class CountingMatcher implements Matcher {
   }
 }
 
+class FailingRemoveOnceUploadStorage extends InMemoryUploadStorage {
+  private readonly failedKeys = new Set<string>()
+
+  override async remove(key: string): Promise<void> {
+    if (!this.failedKeys.has(key)) {
+      this.failedKeys.add(key)
+      throw new UploadCleanupTestError()
+    }
+
+    await super.remove(key)
+  }
+}
+
+class AlwaysFailingRemoveUploadStorage extends InMemoryUploadStorage {
+  override async remove(): Promise<void> {
+    throw new UploadCleanupTestError()
+  }
+}
+
 class UploadProcessingTestError extends Error {
   constructor() {
     super("unexpected processing failure")
@@ -391,6 +826,12 @@ class UploadProcessingTestError extends Error {
 class RepositoryCreateTestError extends Error {
   constructor() {
     super("repository create failed")
+  }
+}
+
+class UploadCleanupTestError extends Error {
+  constructor() {
+    super("upload cleanup failed")
   }
 }
 

--- a/apps/yt-video-mapper-backend/src/services/match-job.service.ts
+++ b/apps/yt-video-mapper-backend/src/services/match-job.service.ts
@@ -7,7 +7,19 @@ import type {
 } from "./upload-signal-extraction.js"
 import type { UploadStorage } from "./upload-storage.js"
 
-export type MatchJobStatus = "queued" | "running" | "complete" | "failed"
+export const JOB_EXPIRED_ERROR_CODE = "job_expired"
+export const QUEUED_JOB_EXPIRY_MINUTES = 30
+export const MATCH_JOB_CLEANER_INTERVAL_MS = 60_000
+export const MATCH_JOB_CLEANER_PAGE_SIZE = 100
+export const MATCH_JOB_CLEANER_LEASE_MINUTES = 30
+export const MATCH_JOB_EXPIRED_UPLOAD_RETRY_PAGES_PER_TICK = 1
+
+export type MatchJobStatus =
+  | "queued"
+  | "running"
+  | "complete"
+  | "failed"
+  | "expired"
 
 export type MatchJobRecord = {
   id: string
@@ -45,6 +57,25 @@ export type MatchJobResult =
       candidates: PublicMatchCandidate[]
     }
 
+export type ExpireQueuedJobsBatch = {
+  jobs: MatchJobRecord[]
+  scannedCount: number
+}
+
+export type ExpiredUploadCursor = {
+  queuedAt: Date
+  id: string
+}
+
+export type MatchJobCleanerSummary = {
+  expiredJobs: number
+  uploadCleanupSucceeded: number
+  uploadCleanupFailed: number
+  expiredUploadRetries: number
+  remainingExpiredUploads: number
+  skippedDueToLock: boolean
+}
+
 export type MatchJobRepository = {
   create(job: MatchJobRecord): Promise<MatchJobRecord>
   get(jobId: string): Promise<MatchJobRecord | null>
@@ -56,6 +87,7 @@ export type MatchJobRepository = {
   claimNextQueued(
     startedAt: Date,
     staleStartedBefore: Date,
+    queuedExpiresAt?: Date,
   ): Promise<MatchJobRecord | null>
   update(
     jobId: string,
@@ -66,6 +98,25 @@ export type MatchJobRepository = {
     candidates: PublicMatchCandidate[],
   ): Promise<StoredMatchCandidate[]>
   listCandidates(jobId: string): Promise<StoredMatchCandidate[]>
+}
+
+export type MatchJobCleanerRepository = {
+  expireQueuedBefore(
+    queuedAtOrBefore: Date,
+    limit: number,
+  ): Promise<ExpireQueuedJobsBatch>
+  listExpiredWithUploads(
+    limit: number,
+    after?: ExpiredUploadCursor,
+  ): Promise<MatchJobRecord[]>
+  clearUploadFields(jobId: string): Promise<void>
+  countExpiredWithUploads(): Promise<number>
+  tryAcquireCleanerLease(
+    now: Date,
+    lockedUntil: Date,
+    ownerToken: string,
+  ): Promise<boolean>
+  releaseCleanerLease(now: Date, ownerToken: string): Promise<void>
 }
 
 export type Matcher = {
@@ -82,13 +133,19 @@ export class SafeMatchJobError extends Error {
 }
 
 export class MatchJobService {
+  private readonly cleanerRepository: MatchJobCleanerRepository | undefined
+
   constructor(
     private readonly repository: MatchJobRepository,
     private readonly storage: UploadStorage,
     private readonly extractor: UploadSignalExtractor,
     private readonly matcher: Matcher,
     private readonly now: () => Date = () => new Date(),
-  ) {}
+    cleanerRepository?: MatchJobCleanerRepository,
+  ) {
+    this.cleanerRepository =
+      cleanerRepository ?? asMatchJobCleanerRepository(repository)
+  }
 
   async createUploadJob({
     bytes,
@@ -122,7 +179,7 @@ export class MatchJobService {
   async processJob(jobId: string): Promise<void> {
     const existingJob = await this.repository.get(jobId)
     if (!existingJob) throw new SafeMatchJobError("job_not_found")
-    if (existingJob.status === "complete" || existingJob.status === "failed") {
+    if (isTerminalJob(existingJob)) {
       return
     }
 
@@ -142,11 +199,121 @@ export class MatchJobService {
     const job = await this.repository.claimNextQueued(
       startedAt,
       addMinutes(startedAt, -env.JOB_RUNNING_STALE_MINUTES),
+      addMinutes(startedAt, -QUEUED_JOB_EXPIRY_MINUTES),
     )
     if (!job) return null
 
     await this.processClaimedJob(job)
     return job
+  }
+
+  async cleanExpiredQueuedJobs({
+    pageSize = MATCH_JOB_CLEANER_PAGE_SIZE,
+  }: {
+    pageSize?: number
+  } = {}): Promise<MatchJobCleanerSummary> {
+    const cleanerRepository = this.requireCleanerRepository()
+    const lockNow = this.now()
+    const ownerToken = randomUUID()
+    const acquired = await cleanerRepository.tryAcquireCleanerLease(
+      lockNow,
+      addMinutes(lockNow, MATCH_JOB_CLEANER_LEASE_MINUTES),
+      ownerToken,
+    )
+
+    if (!acquired) {
+      return emptyCleanerSummary({ skippedDueToLock: true })
+    }
+
+    try {
+      return await this.cleanExpiredQueuedJobsWithoutLock(pageSize)
+    } finally {
+      await cleanerRepository
+        .releaseCleanerLease(this.now(), ownerToken)
+        .catch(() => {
+          // The lease expires on its own if release fails.
+        })
+    }
+  }
+
+  private async cleanExpiredQueuedJobsWithoutLock(
+    pageSize: number,
+  ): Promise<MatchJobCleanerSummary> {
+    const cleanerRepository = this.requireCleanerRepository()
+    const summary = emptyCleanerSummary()
+    const cutoff = addMinutes(this.now(), -QUEUED_JOB_EXPIRY_MINUTES)
+
+    await this.retryExpiredUploadCleanup(
+      pageSize,
+      MATCH_JOB_EXPIRED_UPLOAD_RETRY_PAGES_PER_TICK,
+      summary,
+    )
+
+    while (true) {
+      const batch = await cleanerRepository.expireQueuedBefore(cutoff, pageSize)
+      summary.expiredJobs += batch.jobs.length
+
+      await this.cleanupExpiredUploads(batch.jobs, summary)
+
+      if (batch.scannedCount < pageSize) break
+    }
+
+    summary.remainingExpiredUploads =
+      await cleanerRepository.countExpiredWithUploads()
+    return summary
+  }
+
+  private async retryExpiredUploadCleanup(
+    pageSize: number,
+    maxPages: number,
+    summary: MatchJobCleanerSummary,
+  ): Promise<void> {
+    const cleanerRepository = this.requireCleanerRepository()
+    let cursor: ExpiredUploadCursor | undefined
+    let pages = 0
+
+    while (pages < maxPages) {
+      const jobs = await cleanerRepository.listExpiredWithUploads(
+        pageSize,
+        cursor,
+      )
+      if (jobs.length === 0) break
+
+      pages += 1
+      summary.expiredUploadRetries += jobs.length
+      cursor = toExpiredUploadCursor(jobs[jobs.length - 1]!)
+
+      await this.cleanupExpiredUploads(jobs, summary)
+
+      if (jobs.length < pageSize) break
+    }
+  }
+
+  private async cleanupExpiredUploads(
+    jobs: MatchJobRecord[],
+    summary: MatchJobCleanerSummary,
+  ): Promise<void> {
+    const cleanerRepository = this.requireCleanerRepository()
+    for (const job of jobs) {
+      try {
+        if (job.uploadStorageKey) {
+          await this.storage.remove(job.uploadStorageKey)
+        }
+
+        await cleanerRepository.clearUploadFields(job.id)
+        summary.uploadCleanupSucceeded += 1
+      } catch {
+        summary.uploadCleanupFailed += 1
+      }
+    }
+  }
+
+  private requireCleanerRepository(): MatchJobCleanerRepository {
+    if (!this.cleanerRepository) {
+      throw new SafeMatchJobError("cleaner_repository_unavailable")
+    }
+
+    return this.cleanerRepository
   }
 
   private async processClaimedJob(job: MatchJobRecord): Promise<void> {
@@ -203,6 +370,14 @@ export class MatchJobService {
       }
     }
 
+    if (job.status === "expired") {
+      return {
+        jobId: job.id,
+        status: job.status,
+        errorCode: job.safeErrorCode ?? JOB_EXPIRED_ERROR_CODE,
+      }
+    }
+
     return {
       jobId: job.id,
       status: job.status,
@@ -213,6 +388,8 @@ export class MatchJobService {
 export class InMemoryMatchJobRepository implements MatchJobRepository {
   private readonly jobs = new Map<string, MatchJobRecord>()
   private readonly candidates = new Map<string, StoredMatchCandidate[]>()
+  private cleanerLeaseLockedUntil: Date | undefined
+  private cleanerLeaseOwnerToken: string | undefined
 
   async create(job: MatchJobRecord): Promise<MatchJobRecord> {
     this.jobs.set(job.id, { ...job })
@@ -251,14 +428,110 @@ export class InMemoryMatchJobRepository implements MatchJobRepository {
   async claimNextQueued(
     startedAt: Date,
     staleStartedBefore: Date,
+    queuedExpiresAt?: Date,
   ): Promise<MatchJobRecord | null> {
     const job = Array.from(this.jobs.values())
-      .filter((candidate) => isProcessable(candidate, staleStartedBefore))
-      .sort((a, b) => a.queuedAt.getTime() - b.queuedAt.getTime())[0]
+      .filter((candidate) =>
+        isProcessable(candidate, staleStartedBefore, queuedExpiresAt),
+      )
+      .sort(compareQueuedJobs)[0]
 
     if (!job) return null
 
     return this.claimQueued(job.id, startedAt, staleStartedBefore)
+  }
+
+  async expireQueuedBefore(
+    queuedAtOrBefore: Date,
+    limit: number,
+  ): Promise<ExpireQueuedJobsBatch> {
+    const candidates = Array.from(this.jobs.values())
+      .filter(
+        (job) => job.status === "queued" && job.queuedAt <= queuedAtOrBefore,
+      )
+      .sort(compareQueuedJobs)
+      .slice(0, limit)
+
+    const expiredJobs: MatchJobRecord[] = []
+
+    for (const candidate of candidates) {
+      const job = this.jobs.get(candidate.id)
+      if (!job || job.status !== "queued" || job.queuedAt > queuedAtOrBefore) {
+        continue
+      }
+
+      const expired = {
+        ...job,
+        status: "expired" as const,
+        safeErrorCode: JOB_EXPIRED_ERROR_CODE,
+      }
+      this.jobs.set(job.id, expired)
+      expiredJobs.push({ ...expired })
+    }
+
+    return {
+      jobs: expiredJobs,
+      scannedCount: candidates.length,
+    }
+  }
+
+  async listExpiredWithUploads(
+    limit: number,
+    after?: ExpiredUploadCursor,
+  ): Promise<MatchJobRecord[]> {
+    return Array.from(this.jobs.values())
+      .filter(
+        (job) =>
+          job.status === "expired" &&
+          hasUploadFields(job) &&
+          isAfterExpiredUploadCursor(job, after),
+      )
+      .sort(compareQueuedJobs)
+      .slice(0, limit)
+      .map((job) => ({ ...job }))
+  }
+
+  async clearUploadFields(jobId: string): Promise<void> {
+    const job = this.jobs.get(jobId)
+    if (!job || job.status !== "expired") return
+
+    const updated = {
+      ...job,
+      uploadStorageKey: undefined,
+      uploadContentType: undefined,
+      uploadByteLength: undefined,
+    }
+    this.jobs.set(jobId, updated)
+  }
+
+  async countExpiredWithUploads(): Promise<number> {
+    return Array.from(this.jobs.values()).filter(
+      (job) => job.status === "expired" && hasUploadFields(job),
+    ).length
+  }
+
+  async tryAcquireCleanerLease(
+    now: Date,
+    lockedUntil: Date,
+    ownerToken: string,
+  ): Promise<boolean> {
+    if (this.cleanerLeaseLockedUntil && this.cleanerLeaseLockedUntil > now) {
+      return false
+    }
+
+    this.cleanerLeaseLockedUntil = lockedUntil
+    this.cleanerLeaseOwnerToken = ownerToken
+    return true
+  }
+
+  async releaseCleanerLease(now: Date, ownerToken: string): Promise<void> {
+    if (
+      this.cleanerLeaseOwnerToken === ownerToken &&
+      this.cleanerLeaseLockedUntil &&
+      this.cleanerLeaseLockedUntil > now
+    ) {
+      this.cleanerLeaseLockedUntil = now
+    }
   }
 
   async update(
@@ -293,14 +566,95 @@ export class InMemoryMatchJobRepository implements MatchJobRepository {
   }
 }
 
-function isProcessable(job: MatchJobRecord, staleStartedBefore: Date): boolean {
-  if (job.status === "queued") return true
+function isTerminalJob(job: MatchJobRecord): boolean {
+  return (
+    job.status === "complete" ||
+    job.status === "failed" ||
+    job.status === "expired"
+  )
+}
+
+function isProcessable(
+  job: MatchJobRecord,
+  staleStartedBefore: Date,
+  queuedExpiresAt: Date | undefined,
+): boolean {
+  if (job.status === "queued") {
+    return queuedExpiresAt ? job.queuedAt > queuedExpiresAt : true
+  }
 
   return (
     job.status === "running" &&
     job.startedAt !== undefined &&
     job.startedAt <= staleStartedBefore
   )
+}
+
+function hasUploadFields(job: MatchJobRecord): boolean {
+  return (
+    job.uploadStorageKey !== undefined ||
+    job.uploadContentType !== undefined ||
+    job.uploadByteLength !== undefined
+  )
+}
+
+function compareQueuedJobs(a: MatchJobRecord, b: MatchJobRecord): number {
+  const queuedDelta = a.queuedAt.getTime() - b.queuedAt.getTime()
+  if (queuedDelta !== 0) return queuedDelta
+  return a.id.localeCompare(b.id)
+}
+
+function toExpiredUploadCursor(job: MatchJobRecord): ExpiredUploadCursor {
+  return {
+    queuedAt: job.queuedAt,
+    id: job.id,
+  }
+}
+
+function isAfterExpiredUploadCursor(
+  job: MatchJobRecord,
+  cursor: ExpiredUploadCursor | undefined,
+): boolean {
+  if (!cursor) return true
+  if (job.queuedAt > cursor.queuedAt) return true
+  return (
+    job.queuedAt.getTime() === cursor.queuedAt.getTime() && job.id > cursor.id
+  )
+}
+
+function asMatchJobCleanerRepository(
+  repository: MatchJobRepository,
+): MatchJobCleanerRepository | undefined {
+  const candidate = repository as MatchJobRepository &
+    Partial<MatchJobCleanerRepository>
+
+  if (
+    typeof candidate.expireQueuedBefore === "function" &&
+    typeof candidate.listExpiredWithUploads === "function" &&
+    typeof candidate.clearUploadFields === "function" &&
+    typeof candidate.countExpiredWithUploads === "function" &&
+    typeof candidate.tryAcquireCleanerLease === "function" &&
+    typeof candidate.releaseCleanerLease === "function"
+  ) {
+    return candidate as MatchJobCleanerRepository
+  }
+
+  return undefined
+}
+
+function emptyCleanerSummary({
+  skippedDueToLock = false,
+}: {
+  skippedDueToLock?: boolean
+} = {}): MatchJobCleanerSummary {
+  return {
+    expiredJobs: 0,
+    uploadCleanupSucceeded: 0,
+    uploadCleanupFailed: 0,
+    expiredUploadRetries: 0,
+    remainingExpiredUploads: 0,
+    skippedDueToLock,
+  }
 }
 
 function addHours(date: Date, hours: number): Date {

--- a/docs/brainstorms/2026-06-29-yt-mapper-queued-job-expiry-requirements.md
+++ b/docs/brainstorms/2026-06-29-yt-mapper-queued-job-expiry-requirements.md
@@ -1,0 +1,158 @@
+---
+date: 2026-06-29
+topic: yt-mapper-queued-job-expiry
+title: yt-mapper queued job expiry
+tags: [yt-video-mapper, background-jobs, queue-cleanup, retention]
+---
+
+# Yt-Mapper Queued Job Expiry
+
+## Summary
+
+Add yt-video-mapper-only expiry for queued match jobs: if a job remains queued for 30 minutes, a scheduled cleaner removes its raw upload and marks the lightweight job row as `expired`. Polling an expired job returns a clear terminal response instead of leaving the caller stuck on `queued`.
+
+---
+
+## Problem Frame
+
+The yt-video-mapper backend now has a worker that drains queued match jobs, but queue safety should not depend on every submitted job being promptly claimed or later polled by a client. A caller can submit an upload, lose interest, never poll again, and leave the job plus its raw media input sitting in the durable queue. During worker incidents, deploy windows, or high-volume testing, those forgotten jobs can accumulate and make queue state harder to reason about.
+
+The service needs a yt-mapper-scoped cleanup behavior that protects storage and queue hygiene while keeping the public polling contract understandable for known job IDs.
+
+---
+
+## Key Decisions
+
+- **Expired is a distinct terminal state.** Expiry is different from matcher failure, so callers should be able to tell that the job aged out before processing.
+- **Cleaner owns abandoned-job cleanup.** Expiry cannot rely on client polling because abandoned jobs are the exact case that needs cleanup.
+- **Uploads are removed, rows are preserved.** Raw media bytes should disappear when the queued job expires, while the lightweight job row remains pollable until normal result retention removes it.
+- **Manual rescue is allowed before cleanup.** An operator can still process an overdue queued job until the scheduled cleaner marks it `expired`.
+
+---
+
+## Requirements
+
+**Expiry Policy**
+
+- R1. Only yt-video-mapper match jobs in `apps/yt-video-mapper-backend` are in scope for this expiry behavior.
+- R2. A queued yt-mapper match job becomes eligible to expire when it has remained unclaimed for 30 minutes.
+- R3. Expiry applies only while a job is still `queued`; `running` jobs continue to use the existing stale-running reclaim behavior.
+- R4. Expiry applies to existing queued jobs after deploy, not only to newly created jobs.
+
+**Cleaner Behavior**
+
+- R5. A yt-mapper scheduled cleaner runs every minute to find queued jobs that have crossed the 30-minute expiry threshold.
+- R6. The cleaner removes the raw uploaded media for each expired queued job.
+- R7. The cleaner marks each expired queued job with terminal status `expired` and safe error code `job_expired`.
+- R8. The cleaner preserves the lightweight expired job row until the normal yt-mapper result-retention window removes terminal job records.
+- R9. The cleaner operates independently of client polling, so abandoned jobs expire even when nobody polls their job IDs.
+
+**API and Operator Semantics**
+
+- R10. Polling an expired job returns `{ jobId, status: "expired", errorCode: "job_expired" }`.
+- R11. Expired jobs cannot later be claimed by the background worker or manual process endpoint.
+- R12. A queued job older than 30 minutes can still be manually processed if the cleaner has not yet marked it `expired`.
+- R13. A client polling a non-expired queued job continues to receive the existing queued response.
+
+---
+
+## Actors
+
+- A1. **yt-mapper API client:** submits uploads and polls known match job IDs.
+- A2. **Match Job Worker:** claims queued or stale-running jobs and processes them.
+- A3. **Scheduled Cleaner:** expires abandoned queued jobs and removes their raw uploads.
+- A4. **Operator:** may manually process a known queued job before it is expired.
+
+---
+
+## Key Flows
+
+- F1. Queued job expires without polling
+  - **Trigger:** A queued yt-mapper match job passes the 30-minute threshold.
+  - **Actors:** A3.
+  - **Steps:** Cleaner runs on its one-minute cadence -> finds the overdue queued job -> removes the raw upload -> marks the job `expired` with `job_expired`.
+  - **Outcome:** The job leaves the queue, the upload no longer consumes storage, and the job ID remains pollable.
+  - **Covers:** R2, R5, R6, R7, R8, R9.
+- F2. Client polls an expired job
+  - **Trigger:** A client polls a job ID after the cleaner expired it.
+  - **Actors:** A1.
+  - **Steps:** The API reads the terminal job row -> returns the expired response.
+  - **Outcome:** The caller gets a clear terminal result and stops waiting.
+  - **Covers:** R10.
+- F3. Operator rescues an overdue queued job
+  - **Trigger:** A known queued job is older than 30 minutes, but the cleaner has not marked it expired yet.
+  - **Actors:** A4, A2.
+  - **Steps:** Operator manually processes the known job -> normal processing claims it -> the job follows the existing running/complete/failed lifecycle.
+  - **Outcome:** Manual recovery remains possible until the cleaner formally expires the job.
+  - **Covers:** R11, R12.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued: upload accepted
+  Queued --> Running: worker or operator claims
+  Queued --> Expired: cleaner after 30 minutes
+  Running --> Complete: processing succeeds
+  Running --> Failed: processing fails
+  Running --> Running: stale running reclaimed
+  Expired --> [*]: result retention cleanup
+  Complete --> [*]: result retention cleanup
+  Failed --> [*]: result retention cleanup
+```
+
+---
+
+## Acceptance Examples
+
+- AE1. Cleaner expires an abandoned queued job.
+  - **Given** a yt-mapper match job has been queued for more than 30 minutes, **when** the scheduled cleaner runs, **then** the job becomes `expired`, its raw upload is removed, and its row remains pollable.
+  - **Covers:** R2, R5, R6, R7, R8, R9.
+- AE2. Expired polling response.
+  - **Given** a job has status `expired`, **when** a client polls it, **then** the API returns `{ jobId, status: "expired", errorCode: "job_expired" }`.
+  - **Covers:** R10.
+- AE3. Running jobs are not queue-expired.
+  - **Given** a job was claimed before the 30-minute queued threshold, **when** the cleaner runs later, **then** the cleaner does not expire it because running recovery belongs to stale-running reclaim.
+  - **Covers:** R3.
+- AE4. Manual process can beat the cleaner.
+  - **Given** a queued job is older than 30 minutes but has not yet been marked expired, **when** an operator manually processes it, **then** normal processing can proceed.
+  - **Covers:** R11, R12.
+- AE5. Existing backlog expires on rollout.
+  - **Given** already-queued jobs are older than 30 minutes at deployment time, **when** the cleaner first runs after the feature is live, **then** those overdue queued jobs expire.
+  - **Covers:** R4.
+
+---
+
+## Success Criteria
+
+- Overdue queued yt-mapper jobs no longer remain in the queue indefinitely.
+- Expired jobs do not retain raw upload bytes.
+- Polling a known expired job produces a terminal response that is distinguishable from matcher failure and from an unknown job.
+- The existing worker and stale-running recovery behavior remains intact for non-expired and running jobs.
+
+---
+
+## Scope Boundaries
+
+- Queue, worker, and retention behavior outside `apps/yt-video-mapper-backend` is out of scope.
+- Expiring or killing long-running jobs by total age is out of scope.
+- Replacing the yt-mapper worker with an external queue service is out of scope.
+- Building a public queue listing, queue admin API, or broad operator dashboard is out of scope.
+- Full historical result-row reaping is out of scope beyond preserving expired rows until the existing yt-mapper result-retention policy removes terminal jobs.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing yt-mapper match job lifecycle remains the foundation: queued jobs are claimable, running jobs can be reclaimed when stale, and complete/failed jobs are terminal.
+- The cleaner can safely remove uploaded media independently from preserving the lightweight job record.
+- The first production rollout is allowed to expire old queued yt-mapper jobs that already exceed the 30-minute threshold.
+
+---
+
+## Sources / Research
+
+- `CONCEPTS.md` defines Match Job and Match Job Worker vocabulary, including queued, running, and stale-running recovery semantics.
+- `apps/yt-video-mapper-backend/src/services/match-job.service.ts` contains the current job statuses, result response shape, upload cleanup on terminal processing, and worker-facing queue drain behavior.
+- `apps/yt-video-mapper-backend/src/db/match-job.repository.ts` contains the current Prisma claim logic for queued and stale-running jobs.
+- `apps/yt-video-mapper-backend/prisma/schema.prisma` contains the `MatchJob` model, `retentionExpiresAt`, and current job status enum.
+- `apps/yt-video-mapper-backend/src/worker.ts` contains the process-local worker loop that drains queued jobs.
+- `docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md` calls out the current cleanup caveat: `retentionExpiresAt` exists, but a cleanup worker still needs to delete expired rows and leftover uploads.

--- a/docs/plans/2026-06-29-002-feat-yt-mapper-queued-job-expiry-plan.md
+++ b/docs/plans/2026-06-29-002-feat-yt-mapper-queued-job-expiry-plan.md
@@ -1,0 +1,265 @@
+---
+title: "feat: Expire yt-mapper queued match jobs"
+type: feat
+date: 2026-06-29
+origin: docs/brainstorms/2026-06-29-yt-mapper-queued-job-expiry-requirements.md
+---
+
+# feat: Expire yt-mapper queued match jobs
+
+## Summary
+
+Add a yt-video-mapper-only cleaner that expires abandoned queued Match Jobs after 30 minutes, removes their raw uploads, and keeps lightweight expired rows pollable with `job_expired`. The automatic worker will avoid claiming expiry-eligible queued jobs, while the manual process endpoint can still rescue an overdue queued job until the cleaner marks it `expired`.
+
+---
+
+## Problem Frame
+
+The mapper backend now has an autonomous worker, but forgotten uploads can still sit in durable queue state when no worker claims them soon enough or no client returns to poll them. The origin requirements define this as a yt-mapper-scoped queue hygiene problem, not a cross-service queue framework. The plan keeps the existing durable Match Job model and adds a bounded cleaner path that protects raw upload storage without deleting the public polling trail for known job IDs.
+
+---
+
+## Requirements
+
+**Status and API contract**
+
+- PR1. Add `expired` as a distinct terminal Match Job status for `apps/yt-video-mapper-backend` only.
+- PR2. Polling an expired job returns `{ jobId, status: "expired", errorCode: "job_expired" }` and does not expose upload metadata.
+- PR3. Existing `queued`, `running`, `complete`, and `failed` response behavior remains unchanged for non-expired jobs.
+- PR4. Expired jobs are terminal and cannot be claimed by the automatic worker or manual process endpoint.
+
+**Expiry and cleanup behavior**
+
+- PR5. A queued Match Job is expiry-eligible when `queuedAt` is at least 30 minutes old.
+- PR6. Running jobs are never queue-expired, including stale running jobs; they remain governed by stale-running reclaim.
+- PR7. The cleaner transitions eligible queued jobs to `expired` before attempting raw upload deletion.
+- PR8. After successful upload deletion, the cleaner clears upload storage fields from the expired row so the preserved row is lightweight.
+- PR9. If upload deletion fails after the row is expired, later cleaner runs retry cleanup for expired rows that still have upload storage fields.
+- PR10. Existing queued jobs that are already older than 30 minutes at rollout expire on the first cleaner pass.
+
+**Runtime and operations**
+
+- PR11. The cleaner runs independently of client polling and independently of the Match Job Worker loop.
+- PR12. The cleaner runs on a fixed one-minute cadence and must not overlap a prior long-running cleanup tick; multi-instance deployments coordinate with a database-backed lock before doing cleaner work.
+- PR13. The automatic worker does not claim expiry-eligible queued jobs; the manual process endpoint can still process an overdue queued job before the cleaner marks it expired.
+- PR14. Cleaner logs use safe job IDs, counts, and error codes without bearer tokens, upload bytes, or media URLs.
+- PR15. Documentation explains the cleaner's fixed 30-minute expiry, one-minute cadence, rollout behavior for old queued jobs, and production smoke expectations.
+- PR16. Cleaner logs expose stuck-upload cleanup counts and repeated cleanup failure signals so operators can see when expired rows still reference raw uploads.
+
+**Origin traceability**
+
+- PR1 maps to origin R1 and R7.
+- PR2 maps to origin R10.
+- PR3 maps to origin R13.
+- PR4 maps to origin R11.
+- PR5 maps to origin R2.
+- PR6 maps to origin R3.
+- PR7 maps to origin R6 and R7, with ordering added for race safety.
+- PR8 maps to origin R6 and R8, with field clearing added to satisfy the lightweight-row decision.
+- PR9 is derived from PR8 to make upload cleanup retryable after storage failures.
+- PR10 maps to origin R4 and AE5.
+- PR11 maps to origin R9.
+- PR12 maps to origin R5.
+- PR13 maps to origin R12, with automatic-worker filtering added to protect PR10 during rollout.
+- PR14 is an operational safety requirement derived from the cleaner runtime.
+- PR15 is an operational handoff requirement derived from the deployment scope.
+- PR16 is an operational observability requirement derived from the upload cleanup retry path.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1. Use a real enum status for `expired`.** The job status is persisted as a Postgres enum and mapped through Prisma, so a migration plus status mapping keeps the public API, repository, and service model aligned with the new terminal state.
+- **KTD2. Keep automatic and manual claim rules intentionally different.** The worker-facing next-job path skips queued jobs at or past the expiry threshold so rollout backlog expires, while explicit `processJob(jobId)` keeps the manual rescue window from the requirements.
+- **KTD3. Mark expired before deleting uploads.** The cleaner must win a conditional `queued -> expired` transition before touching storage, preventing a worker or operator from claiming a row whose input was deleted first.
+- **KTD4. Retry upload cleanup for expired rows with leftover upload keys.** Storage deletion can fail after the status transition, so the lightweight-row guarantee needs a retry path that clears upload fields only after deletion succeeds.
+- **KTD5. Run the cleaner as its own runtime loop.** Folding expiry into the worker loop would make cleanup dependent on processing cadence and worker enablement, which conflicts with abandoned-job cleanup.
+- **KTD6. Do not add an `expiredAt` column in v1.** `status`, `safeErrorCode`, `updatedAt`, and existing `retentionExpiresAt` are enough for the public behavior; terminal-row reaping remains a separate follow-up.
+- **KTD7. Keep cleaner policy fixed in production.** The user-selected 30-minute expiry and one-minute cadence are service behavior, not operator-tunable policy in v1; tests can inject shorter intervals and page sizes. `MATCH_JOB_CLEANER_ENABLED` is a rollout and incident kill switch only, not a timing knob.
+- **KTD8. Coordinate cleaner passes with a database lock.** The in-process no-overlap guard prevents local reentry, while a database-backed lock prevents multiple app instances from running the cleaner pass at the same time.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant Cleaner as Match Job Cleaner
+  participant Repo as MatchJobRepository
+  participant Store as UploadStorage
+  participant Worker as Match Job Worker
+  participant API as Manual process / poll
+
+  Cleaner->>Repo: claim expiry-eligible queued jobs
+  Repo-->>Cleaner: rows transitioned to expired
+  Cleaner->>Store: remove raw uploads
+  Cleaner->>Repo: clear upload fields after successful removal
+  Worker->>Repo: claim next processable job
+  Repo-->>Worker: queued jobs before cutoff or stale running jobs only
+  API->>Repo: explicit process known job
+  Repo-->>API: process if still queued/running, or return expired terminal result
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued: upload accepted
+  Queued --> Running: automatic worker claims before expiry
+  Queued --> Running: operator manually processes before cleaner wins
+  Queued --> Expired: cleaner after 30 minutes
+  Running --> Complete: processing succeeds
+  Running --> Failed: processing fails
+  Running --> Running: stale running reclaimed
+  Expired --> [*]: future terminal-row retention reaper
+  Complete --> [*]: future terminal-row retention reaper
+  Failed --> [*]: future terminal-row retention reaper
+```
+
+---
+
+## Implementation Units
+
+### U1. Expired status and public contract
+
+- **Goal:** Add `expired` as a persisted terminal Match Job status and expose the required polling response.
+- **Requirements:** PR1, PR2, PR3, PR4.
+- **Dependencies:** None.
+- **Files:** `apps/yt-video-mapper-backend/prisma/schema.prisma`, `apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql`, `apps/yt-video-mapper-backend/src/services/match-job.service.ts`, `apps/yt-video-mapper-backend/src/db/match-job.repository.ts`, `apps/yt-video-mapper-backend/src/db/schema.test.ts`, `apps/yt-video-mapper-backend/src/services/match-job.service.test.ts`, `apps/yt-video-mapper-backend/src/routes/match-jobs.test.ts`.
+- **Approach:** Add `EXPIRED @map("expired")` to the Prisma enum and a forward migration that mirrors the repo's existing enum-add migration style. Extend the TypeScript status union, Prisma status maps, terminal-state checks, and polling result shape. Keep `failed` handling intact so matcher failures and expiry remain distinguishable.
+- **Patterns to follow:** Existing `MatchJobStatus` mappings in `apps/yt-video-mapper-backend/src/db/match-job.repository.ts`; failed-result response shape in `apps/yt-video-mapper-backend/src/services/match-job.service.ts`; schema assertions in `apps/yt-video-mapper-backend/src/db/schema.test.ts`.
+- **Test scenarios:**
+  - Covers AE2. A job with status `expired` polls as `{ jobId, status: "expired", errorCode: "job_expired" }`.
+  - Calling the manual process endpoint for an expired job returns the terminal expired payload and does not invoke matching.
+  - Status mapping round-trips `expired` between Prisma and the public service model.
+  - Existing failed jobs still return `status: "failed"` with their safe error code.
+- **Verification:** Service, route, and schema tests prove the new status is terminal and publicly distinguishable from failure.
+
+### U2. Atomic expiry repository and service behavior
+
+- **Goal:** Add race-safe queued-job expiry that removes raw uploads only after a successful status transition.
+- **Requirements:** PR5, PR6, PR7, PR8, PR9, PR10, PR13.
+- **Dependencies:** U1.
+- **Files:** `apps/yt-video-mapper-backend/src/services/match-job.service.ts`, `apps/yt-video-mapper-backend/src/db/match-job.repository.ts`, `apps/yt-video-mapper-backend/src/services/upload-storage.ts`, `apps/yt-video-mapper-backend/src/services/match-job.service.test.ts`.
+- **Approach:** Add repository operations that conditionally transition only `queued` rows with `queuedAt <= cutoff` to `expired`, return only rows won by that transition, and later clear upload fields after successful storage deletion. Add a companion cleanup path for already-expired rows that still have upload fields, so a storage error on one tick can be retried on a later tick. Keep explicit `claimQueued(jobId)` eligible for overdue queued jobs until the cleaner wins.
+- **Technical design:** Directional guidance only: each cleaner pass should loop through eligible rows in pages of an internal `MATCH_JOB_CLEANER_PAGE_SIZE` constant until no eligible page remains; the page size bounds each database transition, not the whole pass. Use current-row predicates for every status transition, and treat missing upload files as cleanup success because `FileSystemUploadStorage.remove` is already idempotent.
+- **Patterns to follow:** Conditional `updateMany` claim semantics in `PrismaMatchJobRepository`; best-effort upload cleanup helper in `MatchJobService`; atomic-update caution from `docs/solutions/database-issues/db-lock-must-be-atomic-update-not-select-for-update.md`.
+- **Test scenarios:**
+  - Covers AE1. A queued job older than 30 minutes becomes `expired`, deletes its upload, and remains pollable.
+  - A queued job at 29 minutes 59 seconds does not expire.
+  - A queued job at exactly 30 minutes expires when using the cutoff predicate.
+  - Covers AE3. A running job older than 30 minutes is not expired.
+  - A stale running job older than 30 minutes remains reclaimable through the existing stale-running path.
+  - Covers AE4. Manual `processJob(jobId)` can claim and process an overdue queued job before the cleaner transitions it.
+  - If the cleaner wins before manual processing, the manual process path returns the expired terminal result and does not run extraction or matching.
+  - A storage deletion error leaves upload fields present for retry, and a later cleaner pass removes the upload and clears those fields.
+  - Multiple cleaner attempts or lost races do not delete upload bytes for rows they did not transition.
+- **Verification:** Service tests cover the state transitions, race boundaries, and storage cleanup semantics without requiring a live database.
+
+### U3. Worker claim filtering and rollout safety
+
+- **Goal:** Ensure old queued backlog expires on rollout instead of being auto-processed before the cleaner sees it.
+- **Requirements:** PR6, PR10, PR13.
+- **Dependencies:** U2.
+- **Files:** `apps/yt-video-mapper-backend/src/services/match-job.service.ts`, `apps/yt-video-mapper-backend/src/db/match-job.repository.ts`, `apps/yt-video-mapper-backend/src/services/match-job.service.test.ts`, `apps/yt-video-mapper-backend/src/worker.test.ts`.
+- **Approach:** Thread the expiry cutoff into the worker-facing next-job claim so automatic processing only claims queued jobs that are still younger than the expiry window, while preserving stale-running reclaim. Do not apply that age filter to explicit manual processing.
+- **Patterns to follow:** Existing `claimNextQueued` ordering by queued time; origin requirement that manual rescue remains possible until cleaner marks the job expired.
+- **Test scenarios:**
+  - Covers AE5. A queued job older than 30 minutes is not claimed by the automatic worker and is expired by the cleaner.
+  - A queued job younger than 30 minutes is still claimed and processed by the automatic worker.
+  - A stale running job older than 30 minutes is still claimed by the automatic worker as stale running.
+  - A manual process call can process an older queued job before cleaner expiry.
+- **Verification:** Worker-facing tests prove rollout backlog is routed to cleaner expiry without breaking normal fresh-job processing.
+
+### U4. Cleaner runtime loop
+
+- **Goal:** Run the cleaner on its own one-minute cadence in the yt-mapper server runtime.
+- **Requirements:** PR5, PR11, PR12, PR14, PR16.
+- **Dependencies:** U2, U3.
+- **Files:** `apps/yt-video-mapper-backend/src/cleaner.ts`, `apps/yt-video-mapper-backend/src/cleaner.test.ts`, `apps/yt-video-mapper-backend/src/server.ts`, `apps/yt-video-mapper-backend/src/server.test.ts`, `apps/yt-video-mapper-backend/src/db/match-job.repository.ts`.
+- **Approach:** Add a `startMatchJobCleaner` loop with fake-timer-testable scheduling, an in-process no-overlap guard, a database-backed per-pass lock, safe structured logs, and a `stop()` handle mirroring the worker shape. Use fixed production constants for 30-minute queued expiry, one-minute cadence, and bounded page size, with shorter values injectable only in tests. Start and stop the cleaner alongside the server runtime using the same `MatchJobService`, keep the cleaner independent from `MATCH_JOB_WORKER_ENABLED`, and add `MATCH_JOB_CLEANER_ENABLED=false` as a forward-only rollout kill switch.
+- **Patterns to follow:** `startMatchJobWorker` timer and stop-handle pattern in `apps/yt-video-mapper-backend/src/worker.ts`; repository-owned atomic database operations in `apps/yt-video-mapper-backend/src/db/match-job.repository.ts`.
+- **Test scenarios:**
+  - Cleaner runs immediately on start, then waits the fixed one-minute interval.
+  - Cleaner does not schedule an overlapping tick when one cleanup call is still pending.
+  - Two cleaner instances cannot both run work for the same tick because only one obtains the database-backed lock.
+  - Cleaner logs and continues after one cleanup error.
+  - `stop()` prevents further ticks after an in-flight cleanup resolves.
+  - Server runtime starts the cleaner with the route service and stops it on server close.
+  - Cleaner production behavior is fixed at `queued expiry=30 minutes`, `interval=60000 ms`, with test-injected overrides only.
+  - `MATCH_JOB_CLEANER_ENABLED=false` prevents cleaner startup without disabling the worker.
+  - A cleaner pass with `batchSize + 1` overdue queued jobs expires all eligible rows before the pass completes, using more than one bounded page.
+- **Verification:** Cleaner and server tests demonstrate independent runtime behavior from the worker loop, global pass coordination, and stuck-upload observability.
+
+### U5. Documentation and operational verification
+
+- **Goal:** Document the yt-mapper cleaner behavior, fixed runtime policy, and production smoke expectations.
+- **Requirements:** PR14, PR15, PR16.
+- **Dependencies:** U1, U2, U3, U4.
+- **Files:** `apps/yt-video-mapper-backend/README.md`, `apps/yt-video-mapper-backend/docs/railway-deployment.md`, `docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md`.
+- **Approach:** Update docs to name the Match Job Cleaner, its fixed 30-minute expiry and one-minute cadence, the first-rollout behavior for overdue queued rows, stuck-upload cleanup logging, and the poll response for expired jobs. Clarify that expired rows remain until a separate terminal-row reaper exists because current code records `retentionExpiresAt` but does not delete terminal rows yet.
+- **Patterns to follow:** Existing Railway env and smoke sections in `apps/yt-video-mapper-backend/docs/railway-deployment.md`; existing durable match-job solution note caveat.
+- **Test scenarios:** Test expectation: none -- documentation-only unit.
+- **Verification:** Documentation gives operators enough information to deploy, smoke, and understand old queued-row expiry without exposing secrets.
+
+---
+
+## Acceptance Examples
+
+- AE1. Abandoned queued job expires: A queued job older than 30 minutes becomes `expired`, its upload is removed, and the row remains pollable.
+- AE2. Expired poll response: Polling an expired job returns `{ jobId, status: "expired", errorCode: "job_expired" }`.
+- AE3. Running jobs are not queue-expired: A running job older than 30 minutes is left for stale-running reclaim.
+- AE4. Manual rescue wins before cleaner: A known overdue queued job can still process if the manual endpoint claims it before the cleaner status transition.
+- AE5. Existing backlog expires on rollout: Old queued rows that already exceed 30 minutes expire on the first cleaner pass.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- yt-video-mapper match job status, service, repository, cleaner runtime, tests, and docs.
+- A forward-only Prisma migration for the `expired` enum value and any index needed for cleaner predicates.
+- Fixed cleaner runtime policy with test-injected timing and page-size controls.
+
+### Deferred to Follow-Up Work
+
+- A general terminal-row retention reaper that deletes old expired, complete, and failed rows.
+- A public queue listing or admin dashboard for inspecting all queued jobs.
+- Streaming upload storage hardening for large inputs.
+
+### Out of Scope
+
+- Queue cleanup behavior outside `apps/yt-video-mapper-backend`.
+- Killing or expiring `running` jobs by total age.
+- Replacing the process-local worker with an external queue service.
+
+---
+
+## Risks & Dependencies
+
+- **Enum migration risk:** `expired` is a forward database enum change. Rollback should be forward-only by deploying code that tolerates the value and, if needed, setting `MATCH_JOB_CLEANER_ENABLED=false` rather than trying to remove the enum value.
+- **Worker/cleaner race:** The worker currently starts immediately and can claim old queued rows. U4 mitigates this by filtering automatic claims with the expiry cutoff.
+- **Upload cleanup failure:** A filesystem deletion error after status expiry could leave storage behind. U2 and U4 mitigate this with retryable expired-row cleanup, structured stuck-upload counts, and field clearing only after successful deletion.
+- **Cleaner overlap:** A large backlog could make one tick run longer than a minute, and multiple app instances could otherwise duplicate cleaner work. U4 mitigates this with an in-process no-overlap guard, a database-backed lock, and bounded page draining.
+- **Cleaner outage:** Because the automatic worker skips expiry-eligible queued jobs, a persistent cleaner failure could strand old queued rows. U4 mitigates this with repeated-failure logging that should be included in production smoke and alert review.
+- **Production observability:** The cleaner needs safe logs and smoke guidance because the public API cannot list the whole queue.
+
+---
+
+## Documentation / Operational Notes
+
+The deployed Railway service runs `db:migrate:deploy` before `start`, so the enum migration must land before code that can write `expired`. Production smoke should create one fresh job and confirm it completes or remains processable normally, then verify an intentionally aged local/test fixture through automated tests rather than trying to age a prod upload for 30 minutes.
+
+---
+
+## Sources / Research
+
+- Origin requirements: `docs/brainstorms/2026-06-29-yt-mapper-queued-job-expiry-requirements.md`.
+- Current lifecycle and polling: `apps/yt-video-mapper-backend/src/services/match-job.service.ts`.
+- Current Prisma status mapping and claim logic: `apps/yt-video-mapper-backend/src/db/match-job.repository.ts`.
+- Current schema and indexes: `apps/yt-video-mapper-backend/prisma/schema.prisma`.
+- Runtime worker pattern: `apps/yt-video-mapper-backend/src/worker.ts` and `apps/yt-video-mapper-backend/src/worker.test.ts`.
+- Upload storage deletion semantics: `apps/yt-video-mapper-backend/src/services/upload-storage.ts`.
+- Railway service and env docs: `apps/yt-video-mapper-backend/docs/railway-deployment.md`.
+- Durable match job pattern: `docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md`.
+- Retention scheduler caution: `docs/solutions/platform/admin-search-trace-retention-pattern.md`.
+- Atomic update caution: `docs/solutions/database-issues/db-lock-must-be-atomic-update-not-select-for-update.md`.

--- a/docs/prototypes/yt-video-mapper/tickets/ytm-009-queued-job-expiry-cleaner.md
+++ b/docs/prototypes/yt-video-mapper/tickets/ytm-009-queued-job-expiry-cleaner.md
@@ -1,0 +1,46 @@
+---
+id: YTM-009
+title: "Expire abandoned queued match jobs"
+status: complete
+priority: P1
+depends_on:
+  - YTM-001
+---
+
+# YTM-009: Expire abandoned queued match jobs
+
+## Goal
+
+Prevent yt-video-mapper uploads from remaining in `queued` forever when the
+worker is unavailable, overloaded, or a caller submits and then abandons a job.
+
+## Scope
+
+- Add a distinct terminal `expired` Match Job status.
+- Expire only jobs that remain `queued` for 30 minutes.
+- Run an independent cleaner every minute.
+- Delete raw upload bytes when expiring a job, while keeping the lightweight job
+  row pollable.
+- Return `{ jobId, status: "expired", errorCode: "job_expired" }` for expired
+  jobs.
+- Keep running jobs under the existing stale-running reclaim behavior.
+- Allow manual processing of an overdue queued job until the cleaner marks it
+  expired.
+
+## Acceptance Criteria
+
+- Existing overdue queued jobs expire on the first cleaner pass after deploy.
+- The automatic worker skips queued jobs that have crossed the expiry window.
+- The cleaner coordinates across service instances with a database lease.
+- Upload cleanup failures are retried and logged without exposing secrets.
+- Operators can disable the cleaner with `MATCH_JOB_CLEANER_ENABLED=false`
+  during rollout or incident response.
+
+## Verification
+
+```sh
+pnpm --filter @forge/yt-video-mapper-backend test
+pnpm --filter @forge/yt-video-mapper-backend typecheck
+pnpm --filter @forge/yt-video-mapper-backend lint
+pnpm --filter @forge/yt-video-mapper-backend build
+```

--- a/docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md
+++ b/docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md
@@ -54,11 +54,16 @@ Build the app around an async upload job lifecycle:
 2. `GET /match-jobs/:jobId` polls job state. Once complete, it returns only
    `{ candidates }` so the public contract stays focused on attribution.
 3. The server starts a bounded worker loop by default. The loop claims the
-   oldest queued or stale-running job, processes one job at a time, and polls
-   when the queue is empty.
+   oldest fresh queued or stale-running job, processes one job at a time, and
+   polls when the queue is empty.
 4. `POST /match-jobs/:jobId/process` remains available for authenticated
    operator recovery of a specific job. Tests and operator sessions can disable
    the background loop when deterministic control is needed.
+5. A separate Match Job Cleaner runs every minute and expires queued jobs that
+   have remained unclaimed for 30 minutes. Polling an expired job returns
+   `{ jobId, status: "expired", errorCode: "job_expired" }`.
+   `MATCH_JOB_CLEANER_ENABLED=false` can stop cleaner startup during rollout or
+   incident response without changing the fixed expiry policy.
 
 Use a Prisma-backed repository as the production default and keep in-memory
 repositories test-only. Both the manual process path and the worker path should
@@ -79,8 +84,16 @@ await db.matchJob.updateMany({
 
 Treat uploaded files as transient job inputs, not durable evidence artifacts.
 Store the upload before creating the job, clean it up if job creation fails, and
-clean it up again when processing reaches a terminal state. Keep a retention
-timestamp on the job result so a later reaper can remove old rows.
+clean it up again when processing reaches a terminal state. For abandoned
+queued jobs, mark the job `expired` before deleting the upload, then clear the
+upload fields only after deletion succeeds so retry cleanup can find leftovers.
+Keep a retention timestamp on the job result so a later reaper can remove old
+rows.
+
+Coordinate cleaner passes across service instances with an owner-scoped
+database lease. A cleaner that outlives its lease must not be able to release a
+successor cleaner's lease, and expired-upload retry work should be bounded per
+tick so old cleanup debt cannot starve newly overdue queued jobs.
 
 Keep the catalog identity model explicit:
 
@@ -141,6 +154,12 @@ in `queued` forever because no consumer is running. The manual drain endpoint
 still gives operators a targeted recovery tool without making the public API
 list or mutate the whole queue.
 
+The cleaner closes the other queue-health gap: an upload can be accepted and
+then forgotten by both the caller and the operator. Expiring queued-only jobs
+protects storage while keeping a pollable terminal answer for known job IDs.
+The worker should skip queued jobs that have crossed the expiry window so
+rollout backlogs are cleaned up instead of unexpectedly processed.
+
 Keeping evidence internal lets the team inspect and tune the matcher without
 committing every diagnostic detail to the public API. That matters for future
 fusion work, because visual and audio evidence can disagree: visual should
@@ -155,6 +174,8 @@ choose the best variant.
 - A matcher needs both parent identity and variant identity.
 - The app needs a prototype path before the real queue, catalog sync, and media
   indexing workers are complete.
+- A durable local queue needs abandoned-upload cleanup without tying cleanup to
+  client polling.
 - Evidence is valuable for debugging but should not be exposed to callers yet.
 
 ## Examples
@@ -163,9 +184,11 @@ Good route shape:
 
 ```text
 POST /match-jobs                  -> 202 { jobId, status }
-worker loop                       -> claims queued/stale-running jobs
+worker loop                       -> claims fresh queued/stale-running jobs
+cleaner loop                      -> expires queued jobs after 30 minutes
+MATCH_JOB_CLEANER_ENABLED=false   -> rollout kill switch for cleaner startup
 POST /match-jobs/:jobId/process   -> authenticated operator recovery
-GET  /match-jobs/:jobId           -> queued/running/failed envelope
+GET  /match-jobs/:jobId           -> queued/running/failed/expired envelope
 GET  /match-jobs/:jobId           -> { candidates } when complete
 ```
 
@@ -174,6 +197,12 @@ Avoid these shortcuts:
 - Defaulting production runtime to an in-memory repository.
 - Shipping durable queued jobs without an autonomous consumer or an explicit
   operator drain plan.
+- Deleting raw uploads before a conditional queued-to-expired transition wins.
+- Letting the worker auto-claim jobs that have already crossed the queued
+  expiry threshold.
+- Releasing a database cleaner lease without checking the lease owner.
+- Retrying every expired upload cleanup before marking newly overdue queued
+  jobs expired.
 - Keying fusion by `videoVariantId` without the parent `coreId`.
 - Exposing internal visual/audio/text evidence in the public response before
   the API contract calls for it.
@@ -183,8 +212,8 @@ Prototype caveats to address before large-scale operation:
 
 - The raw upload route currently buffers the request body before storage;
   streaming upload storage is the next hardening step for large files.
-- `retentionExpiresAt` is recorded, but a cleanup worker still needs to delete
-  expired job rows and any leftover uploads.
+- `retentionExpiresAt` is recorded, but a row-retention reaper still needs to
+  delete old complete, failed, and expired job rows.
 - Bearer-token access protects the service surface, but per-caller job
   ownership is not yet modeled.
 - Catalog sync, media signature indexing, and labeled evaluation data still need


### PR DESCRIPTION
## Summary

Abandoned yt-video-mapper uploads now leave the queue on their own instead of polling as `queued` forever. The mapper keeps a lightweight terminal job row with `status: "expired"` and `errorCode: "job_expired"`, deletes raw upload bytes, and leaves running jobs on the existing stale-running recovery path.

The cleaner runs independently from polling and the worker, so clients do not have to come back for forgotten jobs to be cleaned up. The automatic worker skips queued jobs that have crossed the expiry window, while the manual process endpoint can still rescue an overdue queued job until the cleaner wins the status transition.

## Design Notes

| Area | Decision |
| --- | --- |
| Expiry contract | Add a distinct `expired` terminal state instead of overloading `failed`. |
| Cleanup order | Mark `queued -> expired` before deleting uploads, then clear upload fields only after deletion succeeds. |
| Multi-instance safety | Use an owner-scoped DB cleaner lease so stale cleaners cannot release successor leases. |
| Backlog behavior | Drain overdue queued jobs in bounded pages; cap expired-upload retry pages per tick so cleanup debt cannot starve new expirations. |
| Rollout safety | Keep the timing policy fixed, with `MATCH_JOB_CLEANER_ENABLED=false` as a forward-only cleaner kill switch. |

## Verification

- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- `pnpm --filter @forge/yt-video-mapper-backend build`
- `python3 /home/vscode/.codex/plugins/cache/compound-engineering-plugin/compound-engineering/3.13.1/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/platform/yt-video-mapper-backend-app-durable-match-job-upload-poll-process-pattern.md`

## Operations

The Railway runbook now includes post-deploy SQL checks for the new enum value, cleaner indexes, overdue queued jobs, expired rows with leftover upload fields, and cleaner lease ownership. Rollback is forward-only: disable cleaner startup if needed, but leave the enum and lease table in place.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
