### PR TITLE
fix(yt-video-mapper): harden prisma migration guard

### DIFF
--- a/apps/yt-video-mapper-backend/src/db/schema.test.ts
+++ b/apps/yt-video-mapper-backend/src/db/schema.test.ts
@@ -128,6 +128,34 @@ describe("mapper Prisma schema", () => {
     ).toEqual([
       "bad_enum_use adds enum value 'expired' and references it again in the same migration; split dependent SQL into the next migration.",
     ])
+
+    expect(
+      findDeployTransactionViolations({
+        name: "bad_schema_qualified_enum_use",
+        sql: `
+          ALTER TYPE "public"."match_job_status" ADD VALUE 'expired';
+          CREATE INDEX "mapper_match_job_expired_idx"
+          ON "mapper_match_job"("queued_at")
+          WHERE "status" = 'expired';
+        `,
+      }),
+    ).toEqual([
+      "bad_schema_qualified_enum_use adds enum value 'expired' and references it again in the same migration; split dependent SQL into the next migration.",
+    ])
+
+    expect(
+      findDeployTransactionViolations({
+        name: "bad_dollar_quoted_enum_use",
+        sql: `
+          ALTER TYPE "match_job_status" ADD VALUE $$expired$$;
+          CREATE INDEX "mapper_match_job_expired_idx"
+          ON "mapper_match_job"("queued_at")
+          WHERE "status" = $$expired$$::match_job_status;
+        `,
+      }),
+    ).toEqual([
+      "bad_dollar_quoted_enum_use adds enum value 'expired' and references it again in the same migration; split dependent SQL into the next migration.",
+    ])
   })
 
   it("ignores unsafe-looking migration text inside SQL comments", () => {
@@ -138,6 +166,11 @@ describe("mapper Prisma schema", () => {
           -- CREATE INDEX CONCURRENTLY would fail here if executed.
           ALTER TYPE "match_job_status" ADD VALUE 'archived';
           -- WHERE "status" = 'archived' belongs in a later migration.
+          /*
+            CREATE INDEX CONCURRENTLY would also fail here if executed.
+            ALTER TYPE "match_job_status" ADD VALUE 'deleted';
+            WHERE "status" = 'deleted' belongs in a later migration.
+          */
         `,
       }),
     ).toEqual([])
@@ -161,7 +194,7 @@ describe("mapper Prisma schema", () => {
   })
 })
 
-interface MigrationSql {
+type MigrationSql = {
   name: string
   sql: string
 }
@@ -186,10 +219,10 @@ function findDeployTransactionViolations(migration: MigrationSql): string[] {
   )
 
   for (const match of enumAdds) {
-    const enumValue = match.groups?.value
+    const enumValue = enumValueFromMatch(match)
     if (!enumValue) continue
 
-    if (quotedSqlLiteralRegex(enumValue).test(sqlWithoutEnumAddStatements)) {
+    if (sqlLiteralRegex(enumValue).test(sqlWithoutEnumAddStatements)) {
       violations.push(
         `${migration.name} adds enum value '${enumValue}' and references it again in the same migration; split dependent SQL into the next migration.`,
       )
@@ -199,15 +232,42 @@ function findDeployTransactionViolations(migration: MigrationSql): string[] {
   return violations
 }
 
-const enumAddValueRegex =
-  /\bALTER\s+TYPE\s+(?:"[^"]+"|[a-z_][\w$.]*)\s+ADD\s+VALUE\s+(?:IF\s+NOT\s+EXISTS\s+)?'(?<value>(?:''|[^'])*)'/gi
+const sqlIdentifierRegexSource = String.raw`(?:"(?:""|[^"])+"|[a-z_][\w$]*)`
+const qualifiedSqlIdentifierRegexSource = String.raw`${sqlIdentifierRegexSource}(?:\s*\.\s*${sqlIdentifierRegexSource})*`
+const singleQuotedSqlLiteralRegexSource = String.raw`'(?<singleQuotedValue>(?:''|[^'])*)'`
+const emptyDollarQuotedSqlLiteralRegexSource = String.raw`\$\$(?<emptyDollarQuotedValue>[\s\S]*?)\$\$`
+const taggedDollarQuotedSqlLiteralRegexSource = String.raw`\$(?<dollarTag>[A-Za-z_][\w$]*)\$(?<taggedDollarQuotedValue>[\s\S]*?)\$\k<dollarTag>\$`
+
+const enumAddValueRegex = new RegExp(
+  String.raw`\bALTER\s+TYPE\s+${qualifiedSqlIdentifierRegexSource}\s+ADD\s+VALUE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:${singleQuotedSqlLiteralRegexSource}|${emptyDollarQuotedSqlLiteralRegexSource}|${taggedDollarQuotedSqlLiteralRegexSource})`,
+  "gi",
+)
 
 function stripSqlComments(sql: string): string {
   return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--.*$/gm, "")
 }
 
-function quotedSqlLiteralRegex(value: string): RegExp {
-  return new RegExp(`'${escapeRegExp(value)}'`, "i")
+function enumValueFromMatch(match: RegExpMatchArray): string | undefined {
+  const singleQuotedValue = match.groups?.singleQuotedValue
+
+  if (singleQuotedValue !== undefined) {
+    return singleQuotedValue.replace(/''/g, "'")
+  }
+
+  return (
+    match.groups?.emptyDollarQuotedValue ??
+    match.groups?.taggedDollarQuotedValue
+  )
+}
+
+function sqlLiteralRegex(value: string): RegExp {
+  const singleQuotedValue = escapeRegExp(value.replace(/'/g, "''"))
+  const dollarQuotedValue = escapeRegExp(value)
+
+  return new RegExp(
+    String.raw`(?:'${singleQuotedValue}'|\$\$${dollarQuotedValue}\$\$|\$([A-Za-z_][\w$]*)\$${dollarQuotedValue}\$\1\$)`,
+    "i",
+  )
 }
 
 function escapeRegExp(value: string): string {

--- a/docs/plans/2026-06-30-001-fix-yt-mapper-prisma-migration-root-cause-plan.md
+++ b/docs/plans/2026-06-30-001-fix-yt-mapper-prisma-migration-root-cause-plan.md
@@ -1,0 +1,314 @@
+---
+title: "fix: Formalize yt-mapper Prisma migration root-cause remediation"
+type: "fix"
+date: "2026-06-30"
+---
+
+# fix: Formalize yt-mapper Prisma migration root-cause remediation
+
+## Summary
+
+This plan verifies and formalizes the root-cause remediation for the
+yt-video-mapper production migration failures that happened during the queued
+job expiry rollout. The corrective work is not another production change by
+default; it is an evidence-backed audit of the merged migration fix and safety
+guard, followed by formal review and durable learning capture.
+
+---
+
+## Problem Frame
+
+The queued-job expiry feature reached production through three migration
+iterations. PR 1418 introduced the feature and first migration. PR 1419 removed
+`CREATE INDEX CONCURRENTLY` after Prisma deploy failed in a transaction. PR 1421
+split the enum addition from the partial index after Postgres rejected same
+transaction use of the newly added enum value. PR 1422 added a test guard after
+the fact, but that guard was merged before this formal CE pipeline ran.
+
+The root cause to validate is a workflow and test-surface gap: review and local
+verification did not have a general pre-merge invariant for SQL that is unsafe
+inside Prisma `migrate deploy` transactions. The final production migrations may
+now be correct, but the formal pipeline must prove the causal chain, validate
+the remediation, and capture the learning without making another unapproved
+prod-facing change.
+
+---
+
+## Requirements
+
+**Root-cause evidence**
+
+- R1. The formal pass must identify the full causal chain from original SQL
+  shape to production deploy failure using repository, PR, deploy, and primary
+  database documentation evidence.
+- R2. The formal pass must distinguish failed migration attempts from
+  successfully applied migration history, preserving the repo's Forward-Only
+  Migration and Known Recoverable Migration concepts.
+
+**Remediation verification**
+
+- R3. Existing yt-video-mapper migrations must avoid `CONCURRENTLY` and avoid
+  referencing a newly added enum literal in the same migration that adds it.
+- R4. The repository guard must fail on synthetic fixtures for both deploy
+  failure modes and pass against every current yt-mapper migration.
+- R5. Verification must run from a branch based on `upstream/main`, not from an
+  already-merged hotfix branch with different ancestry or generated artifacts.
+
+**Process control**
+
+- R6. The formal run must not merge or deploy additional changes without
+  explicit user approval after review.
+- R7. Durable learning must land in `docs/solutions/` or an equivalent formal
+  `ce:compound` artifact so future mapper migration work can find the trap
+  before production deploy.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["PR 1418: expiry migration ships"] --> B["Prod deploy fails: CREATE INDEX CONCURRENTLY inside Prisma deploy transaction"]
+  B --> C["PR 1419: index made transactional"]
+  C --> D["Prod deploy fails: partial index references enum value before ALTER TYPE transaction commits"]
+  D --> E["PR 1421: enum addition and dependent partial index split into separate migrations"]
+  E --> F["Prod deploy succeeds"]
+  F --> G["PR 1422: repo test guard added after the incident"]
+  G --> H["Formal pipeline audit: prove RCA, validate guard, review, compound"]
+```
+
+The formal pipeline audits the landed state rather than introducing a new
+runtime path. Any additional remediation discovered by review becomes a new,
+separately approved change.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Treat the root cause as a missing migration-safety invariant, not as a
+  remaining bad production migration. The final migrations are split and
+  transaction-compatible; the broader failure was that this compatibility was
+  learned from prod deploy failures instead of enforced before merge.
+- KTD2. Keep the prevention guard in the mapper schema test surface. The
+  current guard in `apps/yt-video-mapper-backend/src/db/schema.test.ts` scans
+  every mapper migration and already runs in the backend test command used by
+  CI.
+- KTD3. Ground the rule in primary sources. Prisma documents `migrate deploy`
+  as the production migration path and recommends pre-deploy migration safety
+  checks; PostgreSQL documents that `CREATE INDEX CONCURRENTLY` cannot run
+  inside a transaction block and that a new enum value added inside a
+  transaction cannot be used until commit.
+- KTD4. Do not use this formal run as a backdoor deployment. The review target
+  is the causal chain, tests, docs, and existing merged remediation. Shipping
+  anything new requires a separate approval point.
+
+---
+
+## Implementation Units
+
+### U0. Evidence Access Prerequisites
+
+**Goal:** Establish the deployment and database evidence sources needed before
+the formal RCA can claim the production history.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:** `apps/yt-video-mapper-backend/docs/railway-deployment.md`
+
+**Approach:** Collect Railway production deployment log URLs or pasted log
+excerpts for the first failed deploy, the second failed deploy, and the final
+successful deploy. Collect a production `_prisma_migrations` status readout
+that shows failed rows separately from applied rows. If any source is
+unavailable, mark U1 blocked for that evidence and carry the limitation into
+the handoff instead of inferring the production state from PR metadata alone.
+
+**Patterns to follow:** Production verification notes in
+`apps/yt-video-mapper-backend/docs/railway-deployment.md`
+
+**Test scenarios:** Test expectation: none -- this unit collects operational
+evidence.
+
+**Verification:** The working notes include deploy-log evidence or an explicit
+access limitation for each failed and successful deploy, plus the migration
+table status evidence or its access limitation.
+
+### U1. Root-Cause Evidence Audit
+
+**Goal:** Prove the causal chain behind the migration failures and identify
+whether the merged state still has an unresolved defect.
+
+**Requirements:** R1, R2
+
+**Dependencies:** U0
+
+**Files:** `apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql`, `apps/yt-video-mapper-backend/prisma/migrations/20260629000200_add_expired_upload_cleanup_index/migration.sql`, `apps/yt-video-mapper-backend/docs/railway-deployment.md`, `CONCEPTS.md`
+
+**Approach:** Compare the two repaired migrations against the two production
+failure modes and the repo's forward-only migration definitions. Use PR merge
+metadata for PRs 1418, 1419, 1421, and 1422 as chronology only, not as the
+source of deploy error truth. Use U0's Railway log excerpts and
+`_prisma_migrations` snapshot as production evidence; if either artifact is
+unavailable, the handoff must state that limitation before concluding R2.
+
+**Patterns to follow:** `docs/solutions/workflow-issues/yt-video-mapper-railway-prisma-backend-deployment.md`, `docs/solutions/deployment/railway-dashboard-override-shadows-railway-toml-20260429.md`
+
+**Test scenarios:** Test expectation: none -- this unit is evidence collection
+and classification.
+
+**Verification:** The handoff names the causal chain with no unresolved
+`somehow` gap, cites failed-deploy and migration-table evidence or names the
+access gap, and states whether any new code change is required.
+
+### U2. Remediation Guard Verification
+
+**Goal:** Verify that the merged test guard covers the production failure modes
+generically, not only by asserting the current migration filenames.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** U1
+
+**Files:** `apps/yt-video-mapper-backend/src/db/schema.test.ts`, `apps/yt-video-mapper-backend/prisma/migrations/*/migration.sql`
+
+**Approach:** Inspect the guard for three properties: it scans all migration
+directories, strips SQL comments, and has synthetic failing fixtures for both
+`CONCURRENTLY` and same-migration enum literal reuse. Reconstruct the
+historical bad migration bodies from PR 1418 and PR 1419 with `git show`, then
+verify the guard reports the two production failure modes against those
+historical inputs before accepting PR 1422 as remediation.
+
+**Patterns to follow:** Existing schema regression tests in
+`apps/yt-video-mapper-backend/src/db/schema.test.ts`
+
+**Test scenarios:**
+
+- Given a synthetic migration containing `CREATE INDEX CONCURRENTLY`, the guard
+  returns a deploy-transaction violation.
+- Given a synthetic migration that adds enum value `expired` and uses
+  `'expired'` again later, the guard returns a split-migration violation.
+- Given unsafe-looking SQL only in comments, the guard returns no violation.
+- Given the current mapper migrations, the guard returns no violations.
+- Given the historical PR 1418 migration body with `CREATE INDEX CONCURRENTLY`,
+  the guard reports the deploy-transaction violation.
+- Given the historical PR 1419 migration bodies where the same migration adds
+  `expired` and uses `'expired'` in a partial index predicate, the guard reports
+  the split-migration violation.
+
+**Verification:** `pnpm --filter @forge/yt-video-mapper-backend test -- src/db/schema.test.ts`
+
+### U3. Package Validation on the Correct Base
+
+**Goal:** Confirm the landed remediation is valid from `upstream/main` with the
+generated Prisma client present.
+
+**Requirements:** R5
+
+**Dependencies:** U2
+
+**Files:** `apps/yt-video-mapper-backend/package.json`, `apps/yt-video-mapper-backend/prisma/schema.prisma`
+
+**Approach:** Run the backend verification commands after regenerating Prisma
+when needed. Treat missing generated Prisma output as an environment setup
+issue, not as a remediation failure, because the build regenerates it. Also run
+`pnpm --filter @forge/yt-video-mapper-backend db:migrate:deploy` against a
+disposable Postgres database from a clean schema so the formal audit exercises
+the same Prisma migration runner class that failed in production.
+
+**Patterns to follow:** Verification commands in
+`docs/prototypes/yt-video-mapper/tickets/ytm-010-prisma-migration-deploy-safety.md`
+
+**Test scenarios:** Test expectation: none -- this unit executes existing
+package verification rather than adding behavior.
+
+**Verification:** Backend schema test, disposable-Postgres migrate deploy, full
+backend tests, typecheck, lint, format check, and build pass.
+
+### U4. Formal Review of Root Cause and Remediation
+
+**Goal:** Run `ce:review` against the root-cause remediation, including the
+test guard and the formal artifacts from this plan.
+
+**Requirements:** R1, R3, R4, R6
+
+**Dependencies:** U1, U2, U3
+
+**Files:** `apps/yt-video-mapper-backend/src/db/schema.test.ts`, `docs/plans/2026-06-30-001-fix-yt-mapper-prisma-migration-root-cause-plan.md`
+
+**Approach:** Review for false positives, false negatives, missing migration
+failure modes, and whether any new production-facing change is being smuggled
+through the formal audit. Because PR 1422 is already merged, do not review the
+empty current worktree as the remediation scope. Review the merged guard
+explicitly by comparing `6737b4c1^` to `6737b4c1`, and include this plan as an
+additional review artifact.
+
+**Patterns to follow:** Formal `ce:review` output under
+`/tmp/compound-engineering/ce-code-review/`
+
+**Test scenarios:** Test expectation: none -- review output is the artifact.
+
+**Verification:** `ce:review` returns a formal review envelope with no P0 or P1
+findings requiring code changes before handoff.
+
+### U5. Compound the Migration-Safety Learning
+
+**Goal:** Preserve the incident lesson where future yt-mapper and Prisma
+migration work will find it before deployment.
+
+**Requirements:** R7
+
+**Dependencies:** U1, U2, U4
+
+**Files:** `docs/solutions/workflow-issues/yt-video-mapper-prisma-migration-transaction-safety.md`
+
+**Approach:** Capture the root cause, detection signals, prevention guard,
+false-confidence trap, and when to split enum migrations from dependent SQL.
+
+**Patterns to follow:** Existing solution-note shape in
+`docs/solutions/workflow-issues/yt-video-mapper-railway-prisma-backend-deployment.md`
+
+**Test scenarios:** Test expectation: none -- this unit creates durable
+engineering documentation.
+
+**Verification:** `ce:compound` produces or updates a `docs/solutions/` note
+that names the failure mode and links the guard.
+
+---
+
+## Scope Boundaries
+
+- This formal run does not change production runtime behavior unless review
+  finds a new defect and the user explicitly approves a follow-up fix.
+- This formal run does not roll back PR 1422 by default; it audits the merged
+  remediation and reports whether rollback or follow-up is warranted.
+- This formal run is scoped to `apps/yt-video-mapper-backend` and its Prisma
+  migrations, not every Prisma service in the monorepo.
+
+---
+
+## Risks & Dependencies
+
+- A regex-based migration guard can miss more complex SQL parsing cases. The
+  present guard is acceptable for the two incident patterns, but a broader
+  monorepo migration linter would be separate work.
+- Prisma and PostgreSQL behavior are external contracts. The plan uses primary
+  docs as sources and should be revisited if the project changes its migration
+  runner or database engine.
+- Generated Prisma client output is intentionally not tracked. Full validation
+  may require `pnpm --filter @forge/yt-video-mapper-backend db:generate` before
+  test or typecheck commands.
+
+---
+
+## Sources & Research
+
+- `apps/yt-video-mapper-backend/src/db/schema.test.ts` contains the merged
+  guard and synthetic fixtures.
+- `apps/yt-video-mapper-backend/prisma/migrations/20260629000100_add_expired_match_job_status/migration.sql` adds the enum value without referencing it again.
+- `apps/yt-video-mapper-backend/prisma/migrations/20260629000200_add_expired_upload_cleanup_index/migration.sql` creates the dependent partial index after the enum-add migration commits.
+- `docs/prototypes/yt-video-mapper/tickets/ytm-010-prisma-migration-deploy-safety.md` records the current acceptance criteria.
+- `docs/solutions/workflow-issues/yt-video-mapper-railway-prisma-backend-deployment.md` records the mapper Railway/Prisma deployment contract.
+- `https://www.prisma.io/docs/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate` documents `prisma migrate deploy` and pre-deploy migration safety checks.
+- `https://www.postgresql.org/docs/current/sql-createindex.html` documents that `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block.
+- `https://www.postgresql.org/docs/current/sql-altertype.html` documents that a newly added enum value inside a transaction cannot be used until commit.

--- a/docs/solutions/workflow-issues/yt-video-mapper-prisma-migration-deploy-safety-guard.md
+++ b/docs/solutions/workflow-issues/yt-video-mapper-prisma-migration-deploy-safety-guard.md
@@ -1,0 +1,191 @@
+---
+title: "YTM Prisma migration deploy safety guard"
+date: "2026-06-30"
+category: "workflow-issues"
+module: "apps/yt-video-mapper-backend"
+problem_type: "workflow_issue"
+component: "development_workflow"
+severity: "high"
+applies_when:
+  - "A Prisma service deploys migrations through `prisma migrate deploy`"
+  - "A Postgres migration adds enum values or enum-dependent SQL"
+  - "A migration creates indexes, constraints, or partial indexes with raw SQL"
+  - "Railway deploy logs are the first place migration safety failures would otherwise appear"
+related_components:
+  - "database"
+  - "testing_framework"
+  - "tooling"
+tags:
+  - "yt-video-mapper"
+  - "prisma"
+  - "postgres"
+  - "migrations"
+  - "deploy-safety"
+  - "railway"
+---
+
+# YTM Prisma migration deploy safety guard
+
+## Context
+
+The yt-video-mapper queued-job expiry rollout exposed two Postgres migration
+hazards through Railway production deploys instead of through local or CI
+checks.
+
+The first failed deploy attempted `CREATE INDEX CONCURRENTLY` inside Prisma's
+`migrate deploy` execution path. Postgres rejects concurrent index creation
+inside a transaction block. The second failed deploy removed `CONCURRENTLY`,
+but added the `expired` enum value and created a partial index referencing
+`'expired'` in the same migration. Postgres accepts adding an enum value inside
+a transaction, but that value cannot be used until the transaction commits.
+
+The repaired shape is split across migrations:
+
+```sql
+-- 20260629000100_add_expired_match_job_status
+ALTER TYPE "match_job_status" ADD VALUE 'expired';
+```
+
+```sql
+-- 20260629000200_add_expired_upload_cleanup_index
+CREATE INDEX IF NOT EXISTS "mapper_match_job_expired_upload_cleanup_idx"
+ON "mapper_match_job"("queued_at", "id")
+WHERE "status" = 'expired'
+  AND (
+    "upload_storage_key" IS NOT NULL
+    OR "upload_content_type" IS NOT NULL
+    OR "upload_byte_length" IS NOT NULL
+  );
+```
+
+Production logs later showed both repaired migrations applying cleanly. Direct
+production `_prisma_migrations` inspection was unavailable in the local formal
+run because Railway's private database host was not resolvable and the token
+could not open an SSH tunnel, so the audit preserved that access limitation
+instead of creating a public database proxy. A disposable local Postgres
+`prisma migrate deploy` run applied all mapper migrations cleanly.
+
+## Guidance
+
+Treat Prisma migration transaction safety as a pre-merge invariant, not a
+production deploy experiment.
+
+For yt-video-mapper migrations:
+
+- Do not put `CREATE INDEX CONCURRENTLY` in migrations that run through
+  `prisma migrate deploy`.
+- Isolate `ALTER TYPE ... ADD VALUE` from any SQL that references the new enum
+  value. Partial indexes, constraints, casts, and data updates that depend on
+  the new literal belong in a later migration.
+- Keep the mapper guard in
+  `apps/yt-video-mapper-backend/src/db/schema.test.ts` scanning every mapper
+  migration directory, not only the migration that triggered the incident.
+- Test the real SQL spelling space that authors may write, including quoted
+  schema-qualified enum type names such as `"public"."match_job_status"` and
+  dollar-quoted enum literals such as `$$expired$$`.
+- Replay exact historical bad SQL during incident RCA. Synthetic fixtures are
+  useful prevention tests, but replaying the PR bodies that failed in
+  production proves the guard matches the real failure, not a nearby toy case.
+
+## Why This Matters
+
+Prisma `migrate deploy` is the production migration runner for this service.
+When a migration only fails inside that runner, the service can be healthy at
+`/health` while deploys repeatedly stop before the server starts. The outcome
+looks like an infrastructure incident, but the root cause is an unsafe SQL
+shape that could have been rejected by tests.
+
+Failed migration attempts and successfully applied migration history need
+different recovery paths. A failed migration row can be marked rolled back
+after the underlying SQL is repaired and reapplied. A successfully applied
+schema change is forward-only: do not edit or delete migration history that a
+deployed database has observed.
+
+The guard also prevents false confidence in app-level expiry behavior. The
+expiry cleaner, worker, and polling contract can all be correct while the
+service still cannot deploy because the migration introducing their schema
+support is not transaction-compatible.
+
+## When to Apply
+
+- A mapper migration contains hand-written SQL.
+- A migration adds a Postgres enum value.
+- A later index, constraint, cast, or query depends on a new enum literal.
+- A migration uses any index option whose legality depends on transaction
+  context.
+- A Railway deploy failure mentions Prisma `P3018`, Postgres `25001`, or
+  Postgres `55P04`.
+- An operator needs to distinguish a Known Recoverable Migration from a
+  Forward-Only Migration.
+
+## Examples
+
+Unsafe: enum add and dependent partial index in one Prisma migration.
+
+```sql
+ALTER TYPE "match_job_status" ADD VALUE 'expired';
+
+CREATE INDEX "mapper_match_job_expired_idx"
+ON "mapper_match_job"("queued_at")
+WHERE "status" = 'expired';
+```
+
+Safe: split the enum add from dependent SQL so the enum value commits before it
+is referenced.
+
+```sql
+-- migration 1
+ALTER TYPE "match_job_status" ADD VALUE 'expired';
+```
+
+```sql
+-- migration 2
+CREATE INDEX "mapper_match_job_expired_idx"
+ON "mapper_match_job"("queued_at")
+WHERE "status" = 'expired';
+```
+
+Guard fixture for quoted schema-qualified type names:
+
+```ts
+expect(
+  findDeployTransactionViolations({
+    name: "bad_schema_qualified_enum_use",
+    sql: `
+      ALTER TYPE "public"."match_job_status" ADD VALUE 'expired';
+      CREATE INDEX "mapper_match_job_expired_idx"
+      ON "mapper_match_job"("queued_at")
+      WHERE "status" = 'expired';
+    `,
+  }),
+).toEqual([
+  "bad_schema_qualified_enum_use adds enum value 'expired' and references it again in the same migration; split dependent SQL into the next migration.",
+])
+```
+
+Guard fixture for dollar-quoted enum literals:
+
+```ts
+expect(
+  findDeployTransactionViolations({
+    name: "bad_dollar_quoted_enum_use",
+    sql: `
+      ALTER TYPE "match_job_status" ADD VALUE $$expired$$;
+      CREATE INDEX "mapper_match_job_expired_idx"
+      ON "mapper_match_job"("queued_at")
+      WHERE "status" = $$expired$$::match_job_status;
+    `,
+  }),
+).toEqual([
+  "bad_dollar_quoted_enum_use adds enum value 'expired' and references it again in the same migration; split dependent SQL into the next migration.",
+])
+```
+
+## Related
+
+- [YTM Railway Prisma backend deployment hardening](./yt-video-mapper-railway-prisma-backend-deployment.md) - same service and Railway `prisma migrate deploy` contract.
+- [Railway dashboard config silently shadows per-service `apps/<svc>/railway.toml`](../deployment/railway-dashboard-override-shadows-railway-toml-20260429.md) - deployment config must be verified through an independent read path.
+- [Prisma migration-backed reverts need a database state check first](../database-issues/prisma-migration-backed-revert-state-check.md) - distinguishes failed migration recovery from forward-only history.
+- [First DROP COLUMN forward-only migration playbook](../database-issues/first-drop-column-forward-only-migration-playbook-20260517.md) - related Prisma/Postgres migration safety discipline.
+- [Assert Prisma raw-SQL invariants by scraping tagged-template text](../best-practices/prisma-raw-sql-invariant-assertions-20260423.md) - adjacent testing pattern for SQL shape guards.
+- [Prisma `@map`'d enums: raw SQL bypasses Prisma's coercion](../database-issues/prisma-raw-sql-enum-mapping-seam-20260504.md) - adjacent enum literal and raw SQL discipline.


### PR DESCRIPTION
## Summary

The yt-video-mapper migration guard now catches the transaction-safety variants that could have let the same Railway deploy failure recur under valid Postgres SQL spellings. The formal RCA also documents why the incident happened: Prisma `migrate deploy` runs migrations in a transaction, so `CREATE INDEX CONCURRENTLY` and same-transaction enum-value reuse must be rejected before deploy.

This PR tightens the guard added in #1422 by covering quoted schema-qualified enum type names and dollar-quoted enum literals, then compounds the incident into a durable solution note for future Prisma/Railway migration work.

## What Changed

| Area | Change |
|---|---|
| Migration guard | Detects `ALTER TYPE "public"."match_job_status" ADD VALUE ...` plus same-migration enum literal reuse |
| Migration guard | Detects dollar-quoted enum values such as `$$expired$$` when reused before commit |
| Formal RCA | Adds the formal plan and review-driven root-cause trail |
| Knowledge base | Adds a targeted `docs/solutions/` note for Prisma/Postgres transaction-safety traps |

## Validation

- `pnpm --filter @forge/yt-video-mapper-backend test -- src/db/schema.test.ts`
- `pnpm --filter @forge/yt-video-mapper-backend test`
- `pnpm --filter @forge/yt-video-mapper-backend typecheck`
- `pnpm --filter @forge/yt-video-mapper-backend lint`
- `pnpm run format:check`
- `pnpm --filter @forge/yt-video-mapper-backend build`
- disposable Postgres `prisma migrate deploy`
- formal CE review: `/tmp/compound-engineering/ce-code-review/20260630-020028-cb7e69a2/report.md`

## Operational Note

No production mutation was made during the formal pass. Direct production `_prisma_migrations` inspection was unavailable from this environment because Railway's private database host was not locally resolvable and the token could not open an SSH tunnel, so I did not create a public TCP proxy without approval.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
