### PR TITLE
fix(yt-video-mapper): split expired enum index migration

### DIFF
--- a/apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql
+++ b/apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql
@@ -5,16 +5,6 @@ ALTER TYPE "match_job_status" ADD VALUE 'expired';
 CREATE INDEX IF NOT EXISTS "mapper_match_job_status_queued_at_idx"
 ON "mapper_match_job"("status", "queued_at");
 
--- Support sparse retries for expired rows whose raw upload cleanup failed.
-CREATE INDEX IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"
-ON "mapper_match_job"("queued_at", "id")
-WHERE "status" = 'expired'
-  AND (
-    "upload_storage_key" IS NOT NULL
-    OR "upload_content_type" IS NOT NULL
-    OR "upload_byte_length" IS NOT NULL
-  );
-
 -- Coordinate cleaner passes across app instances without adding an external queue.
 CREATE TABLE "mapper_match_job_cleaner_lease" (
   "name" TEXT NOT NULL,

--- a/apps/yt-video-mapper-backend/prisma/migrations/20260629000200_add_expired_upload_cleanup_index/migration.sql
+++ b/apps/yt-video-mapper-backend/prisma/migrations/20260629000200_add_expired_upload_cleanup_index/migration.sql
@@ -1,0 +1,10 @@
+-- Run after the expired enum value is committed, because Postgres does not
+-- allow a new enum value to be referenced in the same transaction that adds it.
+CREATE INDEX IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"
+ON "mapper_match_job"("queued_at", "id")
+WHERE "status" = 'expired'
+  AND (
+    "upload_storage_key" IS NOT NULL
+    OR "upload_content_type" IS NOT NULL
+    OR "upload_byte_length" IS NOT NULL
+  );

--- a/apps/yt-video-mapper-backend/src/db/schema.test.ts
+++ b/apps/yt-video-mapper-backend/src/db/schema.test.ts
@@ -12,6 +12,13 @@ const expiryMigration = readFileSync(
   ),
   "utf8",
 )
+const expiredUploadCleanupIndexMigration = readFileSync(
+  new URL(
+    "../../prisma/migrations/20260629000200_add_expired_upload_cleanup_index/migration.sql",
+    import.meta.url,
+  ),
+  "utf8",
+)
 
 describe("mapper Prisma schema", () => {
   it("keeps the public Core identifiers unique in the catalog map", () => {
@@ -69,10 +76,12 @@ describe("mapper Prisma schema", () => {
     expect(expiryMigration).toContain(
       'CREATE INDEX IF NOT EXISTS "mapper_match_job_status_queued_at_idx"',
     )
-    expect(expiryMigration).toContain(
+    expect(expiredUploadCleanupIndexMigration).toContain(
       'CREATE INDEX IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"',
     )
-    expect(expiryMigration).toContain("WHERE \"status\" = 'expired'")
+    expect(expiredUploadCleanupIndexMigration).toContain(
+      "WHERE \"status\" = 'expired'",
+    )
     expect(expiryMigration).toContain('"owner_token" TEXT NOT NULL')
     expect(expiryMigration).not.toContain(
       '"updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP',


### PR DESCRIPTION
## Summary

The expiry migration now commits the new `expired` enum value before any SQL references it in a partial index predicate. Postgres rejects using a freshly added enum value inside the same migration transaction, so the expired-upload cleanup index moves into a second migration.

This preserves the queue-expiry schema shape while letting Prisma Migrate apply the enum migration and then the cleanup index migration in separate transactions.

## Verification

- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- `pnpm run format:check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
