### PR TITLE
fix(yt-video-mapper): guard prisma migration deploy safety

### DIFF
--- a/apps/yt-video-mapper-backend/src/db/schema.test.ts
+++ b/apps/yt-video-mapper-backend/src/db/schema.test.ts
@@ -1,6 +1,7 @@
-import { readFileSync } from "node:fs"
+import { readdirSync, readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
 
+const migrationsDir = new URL("../../prisma/migrations/", import.meta.url)
 const schema = readFileSync(
   new URL("../../prisma/schema.prisma", import.meta.url),
   "utf8",
@@ -19,6 +20,15 @@ const expiredUploadCleanupIndexMigration = readFileSync(
   ),
   "utf8",
 )
+
+const migrations = readdirSync(migrationsDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => ({
+    name: entry.name,
+    sql: readFileSync(new URL(`${entry.name}/migration.sql`, migrationsDir), {
+      encoding: "utf8",
+    }),
+  }))
 
 describe("mapper Prisma schema", () => {
   it("keeps the public Core identifiers unique in the catalog map", () => {
@@ -88,6 +98,51 @@ describe("mapper Prisma schema", () => {
     )
   })
 
+  it("keeps migrations compatible with Prisma deploy transactions", () => {
+    expect(migrations.flatMap(findDeployTransactionViolations)).toEqual([])
+  })
+
+  it("flags migration SQL patterns that break Prisma deploy transactions", () => {
+    expect(
+      findDeployTransactionViolations({
+        name: "bad_concurrent_index",
+        sql: `
+          CREATE INDEX CONCURRENTLY "mapper_match_job_status_idx"
+          ON "mapper_match_job"("status");
+        `,
+      }),
+    ).toEqual([
+      "bad_concurrent_index uses CONCURRENTLY, which cannot run inside Prisma migrate deploy transactions.",
+    ])
+
+    expect(
+      findDeployTransactionViolations({
+        name: "bad_enum_use",
+        sql: `
+          ALTER TYPE "match_job_status" ADD VALUE 'expired';
+          CREATE INDEX "mapper_match_job_expired_idx"
+          ON "mapper_match_job"("queued_at")
+          WHERE "status" = 'expired';
+        `,
+      }),
+    ).toEqual([
+      "bad_enum_use adds enum value 'expired' and references it again in the same migration; split dependent SQL into the next migration.",
+    ])
+  })
+
+  it("ignores unsafe-looking migration text inside SQL comments", () => {
+    expect(
+      findDeployTransactionViolations({
+        name: "comment_only",
+        sql: `
+          -- CREATE INDEX CONCURRENTLY would fail here if executed.
+          ALTER TYPE "match_job_status" ADD VALUE 'archived';
+          -- WHERE "status" = 'archived' belongs in a later migration.
+        `,
+      }),
+    ).toEqual([])
+  })
+
   it("keeps evidence internal and attached to jobs and candidates", () => {
     expect(schema).toContain("model MatchEvidence")
     expect(schema).toContain("internal    Boolean        @default(true)")
@@ -105,3 +160,56 @@ describe("mapper Prisma schema", () => {
     )
   })
 })
+
+interface MigrationSql {
+  name: string
+  sql: string
+}
+
+function findDeployTransactionViolations(migration: MigrationSql): string[] {
+  const sql = stripSqlComments(migration.sql)
+  const violations: string[] = []
+
+  if (/\bCONCURRENTLY\b/i.test(sql)) {
+    violations.push(
+      `${migration.name} uses CONCURRENTLY, which cannot run inside Prisma migrate deploy transactions.`,
+    )
+  }
+
+  const enumAdds = [...sql.matchAll(enumAddValueRegex)]
+  const sqlWithoutEnumAddStatements = enumAdds.reduceRight(
+    (remainingSql, match) =>
+      `${remainingSql.slice(0, match.index)}${remainingSql.slice(
+        (match.index ?? 0) + match[0].length,
+      )}`,
+    sql,
+  )
+
+  for (const match of enumAdds) {
+    const enumValue = match.groups?.value
+    if (!enumValue) continue
+
+    if (quotedSqlLiteralRegex(enumValue).test(sqlWithoutEnumAddStatements)) {
+      violations.push(
+        `${migration.name} adds enum value '${enumValue}' and references it again in the same migration; split dependent SQL into the next migration.`,
+      )
+    }
+  }
+
+  return violations
+}
+
+const enumAddValueRegex =
+  /\bALTER\s+TYPE\s+(?:"[^"]+"|[a-z_][\w$.]*)\s+ADD\s+VALUE\s+(?:IF\s+NOT\s+EXISTS\s+)?'(?<value>(?:''|[^'])*)'/gi
+
+function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--.*$/gm, "")
+}
+
+function quotedSqlLiteralRegex(value: string): RegExp {
+  return new RegExp(`'${escapeRegExp(value)}'`, "i")
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}

--- a/docs/prototypes/yt-video-mapper/tickets/README.md
+++ b/docs/prototypes/yt-video-mapper/tickets/README.md
@@ -23,3 +23,5 @@ roadmap tickets broad; keep this folder practical and close to the mapper code.
 | [YTM-006](./ytm-006-evaluation-harness-and-thresholds.md)      | todo     | P1       | Evaluation harness and confidence thresholds |
 | [YTM-007](./ytm-007-ops-hardening.md)                          | todo     | P2       | Operations hardening                         |
 | [YTM-008](./ytm-008-model-assisted-review-research.md)         | backlog  | P3       | Model-assisted review research               |
+| [YTM-009](./ytm-009-queued-job-expiry-cleaner.md)              | complete | P1       | Expire abandoned queued match jobs           |
+| [YTM-010](./ytm-010-prisma-migration-deploy-safety.md)         | complete | P1       | Guard Prisma migration deploy safety         |

--- a/docs/prototypes/yt-video-mapper/tickets/ytm-010-prisma-migration-deploy-safety.md
+++ b/docs/prototypes/yt-video-mapper/tickets/ytm-010-prisma-migration-deploy-safety.md
@@ -1,0 +1,41 @@
+---
+id: YTM-010
+title: "Guard Prisma migration deploy safety"
+status: complete
+priority: P1
+depends_on:
+  - YTM-009
+---
+
+# YTM-010: Guard Prisma migration deploy safety
+
+## Goal
+
+Prevent yt-video-mapper migrations from repeating the production deploy failure
+patterns found during the queued-job expiry rollout.
+
+## Scope
+
+- Reject migration SQL that uses transaction-hostile `CONCURRENTLY` clauses.
+- Reject migrations that add a Postgres enum value and reference that new value
+  again before the migration transaction can commit.
+- Keep enum additions allowed when dependent SQL is split into a later
+  migration.
+- Keep the guard close to the mapper Prisma schema tests so it runs in the
+  normal backend test command.
+
+## Acceptance Criteria
+
+- A synthetic `CREATE INDEX CONCURRENTLY` migration fixture fails the guard.
+- A synthetic enum-add-plus-partial-index fixture fails the guard.
+- Existing yt-video-mapper migrations pass the guard.
+- Unsafe-looking text in SQL comments is ignored.
+
+## Verification
+
+```sh
+pnpm --filter @forge/yt-video-mapper-backend test -- src/db/schema.test.ts
+pnpm --filter @forge/yt-video-mapper-backend test
+pnpm --filter @forge/yt-video-mapper-backend typecheck
+pnpm --filter @forge/yt-video-mapper-backend lint
+```


### PR DESCRIPTION
## Summary

yt-video-mapper migrations now fail tests before they can repeat the two deploy-breaking patterns from the queued-job expiry rollout: transaction-hostile `CONCURRENTLY` clauses and same-migration use of newly added enum literals. The guard scans every mapper Prisma migration while still allowing enum additions whose dependent SQL is split into a later migration.

## Verification

- `pnpm --filter @forge/yt-video-mapper-backend test -- src/db/schema.test.ts`
- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- `pnpm run format:check`
- `pnpm --filter @forge/yt-video-mapper-backend build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
