### PR TITLE
fix(yt-video-mapper): make expiry migration transactional

### DIFF
--- a/apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql
+++ b/apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql
@@ -2,11 +2,11 @@
 ALTER TYPE "match_job_status" ADD VALUE 'expired';
 
 -- Support cleaner scans for queued jobs crossing the expiry threshold.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_status_queued_at_idx"
+CREATE INDEX IF NOT EXISTS "mapper_match_job_status_queued_at_idx"
 ON "mapper_match_job"("status", "queued_at");
 
 -- Support sparse retries for expired rows whose raw upload cleanup failed.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"
+CREATE INDEX IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"
 ON "mapper_match_job"("queued_at", "id")
 WHERE "status" = 'expired'
   AND (

--- a/apps/yt-video-mapper-backend/src/db/schema.test.ts
+++ b/apps/yt-video-mapper-backend/src/db/schema.test.ts
@@ -67,10 +67,10 @@ describe("mapper Prisma schema", () => {
       "ALTER TYPE \"match_job_status\" ADD VALUE 'expired'",
     )
     expect(expiryMigration).toContain(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_status_queued_at_idx"',
+      'CREATE INDEX IF NOT EXISTS "mapper_match_job_status_queued_at_idx"',
     )
     expect(expiryMigration).toContain(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"',
+      'CREATE INDEX IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"',
     )
     expect(expiryMigration).toContain("WHERE \"status\" = 'expired'")
     expect(expiryMigration).toContain('"owner_token" TEXT NOT NULL')


### PR DESCRIPTION
## Summary

The expiry migration now runs inside Prisma Migrate's production transaction. Railway exposed that `CREATE INDEX CONCURRENTLY` is not allowed in this path, so the indexes use normal `CREATE INDEX IF NOT EXISTS` statements instead.

This keeps the migration idempotent enough for retry while letting `prisma migrate deploy` apply it normally. The schema test now asserts the transactional form so we do not accidentally reintroduce concurrent index creation into a Prisma migration.

## Verification

- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- `pnpm run format:check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
