### PR TITLE
feat: persona-aware experience variants + "Create persona version" button

### DIFF
--- a/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
+++ b/apps/admin/src/app/dashboard/experiences/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/app/dashboard/experiences/experience-chat-actions"
 import { runGenerateDraftAction } from "@/app/dashboard/experiences/generate-draft-action"
 import { runGenerateSectionAction } from "@/app/dashboard/experiences/generate-section-action"
+import { runGenerateVariantAction } from "@/app/dashboard/experiences/generate-variant-action"
 import {
   loadVideoRows,
   videoIdsFromExperienceBlocks,
@@ -626,6 +627,19 @@ export default async function ExperienceEditorPage({
     )
   }
 
+  async function generateVariantAction(input: { personaId: string }) {
+    "use server"
+    const user = await requireSession()
+    return runGenerateVariantAction(
+      { prisma, user },
+      {
+        sourceLocaleId: selectedLocale.id,
+        locale: selectedLocale.locale,
+        personaId: input.personaId,
+      },
+    )
+  }
+
   return (
     <ExperienceEditorWithChat
       key={`${selectedLocale.id}:${selectedLocale.updatedAt.toISOString()}:${selectedLocale.status}`}
@@ -673,6 +687,7 @@ export default async function ExperienceEditorPage({
       restoreAction={restoreRevisionAction}
       generateDraftAction={generateDraftAction}
       generateSectionAction={generateSectionAction}
+      generateVariantAction={generateVariantAction}
     />
   )
 }

--- a/apps/admin/src/app/dashboard/experiences/experience-editor-with-chat.tsx
+++ b/apps/admin/src/app/dashboard/experiences/experience-editor-with-chat.tsx
@@ -18,6 +18,8 @@ import {
   type ExperienceChatPanelActions,
 } from "@/app/dashboard/experiences/experience-editor/experience-chat-panel"
 import { getSuggestedPrompts } from "@/app/dashboard/experiences/experience-editor/experience-chat-suggested-prompts"
+import { PersonaVariantButton } from "@/app/dashboard/experiences/persona-variant-button"
+import type { GenerateVariantActionResult } from "@/app/dashboard/experiences/generate-variant-action"
 
 type ExperienceEditorProps = Parameters<typeof ExperienceEditor>[0]
 
@@ -51,6 +53,14 @@ export type ExperienceEditorWithChatProps = Omit<
    * "Generate section from video" control. Optional, like generateDraftAction.
    */
   generateSectionAction?: ChatGenerateSectionAction
+  /**
+   * "Create persona version" — duplicates this experience as a new DRAFT
+   * re-toned for a chosen audience persona. Optional; the button only renders
+   * when the AI variant surface is wired.
+   */
+  generateVariantAction?: (input: {
+    personaId: string
+  }) => Promise<GenerateVariantActionResult>
 }
 
 function collectVideoIdsFromBlocks(blocks: readonly unknown[]): string[] {
@@ -80,6 +90,7 @@ export function ExperienceEditorWithChat({
   loadVideosByIdsAction,
   generateDraftAction,
   generateSectionAction,
+  generateVariantAction,
   ...editorProps
 }: ExperienceEditorWithChatProps) {
   const controllerRef = useRef<ExperienceCanvasController | null>(null)
@@ -198,6 +209,11 @@ export function ExperienceEditorWithChat({
         generateSectionAction={generateSectionAction}
       />
       <div className="flex min-w-0 flex-1 flex-col">
+        {generateVariantAction && (
+          <div className="border-b border-[var(--color-hairline)] px-4 py-2">
+            <PersonaVariantButton action={generateVariantAction} />
+          </div>
+        )}
         <ExperienceEditor
           {...editorProps}
           videoLibrary={videoLibrary}

--- a/apps/admin/src/app/dashboard/experiences/generate-variant-action.test.ts
+++ b/apps/admin/src/app/dashboard/experiences/generate-variant-action.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest"
+
+import type { PrismaClient } from "@prisma/client"
+import type { DraftExperience } from "@forge/experience-schema"
+
+import type { Principal } from "@/auth/principal"
+
+import { runGenerateVariantAction } from "./generate-variant-action"
+
+// A source experience locale the editor is duplicating from.
+const SOURCE = {
+  id: "loc-src",
+  slug: "easter",
+  title: "Easter",
+  metaDescription: "An Easter page for everyone.",
+  blocks: [
+    {
+      t: "text",
+      heading: "He is risen",
+      contentParagraphs: ["The tomb is empty."],
+    },
+    { t: "cta", buttonLabel: "Watch" },
+  ],
+  status: "PUBLISHED",
+  experienceId: "exp-src",
+  experience: { ownerId: "u1", archivedAt: null },
+}
+
+function makeDeps(sourceRow: unknown = SOURCE, user?: Principal) {
+  const prisma = {
+    experienceLocale: { findUnique: vi.fn(async () => sourceRow) },
+  } as unknown as PrismaClient
+  return { prisma, user: user ?? ({ id: "u1", role: "ADMIN" } as Principal) }
+}
+
+// A valid generated draft (2 text blocks — normalizes with no candidates).
+const VALID_DRAFT: DraftExperience = {
+  title: "Easter, for a grieving heart",
+  metaDescription: "Comfort and quiet hope in the Easter story.",
+  blocks: [
+    {
+      t: "text",
+      heading: "You are not alone",
+      contentParagraphs: ["Grief is heavy. The Easter story meets it gently."],
+    },
+    {
+      t: "text",
+      heading: "Hope is real",
+      contentParagraphs: ["The resurrection is a quiet, deep word of hope."],
+    },
+  ],
+}
+
+const INPUT = {
+  sourceLocaleId: "loc-src",
+  locale: "en",
+  personaId: "grieving",
+}
+
+const okLaunch = vi.fn(async () => ({
+  ok: true as const,
+  draft: VALID_DRAFT,
+  personaId: "grieving",
+}))
+
+function baseOverrides() {
+  return {
+    loadCandidates: vi.fn(async () => []),
+    launchVariant: vi.fn(async () => ({
+      ok: true as const,
+      draft: VALID_DRAFT,
+      personaId: "grieving",
+    })),
+    persist: vi.fn(async () => ({
+      experienceId: "exp-new",
+      localeId: "loc-new",
+    })),
+  }
+}
+
+describe("runGenerateVariantAction", () => {
+  it("creates a DRAFT duplicate and returns its editor href (happy path)", async () => {
+    const persist = vi.fn(async () => ({
+      experienceId: "exp-new",
+      localeId: "loc-new",
+    }))
+    const result = await runGenerateVariantAction(makeDeps(), INPUT, {
+      loadCandidates: vi.fn(async () => []),
+      launchVariant: okLaunch,
+      persist,
+    })
+    expect(result).toMatchObject({
+      ok: true,
+      experienceId: "exp-new",
+      localeId: "loc-new",
+      slug: "easter-grieving",
+    })
+    if (result.ok)
+      expect(result.href).toContain("/dashboard/experiences/exp-new")
+    // The normalized title + derived slug reach persistence.
+    expect(persist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "easter-grieving",
+        title: "Easter, for a grieving heart",
+        locale: "en",
+      }),
+    )
+  })
+
+  it("seeds topic + a sanitized exemplar from the source experience", async () => {
+    const launchVariant = vi.fn(
+      async (input: {
+        topic: string
+        personaId: string
+        exemplar?: string
+      }) => {
+        void input
+        return { ok: true as const, draft: VALID_DRAFT, personaId: "grieving" }
+      },
+    )
+    await runGenerateVariantAction(makeDeps(), INPUT, {
+      loadCandidates: vi.fn(async () => []),
+      launchVariant,
+      persist: vi.fn(async () => ({ experienceId: "e", localeId: "l" })),
+    })
+    const call = launchVariant.mock.calls[0]![0]
+    expect(call.topic).toBe("Easter")
+    expect(call.personaId).toBe("grieving")
+    // Exemplar is the sanitized source outline — a non-empty string built from
+    // the source page (structure/voice reference; video ids stripped upstream).
+    expect(typeof call.exemplar).toBe("string")
+    expect((call.exemplar as string).length).toBeGreaterThan(0)
+  })
+
+  it("returns SOURCE_NOT_FOUND when the source locale is missing", async () => {
+    const result = await runGenerateVariantAction(
+      makeDeps(null),
+      INPUT,
+      baseOverrides(),
+    )
+    expect(result).toMatchObject({ ok: false, code: "SOURCE_NOT_FOUND" })
+  })
+
+  it("returns FORBIDDEN when the user cannot edit the source", async () => {
+    const result = await runGenerateVariantAction(
+      makeDeps(SOURCE, { id: "other", role: "VIEWER" } as Principal),
+      INPUT,
+      baseOverrides(),
+    )
+    expect(result).toMatchObject({ ok: false, code: "FORBIDDEN" })
+  })
+
+  it("maps remote config_missing → NOT_CONFIGURED", async () => {
+    const result = await runGenerateVariantAction(makeDeps(), INPUT, {
+      loadCandidates: vi.fn(async () => []),
+      launchVariant: vi.fn(async () => ({
+        ok: false as const,
+        reason: "config_missing" as const,
+        retryable: false,
+      })),
+    })
+    expect(result).toMatchObject({ ok: false, code: "NOT_CONFIGURED" })
+  })
+
+  it("maps remote generation_failed → GENERATION_FAILED", async () => {
+    const result = await runGenerateVariantAction(makeDeps(), INPUT, {
+      loadCandidates: vi.fn(async () => []),
+      launchVariant: vi.fn(async () => ({
+        ok: false as const,
+        reason: "generation_failed" as const,
+        retryable: true,
+      })),
+    })
+    expect(result).toMatchObject({ ok: false, code: "GENERATION_FAILED" })
+  })
+
+  it("maps a below-minimum draft → SCHEMA_MISMATCH (real normalize gate)", async () => {
+    const thin: DraftExperience = {
+      title: "x",
+      metaDescription: "y",
+      blocks: [{ t: "text", heading: "h", contentParagraphs: ["p"] }],
+    }
+    const result = await runGenerateVariantAction(makeDeps(), INPUT, {
+      loadCandidates: vi.fn(async () => []),
+      launchVariant: vi.fn(async () => ({
+        ok: true as const,
+        draft: thin,
+        personaId: "grieving",
+      })),
+      persist: vi.fn(async () => ({ experienceId: "e", localeId: "l" })),
+    })
+    expect(result).toMatchObject({ ok: false, code: "SCHEMA_MISMATCH" })
+  })
+})

--- a/apps/admin/src/app/dashboard/experiences/generate-variant-action.ts
+++ b/apps/admin/src/app/dashboard/experiences/generate-variant-action.ts
@@ -1,0 +1,257 @@
+/**
+ * Server action core — "duplicate experience with persona influence".
+ *
+ * Given a SOURCE experience locale + a persona, generate a persona-adapted
+ * DUPLICATE and stage it as a NEW DRAFT experience. The source page's structure
+ * and voice steer generation (via the sanitized `buildExemplarOutline` string —
+ * video ids/urls/colors stripped, so the source's videos are NOT reused); the
+ * persona drives framing/tone/Scripture/audience; copy is freshly written and
+ * videos come only from semantic candidate retrieval. The result is staged as a
+ * DRAFT (`<topic>-<persona>`) for review — never published.
+ *
+ * This is "Phase B's button": it assembles the already-built persona-variant
+ * backend (`launchMastraExperienceVariant` + `normalizeExperienceDraft` +
+ * `ExperienceService.create`). Remote generation runs on the standalone mastra
+ * `/forge-experience-variant` route; an unconfigured client → NOT_CONFIGURED.
+ *
+ * Pure, injectable core (deps + overrides) so it unit-tests without a real
+ * Prisma / network — the `"use server"` boundary is the thunk in `[id]/page.tsx`.
+ */
+
+import type { PrismaClient } from "@prisma/client"
+
+import { canEditExperienceLocale } from "@/auth/permissions"
+import type { Principal } from "@/auth/principal"
+
+import { buildExemplarOutline } from "@/services/experience-ai/experience-ai-exemplar-outline"
+import {
+  ExperienceAiNormalizationError,
+  normalizeExperienceDraft,
+  type NormalizedExperienceDraft,
+} from "@/services/experience-ai/experience-ai-normalize"
+import { loadExperienceAiVideoCandidates } from "@/services/experience-ai/experience-ai.service"
+import { launchMastraExperienceVariant } from "@/services/experience-ai/mastra-experience-variant-client"
+import { ExperienceService } from "@/services/experience.service"
+import { variantSlug } from "@/scripts/generate-persona-variants"
+
+export type GenerateVariantActionInput = {
+  /** The source experience locale to duplicate from. */
+  sourceLocaleId: string
+  /** Locale of the source + the new duplicate. */
+  locale: string
+  /** Persona id from the Mastra roster (e.g. "grieving", "seeker-skeptic"). */
+  personaId: string
+}
+
+export type GenerateVariantActionErrorCode =
+  | "SOURCE_NOT_FOUND"
+  | "FORBIDDEN"
+  | "NOT_CONFIGURED"
+  | "GENERATION_FAILED"
+  | "TIMEOUT"
+  | "SCHEMA_MISMATCH"
+  | "PERSIST_FAILED"
+  | "UPSTREAM_ERROR"
+  | "UNKNOWN"
+
+export type GenerateVariantActionResult =
+  | {
+      ok: true
+      experienceId: string
+      localeId: string
+      slug: string
+      /** Editor href for the freshly-created DRAFT duplicate. */
+      href: string
+    }
+  | { ok: false; code: GenerateVariantActionErrorCode; error: string }
+
+export const VARIANT_USER_MESSAGES: Record<
+  GenerateVariantActionErrorCode,
+  string
+> = {
+  SOURCE_NOT_FOUND: "The experience to duplicate was not found.",
+  FORBIDDEN: "You do not have permission to duplicate this experience.",
+  NOT_CONFIGURED:
+    "AI persona generation is not configured for this environment.",
+  GENERATION_FAILED: "The AI couldn't generate a persona version. Try again.",
+  TIMEOUT: "Generation took too long. Try again shortly.",
+  SCHEMA_MISMATCH: "The generated page wasn't valid. Try again.",
+  PERSIST_FAILED: "The persona version was generated but couldn't be saved.",
+  UPSTREAM_ERROR: "The AI service is unavailable right now. Try again shortly.",
+  UNKNOWN: "Unable to create a persona version right now.",
+}
+
+type GenerateVariantActionDeps = {
+  prisma: PrismaClient
+  user: Principal | null
+}
+
+export type GenerateVariantActionOverrides = {
+  loadCandidates?: typeof loadExperienceAiVideoCandidates
+  launchVariant?: typeof launchMastraExperienceVariant
+  /** Persist the staged DRAFT; defaults to ExperienceService.create + updateLocale. */
+  persist?: (args: {
+    slug: string
+    title: string
+    metaDescription: string
+    blocks: NormalizedExperienceDraft["blocks"]
+    locale: string
+  }) => Promise<{ experienceId: string; localeId: string }>
+}
+
+function fail(
+  code: GenerateVariantActionErrorCode,
+): Extract<GenerateVariantActionResult, { ok: false }> {
+  return { ok: false, code, error: VARIANT_USER_MESSAGES[code] }
+}
+
+export async function runGenerateVariantAction(
+  deps: GenerateVariantActionDeps,
+  input: GenerateVariantActionInput,
+  overrides: GenerateVariantActionOverrides = {},
+): Promise<GenerateVariantActionResult> {
+  // 1. Load the source locale + ABAC (must be allowed to read/edit the source).
+  const source = await deps.prisma.experienceLocale.findUnique({
+    where: { id: input.sourceLocaleId },
+    select: {
+      id: true,
+      slug: true,
+      title: true,
+      metaDescription: true,
+      blocks: true,
+      status: true,
+      experienceId: true,
+      experience: { select: { ownerId: true, archivedAt: true } },
+    },
+  })
+  if (!source) return fail("SOURCE_NOT_FOUND")
+  if (!canEditExperienceLocale(deps.user, source)) return fail("FORBIDDEN")
+
+  // Topic drives both candidate retrieval and the persona prompt subject.
+  const topic = (source.title?.trim() || source.slug).slice(0, 200)
+  // Sanitized structure-and-voice reference (source video ids/urls stripped).
+  const exemplar =
+    buildExemplarOutline({
+      title: source.title,
+      metaDescription: source.metaDescription,
+      blocks: source.blocks,
+    }) ?? undefined
+
+  // 2. Load fresh video candidates by semantic relevance to the topic.
+  const loadCandidates =
+    overrides.loadCandidates ?? loadExperienceAiVideoCandidates
+  let candidates
+  try {
+    candidates = await loadCandidates(deps.prisma, {
+      locale: input.locale,
+      prompt: topic,
+    })
+  } catch (error) {
+    console.error(
+      `[runGenerateVariantAction] event=candidates_error message=${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+    return fail("UPSTREAM_ERROR")
+  }
+
+  // 3. Remote persona-variant generation (source as exemplar + persona steering).
+  const launch = overrides.launchVariant ?? launchMastraExperienceVariant
+  const remote = await launch({
+    topic,
+    locale: input.locale,
+    personaId: input.personaId,
+    candidates,
+    exemplar,
+  })
+  if (!remote.ok) {
+    console.warn(
+      `[runGenerateVariantAction] event=remote_failed reason=${remote.reason} retryable=${remote.retryable}`,
+    )
+    switch (remote.reason) {
+      case "config_missing":
+        return fail("NOT_CONFIGURED")
+      case "timeout":
+        return fail("TIMEOUT")
+      case "generation_failed":
+      case "invalid_input":
+        return fail("GENERATION_FAILED")
+      default:
+        return fail("UPSTREAM_ERROR")
+    }
+  }
+
+  // 4. R11 block gate — re-validate + resolve candidateRefs against the pack.
+  let normalized: NormalizedExperienceDraft
+  try {
+    normalized = normalizeExperienceDraft(remote.draft, [...candidates])
+  } catch (error) {
+    if (error instanceof ExperienceAiNormalizationError) {
+      console.warn(
+        `[runGenerateVariantAction] event=normalize_failed code=${error.code}`,
+      )
+      return fail("SCHEMA_MISMATCH")
+    }
+    console.error("[runGenerateVariantAction] event=normalize_error", error)
+    return fail("UNKNOWN")
+  }
+
+  // 5. Persist as a NEW DRAFT. Drafts may share a (locale, slug) — the partial
+  //    unique index is published-only — so we create rather than delete-by-slug
+  //    (a destructive nuke-by-slug would be unsafe from a user-facing action).
+  const slug = variantSlug(topic, input.personaId)
+  const persist = overrides.persist ?? ((args) => defaultPersist(deps, args))
+  let persisted: { experienceId: string; localeId: string }
+  try {
+    persisted = await persist({
+      slug,
+      title: normalized.title,
+      metaDescription: normalized.metaDescription,
+      blocks: normalized.blocks,
+      locale: input.locale,
+    })
+  } catch (error) {
+    console.error("[runGenerateVariantAction] event=persist_error", error)
+    return fail("PERSIST_FAILED")
+  }
+
+  return {
+    ok: true,
+    experienceId: persisted.experienceId,
+    localeId: persisted.localeId,
+    slug,
+    href: `/dashboard/experiences/${persisted.experienceId}?locale=${encodeURIComponent(
+      input.locale,
+    )}`,
+  }
+}
+
+async function defaultPersist(
+  deps: GenerateVariantActionDeps,
+  args: {
+    slug: string
+    title: string
+    metaDescription: string
+    blocks: NormalizedExperienceDraft["blocks"]
+    locale: string
+  },
+): Promise<{ experienceId: string; localeId: string }> {
+  const service = new ExperienceService(deps.prisma)
+  const created = await service.create({
+    input: {
+      locale: args.locale,
+      slug: args.slug,
+      title: args.title,
+      blocks: args.blocks,
+    },
+    user: deps.user,
+  })
+  const localeId = created.locales[0]!.id
+  if (args.metaDescription) {
+    await service.updateLocale({
+      input: { id: localeId, metaDescription: args.metaDescription },
+      user: deps.user,
+    })
+  }
+  return { experienceId: created.id, localeId }
+}

--- a/apps/admin/src/app/dashboard/experiences/persona-variant-button.tsx
+++ b/apps/admin/src/app/dashboard/experiences/persona-variant-button.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+/**
+ * "Create persona version" — duplicates the current experience as a NEW DRAFT,
+ * re-toned for a chosen audience persona (the source page steers structure +
+ * voice; the persona drives framing/tone/Scripture). On success it navigates to
+ * the freshly-created draft.
+ *
+ * The 5 persona ids mirror the Mastra roster
+ * (`apps/mastra/src/config/personas/persona-roster.ts`) and are hardcoded here
+ * because admin must NOT import from apps/mastra — the persona `id` is the
+ * stable cross-app contract.
+ */
+
+import type { Route } from "next"
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
+import type { GenerateVariantActionResult } from "@/app/dashboard/experiences/generate-variant-action"
+
+const PERSONAS: ReadonlyArray<{ id: string; label: string }> = [
+  { id: "seeker-skeptic", label: "Seeker / skeptic" },
+  { id: "grieving", label: "Grieving" },
+  { id: "new-believer", label: "New believer" },
+  { id: "family", label: "Family with children" },
+  { id: "seasoned-believer", label: "Seasoned believer" },
+]
+
+const CONTROL_CLASS =
+  "inline-flex h-8 cursor-pointer items-center rounded-sm border border-[var(--color-hairline)] px-3 text-[13px] text-[var(--color-text-secondary)] transition-all duration-[120ms] ease-out hover:border-[var(--color-hairline-strong)] hover:bg-[var(--color-surface-raised)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)] disabled:cursor-not-allowed disabled:opacity-60"
+
+type PersonaVariantButtonProps = {
+  action: (input: { personaId: string }) => Promise<GenerateVariantActionResult>
+}
+
+export function PersonaVariantButton({ action }: PersonaVariantButtonProps) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [personaId, setPersonaId] = useState<string>(PERSONAS[0]!.id)
+  const [status, setStatus] = useState<"idle" | "generating" | "error">("idle")
+  const [error, setError] = useState<string | null>(null)
+
+  const generating = status === "generating"
+
+  async function handleCreate() {
+    setStatus("generating")
+    setError(null)
+    try {
+      const result = await action({ personaId })
+      if (!result.ok) {
+        setStatus("error")
+        setError(result.error)
+        return
+      }
+      setStatus("idle")
+      setOpen(false)
+      // Navigate to the freshly-created DRAFT duplicate.
+      router.push(result.href as Route)
+    } catch {
+      setStatus("error")
+      setError("Something went wrong generating the persona version.")
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className={CONTROL_CLASS}
+        aria-expanded={open}
+      >
+        Create persona version…
+      </button>
+
+      {open && (
+        <div className="flex flex-wrap items-center gap-2 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-surface)] p-3">
+          <label
+            htmlFor="persona-variant-select"
+            className="text-[12px] text-[var(--color-text-muted)]"
+          >
+            Audience
+          </label>
+          <select
+            id="persona-variant-select"
+            value={personaId}
+            onChange={(event) => setPersonaId(event.target.value)}
+            disabled={generating}
+            className="h-9 rounded-sm border border-[var(--color-hairline)] bg-[var(--color-bg)] px-3 text-[13px] outline-none transition-all duration-[120ms] ease-out focus:border-[var(--color-hairline-strong)] disabled:opacity-60"
+          >
+            {PERSONAS.map((persona) => (
+              <option key={persona.id} value={persona.id}>
+                {persona.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={generating}
+            className={CONTROL_CLASS}
+          >
+            {generating ? "Generating… (~60s)" : "Create draft"}
+          </button>
+          {error && (
+            <p className="w-full text-[12px] text-[var(--color-danger,#dc2626)]">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/admin/src/config/env.ts
+++ b/apps/admin/src/config/env.ts
@@ -430,6 +430,24 @@ export const env = createEnv({
       .int()
       .positive()
       .default(75_000),
+    // Persona-aware variant generation (persona-variants v1). When "true", the
+    // operator script calls the standalone `/forge-experience-variant` route
+    // (reusing MASTRA_BASE_URL + MASTRA_SERVICE_API_KEY) to generate one tailored
+    // experience per persona. Remote-only, like the section path. Opt-in
+    // scaffolding: optional + defaulted so an unprovisioned env still boots.
+    EXPERIENCE_AI_REMOTE_VARIANTS: z
+      .enum(["true", "false"])
+      .optional()
+      .default("false"),
+    // Outbound HTTP budget per persona-variant call. MUST stay strictly LARGER
+    // than mastra's internal multi-step budget (TIME_BUDGET_MS.multiStepWorkflow,
+    // 180s) so the mastra-side timeout wins the race (same invariant as
+    // MASTRA_DRAFT_TIMEOUT_MS).
+    MASTRA_VARIANTS_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(200_000),
     // Flag-gated streaming chat cutover (consolidation U9). When "true",
     // `runMastraChat` relays the token stream from the standalone
     // `/forge-experience-chat` route instead of running the agent in-process;
@@ -702,6 +720,12 @@ export const env = createEnv({
     ),
     MASTRA_SECTION_TIMEOUT_MS: emptyToUndefined(
       process.env.MASTRA_SECTION_TIMEOUT_MS,
+    ),
+    EXPERIENCE_AI_REMOTE_VARIANTS: emptyToUndefined(
+      process.env.EXPERIENCE_AI_REMOTE_VARIANTS,
+    ),
+    MASTRA_VARIANTS_TIMEOUT_MS: emptyToUndefined(
+      process.env.MASTRA_VARIANTS_TIMEOUT_MS,
     ),
     EXPERIENCE_AI_REMOTE_CHAT: emptyToUndefined(
       process.env.EXPERIENCE_AI_REMOTE_CHAT,

--- a/apps/admin/src/scripts/generate-persona-variants.test.ts
+++ b/apps/admin/src/scripts/generate-persona-variants.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+
+import type { DraftExperience, VideoCandidate } from "@forge/experience-schema"
+
+import type { NormalizedExperienceDraft } from "@/services/experience-ai/experience-ai-normalize"
+import {
+  assertNotProdUrl,
+  runPersonaVariants,
+  variantSlug,
+  type RunPersonaVariantsDeps,
+} from "./generate-persona-variants"
+
+const DRAFT: DraftExperience = {
+  title: "T",
+  metaDescription: "M",
+  blocks: [
+    { t: "text", contentParagraphs: ["a"] },
+    { t: "text", contentParagraphs: ["b"] },
+  ],
+}
+
+const NORMALIZED: NormalizedExperienceDraft = {
+  title: "T",
+  metaDescription: "M",
+  blocks: [{ t: "text", contentParagraphs: ["a"] }],
+}
+
+const CANDIDATES: readonly VideoCandidate[] = []
+
+function deps(over: Partial<RunPersonaVariantsDeps> = {}): {
+  deps: RunPersonaVariantsDeps
+  persistedPersonas: string[]
+} {
+  const persistedPersonas: string[] = []
+  return {
+    persistedPersonas,
+    deps: {
+      candidates: CANDIDATES,
+      launchVariant: async ({ personaId }) => ({
+        ok: true,
+        draft: DRAFT,
+        personaId,
+      }),
+      normalize: () => NORMALIZED,
+      persist: async ({ slug }) => {
+        const personaId = slug.split("-").slice(-1)[0]!
+        persistedPersonas.push(personaId)
+        return {
+          experienceId: `exp-${personaId}`,
+          localeId: `loc-${personaId}`,
+        }
+      },
+      ...over,
+    },
+  }
+}
+
+describe("generate-persona-variants", () => {
+  it("produces one outcome per persona and persists each success", async () => {
+    const { deps: d, persistedPersonas } = deps()
+    const { outcomes } = await runPersonaVariants(
+      {
+        topic: "Easter",
+        locale: "en",
+        personaIds: ["grieving", "family"],
+        concurrency: 2,
+      },
+      d,
+    )
+    expect(outcomes).toHaveLength(2)
+    expect(outcomes.every((o) => o.status === "succeeded")).toBe(true)
+    expect(persistedPersonas.sort()).toEqual(["family", "grieving"])
+  })
+
+  it("isolates a per-persona generation failure (others still persist)", async () => {
+    const { deps: d, persistedPersonas } = deps({
+      launchVariant: async ({ personaId }) =>
+        personaId === "family"
+          ? { ok: false, reason: "timeout", retryable: true }
+          : { ok: true, draft: DRAFT, personaId },
+    })
+    const { outcomes } = await runPersonaVariants(
+      {
+        topic: "Easter",
+        locale: "en",
+        personaIds: ["grieving", "family"],
+        concurrency: 2,
+      },
+      d,
+    )
+    const byPersona = Object.fromEntries(outcomes.map((o) => [o.personaId, o]))
+    expect(byPersona.grieving?.status).toBe("succeeded")
+    expect(byPersona.family).toMatchObject({
+      status: "failed",
+      reason: "timeout",
+    })
+    expect(persistedPersonas).toEqual(["grieving"])
+  })
+
+  it("rejects a variant whose blocks fail the normalize gate and does not persist it (R11/AE4)", async () => {
+    const { deps: d, persistedPersonas } = deps({
+      normalize: (draft) => {
+        if (draft === DRAFT) throw new Error("INVALID_BLOCKS")
+        return NORMALIZED
+      },
+    })
+    const { outcomes } = await runPersonaVariants(
+      {
+        topic: "Easter",
+        locale: "en",
+        personaIds: ["grieving"],
+        concurrency: 1,
+      },
+      d,
+    )
+    expect(outcomes[0]).toMatchObject({ status: "failed" })
+    expect(persistedPersonas).toEqual([])
+  })
+
+  it("never exceeds the concurrency cap", async () => {
+    const { deps: d } = deps({
+      launchVariant: async ({ personaId }) => {
+        await new Promise((r) => setTimeout(r, 10))
+        return { ok: true, draft: DRAFT, personaId }
+      },
+    })
+    const { observedMaxInFlight } = await runPersonaVariants(
+      {
+        topic: "Easter",
+        locale: "en",
+        personaIds: ["a", "b", "c", "d", "e"],
+        concurrency: 2,
+      },
+      d,
+    )
+    expect(observedMaxInFlight).toBeLessThanOrEqual(2)
+    expect(observedMaxInFlight).toBe(2)
+  })
+
+  it("guards against production-like DATABASE_URL hosts", () => {
+    expect(() =>
+      assertNotProdUrl("postgresql://forge:forge@db:5432/forge_admin"),
+    ).not.toThrow()
+    expect(() =>
+      assertNotProdUrl("postgresql://u:p@admin.jesusfilm.org:5432/db"),
+    ).toThrow()
+    expect(() =>
+      assertNotProdUrl("postgresql://u:p@something.railway.app:5432/db"),
+    ).toThrow()
+    expect(() => assertNotProdUrl(undefined)).toThrow()
+  })
+
+  it("builds a topic+persona slug", () => {
+    expect(variantSlug("Easter", "grieving")).toBe("easter-grieving")
+    expect(variantSlug("Who Is Jesus?", "seeker-skeptic")).toBe(
+      "who-is-jesus-seeker-skeptic",
+    )
+  })
+})

--- a/apps/admin/src/scripts/generate-persona-variants.ts
+++ b/apps/admin/src/scripts/generate-persona-variants.ts
@@ -1,0 +1,306 @@
+/**
+ * Operator script: generate persona-tailored experience variants for one topic.
+ *
+ *   CI=true DATABASE_URL='postgresql://forge:forge@db:5432/forge_admin' \
+ *     pnpm --filter @forge/admin exec tsx src/scripts/generate-persona-variants.ts \
+ *       --topic "Easter" --persona grieving --persona family --persona seeker-skeptic
+ *
+ * Loads video candidates once, fans out one `/forge-experience-variant` call per
+ * persona under bounded concurrency, runs each result through the same block
+ * gate the editor uses (`normalizeExperienceDraft`, R11), and stages each as a
+ * DRAFT experience (slug `<topic>-<persona>`) for review in the dashboard. One
+ * persona's failure never drops the others. Auto-routing, grouping, and the
+ * editor UI are Phase B.
+ *
+ * Safety: refuses production-like DATABASE_URL hosts.
+ */
+
+import pLimit from "p-limit"
+
+import type { PrismaClient } from "@prisma/client"
+import type { DraftExperience, VideoCandidate } from "@forge/experience-schema"
+
+import type { Principal } from "@/auth/principal"
+import {
+  ExperienceAiNormalizationError,
+  normalizeExperienceDraft,
+  type NormalizedExperienceDraft,
+} from "@/services/experience-ai/experience-ai-normalize"
+import { loadExperienceAiVideoCandidates } from "@/services/experience-ai/experience-ai.service"
+import {
+  launchMastraExperienceVariant,
+  type MastraExperienceVariantLaunchResult,
+} from "@/services/experience-ai/mastra-experience-variant-client"
+
+// ---------------------------------------------------------------------------
+// Prod-URL guard (fail-closed) — exported for tests
+// ---------------------------------------------------------------------------
+
+const PROD_DENY = new Set([
+  "admin.jesusfilm.org",
+  "www.jesusfilm.org",
+  "jesusfilm.org",
+  "manager.jesusfilm.org",
+  "web.jesusfilm.org",
+])
+
+export function assertNotProdUrl(raw: string | undefined): void {
+  if (!raw) throw new Error("DATABASE_URL is required")
+  let host: string
+  try {
+    host = new URL(raw).hostname.toLowerCase()
+  } catch {
+    throw new Error("DATABASE_URL is not a parseable URL")
+  }
+  if (
+    host.endsWith(".railway.app") ||
+    host.endsWith(".jesusfilm.org") ||
+    PROD_DENY.has(host)
+  ) {
+    throw new Error(`Refusing to run against production-like host: ${host}`)
+  }
+}
+
+/** Slug for a persona variant of a topic, e.g. ("Easter","grieving") → easter-grieving. */
+export function variantSlug(topic: string, personaId: string): string {
+  const base = topic
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return `${base || "experience"}-${personaId}`
+}
+
+// ---------------------------------------------------------------------------
+// Injectable core — fan-out + R11 gate (DB- and network-free; unit-testable)
+// ---------------------------------------------------------------------------
+
+export type VariantOutcome =
+  | {
+      personaId: string
+      status: "succeeded"
+      slug: string
+      experienceId: string
+      localeId: string
+    }
+  | { personaId: string; status: "failed"; reason: string }
+
+export type RunPersonaVariantsArgs = {
+  topic: string
+  locale: string
+  personaIds: readonly string[]
+  concurrency: number
+}
+
+export type RunPersonaVariantsDeps = {
+  candidates: readonly VideoCandidate[]
+  launchVariant: (input: {
+    topic: string
+    locale: string
+    personaId: string
+    candidates: readonly VideoCandidate[]
+  }) => Promise<MastraExperienceVariantLaunchResult>
+  /** Wraps `normalizeExperienceDraft(draft, candidates)` (the R11 gate). */
+  normalize: (draft: DraftExperience) => NormalizedExperienceDraft
+  /** Persists one staged DRAFT experience; returns its ids. */
+  persist: (args: {
+    slug: string
+    title: string
+    metaDescription: string
+    blocks: NormalizedExperienceDraft["blocks"]
+    locale: string
+  }) => Promise<{ experienceId: string; localeId: string }>
+}
+
+export async function runPersonaVariants(
+  args: RunPersonaVariantsArgs,
+  deps: RunPersonaVariantsDeps,
+): Promise<{ outcomes: VariantOutcome[]; observedMaxInFlight: number }> {
+  const limit = pLimit(Math.max(1, args.concurrency))
+  let inFlight = 0
+  let observedMaxInFlight = 0
+
+  const settled = await Promise.allSettled(
+    args.personaIds.map((personaId) =>
+      limit(async (): Promise<VariantOutcome> => {
+        inFlight += 1
+        observedMaxInFlight = Math.max(observedMaxInFlight, inFlight)
+        try {
+          const launched = await deps.launchVariant({
+            topic: args.topic,
+            locale: args.locale,
+            personaId,
+            candidates: deps.candidates,
+          })
+          if (!launched.ok) {
+            return { personaId, status: "failed", reason: launched.reason }
+          }
+
+          let normalized: NormalizedExperienceDraft
+          try {
+            normalized = deps.normalize(launched.draft)
+          } catch (error) {
+            return {
+              personaId,
+              status: "failed",
+              reason:
+                error instanceof ExperienceAiNormalizationError
+                  ? error.code
+                  : "normalize_failed",
+            }
+          }
+
+          try {
+            const { experienceId, localeId } = await deps.persist({
+              slug: variantSlug(args.topic, personaId),
+              title: normalized.title,
+              metaDescription: normalized.metaDescription,
+              blocks: normalized.blocks,
+              locale: args.locale,
+            })
+            return {
+              personaId,
+              status: "succeeded",
+              slug: variantSlug(args.topic, personaId),
+              experienceId,
+              localeId,
+            }
+          } catch {
+            return { personaId, status: "failed", reason: "persist_failed" }
+          }
+        } finally {
+          inFlight -= 1
+        }
+      }),
+    ),
+  )
+
+  // Every thunk returns a VariantOutcome and never throws, so all settle
+  // fulfilled; the defensive map keeps the contract explicit.
+  const outcomes = settled.map((s, i) =>
+    s.status === "fulfilled"
+      ? s.value
+      : ({
+          personaId: args.personaIds[i] ?? "?",
+          status: "failed",
+          reason: "unexpected_rejection",
+        } satisfies VariantOutcome),
+  )
+  return { outcomes, observedMaxInFlight }
+}
+
+// ---------------------------------------------------------------------------
+// CLI wiring
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: readonly string[]): RunPersonaVariantsArgs {
+  let topic = ""
+  let locale = "en"
+  let concurrency = 3
+  const personaIds: string[] = []
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i]
+    const value = argv[i + 1]
+    if (flag === "--topic" && value) {
+      topic = value
+      i += 1
+    } else if (flag === "--persona" && value) {
+      personaIds.push(value)
+      i += 1
+    } else if (flag === "--locale" && value) {
+      locale = value
+      i += 1
+    } else if (flag === "--concurrency" && value) {
+      concurrency = Number(value) || concurrency
+      i += 1
+    }
+  }
+  if (!topic) throw new Error("--topic is required")
+  if (personaIds.length === 0)
+    throw new Error("at least one --persona is required")
+  return { topic, locale, personaIds, concurrency }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  assertNotProdUrl(process.env.DATABASE_URL)
+
+  const { prisma } = await import("@/db/client")
+  const { ExperienceService } = await import("@/services/experience.service")
+  const admin: Principal = { id: null, role: "ADMIN" }
+  const service = new ExperienceService(prisma)
+
+  try {
+    const candidates = await loadExperienceAiVideoCandidates(
+      prisma as PrismaClient,
+      { locale: args.locale, prompt: args.topic },
+    )
+    process.stdout.write(
+      `Loaded ${candidates.length} candidate(s) for "${args.topic}"; generating ${args.personaIds.length} variant(s)\n`,
+    )
+
+    const { outcomes, observedMaxInFlight } = await runPersonaVariants(args, {
+      candidates,
+      launchVariant: (input) => launchMastraExperienceVariant(input),
+      normalize: (draft) => normalizeExperienceDraft(draft, [...candidates]),
+      persist: async ({ slug, title, metaDescription, blocks, locale }) => {
+        // Idempotent: drop a prior staged variant with the same slug.
+        const prior = await prisma.experienceLocale.findMany({
+          where: { slug },
+          select: { experienceId: true },
+        })
+        const priorIds = [...new Set(prior.map((p) => p.experienceId))]
+        if (priorIds.length) {
+          await prisma.experience.deleteMany({
+            where: { id: { in: priorIds } },
+          })
+        }
+        const created = await service.create({
+          input: { locale, slug, title, blocks },
+          user: admin,
+        })
+        const localeId = created.locales[0]!.id
+        if (metaDescription) {
+          await service.updateLocale({
+            input: { id: localeId, metaDescription },
+            user: admin,
+          })
+        }
+        return { experienceId: created.id, localeId }
+      },
+    })
+
+    const succeeded = outcomes.filter((o) => o.status === "succeeded")
+    const failed = outcomes.filter((o) => o.status === "failed")
+    process.stdout.write(
+      `\nDone — ${succeeded.length} staged, ${failed.length} failed (max in-flight ${observedMaxInFlight}).\n`,
+    )
+    for (const o of outcomes) {
+      if (o.status === "succeeded") {
+        process.stdout.write(
+          `  ✓ ${o.personaId}  http://localhost:3000/watch/${o.slug}.html/english.html\n`,
+        )
+      } else {
+        process.stdout.write(`  ✗ ${o.personaId}  ${o.reason}\n`)
+      }
+    }
+    process.stdout.write(
+      "\nReview the staged DRAFT experiences in the dashboard, then publish the ones you want.\n",
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+const isDirect =
+  typeof process !== "undefined" &&
+  !!process.argv[1] &&
+  process.argv[1].endsWith("generate-persona-variants.ts")
+
+if (isDirect) {
+  main().catch((err) => {
+    process.stderr.write(
+      `[generate-persona-variants] fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    )
+    process.exit(1)
+  })
+}

--- a/apps/admin/src/scripts/generate-persona-variants.ts
+++ b/apps/admin/src/scripts/generate-persona-variants.ts
@@ -220,9 +220,40 @@ function parseArgs(argv: readonly string[]): RunPersonaVariantsArgs {
   return { topic, locale, personaIds, concurrency }
 }
 
+/**
+ * Bounded retry around one variant launch. The route marks `generation_failed`
+ * and transport hiccups `retryable: true`, and the generator is
+ * non-deterministic — a fresh attempt frequently produces a conformant draft
+ * where the prior one slipped a schema violation. Retries only while the result
+ * is `retryable`; fail-fast reasons (`config_missing`, `auth_failed`,
+ * `invalid_input`) return on the first attempt. Override the cap with
+ * `VARIANT_GENERATION_ATTEMPTS` (default 3).
+ */
+async function launchVariantWithRetry(
+  input: Parameters<typeof launchMastraExperienceVariant>[0],
+  attempts: number,
+): Promise<MastraExperienceVariantLaunchResult> {
+  let result = await launchMastraExperienceVariant(input)
+  for (
+    let attempt = 2;
+    attempt <= attempts && !result.ok && result.retryable;
+    attempt += 1
+  ) {
+    process.stdout.write(
+      `  … retry ${attempt - 1}/${attempts - 1} for ${input.personaId} (was ${result.reason})\n`,
+    )
+    result = await launchMastraExperienceVariant(input)
+  }
+  return result
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2))
   assertNotProdUrl(process.env.DATABASE_URL)
+  const generationAttempts = Math.max(
+    1,
+    Number(process.env.VARIANT_GENERATION_ATTEMPTS) || 3,
+  )
 
   const { prisma } = await import("@/db/client")
   const { ExperienceService } = await import("@/services/experience.service")
@@ -240,7 +271,8 @@ async function main(): Promise<void> {
 
     const { outcomes, observedMaxInFlight } = await runPersonaVariants(args, {
       candidates,
-      launchVariant: (input) => launchMastraExperienceVariant(input),
+      launchVariant: (input) =>
+        launchVariantWithRetry(input, generationAttempts),
       normalize: (draft) => normalizeExperienceDraft(draft, [...candidates]),
       persist: async ({ slug, title, metaDescription, blocks, locale }) => {
         // Idempotent: drop a prior staged variant with the same slug.

--- a/apps/admin/src/services/experience-ai/mastra-experience-variant-client.test.ts
+++ b/apps/admin/src/services/experience-ai/mastra-experience-variant-client.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+
+import type { DraftExperience } from "@forge/experience-schema"
+
+import {
+  _internals,
+  launchMastraExperienceVariant,
+  type MastraExperienceVariantLaunchInput,
+} from "./mastra-experience-variant-client"
+
+const VALID_DRAFT: DraftExperience = {
+  title: "Easter, for a grieving heart",
+  metaDescription: "Comfort and quiet hope in the Easter story.",
+  blocks: [
+    { t: "text", contentParagraphs: ["Grief is heavy. The story meets it."] },
+    { t: "text", contentParagraphs: ["Hope, offered gently."] },
+  ],
+}
+
+const INPUT: MastraExperienceVariantLaunchInput = {
+  topic: "Easter",
+  locale: "en",
+  personaId: "grieving",
+  candidates: [],
+}
+
+function jsonResponse(status: number, obj: unknown): Response {
+  return {
+    status,
+    text: async () => JSON.stringify(obj),
+  } as unknown as Response
+}
+
+const CALLER = { baseUrl: "http://mastra.test", bearer: "k" } as const
+
+describe("launchMastraExperienceVariant", () => {
+  it("returns the validated draft + personaId on a 200 envelope", async () => {
+    const result = await launchMastraExperienceVariant(INPUT, {
+      ...CALLER,
+      fetchImpl: async () =>
+        jsonResponse(200, {
+          ok: true,
+          personaId: "grieving",
+          draft: VALID_DRAFT,
+        }),
+    })
+    expect(result).toMatchObject({
+      ok: true,
+      personaId: "grieving",
+      draft: { title: VALID_DRAFT.title },
+    })
+  })
+
+  it("short-circuits to config_missing when baseUrl/bearer are unset (no throw)", async () => {
+    const result = await launchMastraExperienceVariant(INPUT, {
+      baseUrl: "",
+      bearer: "",
+    })
+    expect(result).toEqual({
+      ok: false,
+      reason: "config_missing",
+      retryable: false,
+    })
+  })
+
+  it("maps a 401 to auth_failed", async () => {
+    const result = await launchMastraExperienceVariant(INPUT, {
+      ...CALLER,
+      fetchImpl: async () => jsonResponse(401, { error: "nope" }),
+    })
+    expect(result).toEqual({
+      ok: false,
+      reason: "auth_failed",
+      retryable: false,
+    })
+  })
+
+  it("passes a route failure envelope through verbatim", async () => {
+    const result = await launchMastraExperienceVariant(INPUT, {
+      ...CALLER,
+      fetchImpl: async () =>
+        jsonResponse(502, {
+          ok: false,
+          reason: "generation_failed",
+          retryable: true,
+        }),
+    })
+    expect(result).toEqual({
+      ok: false,
+      reason: "generation_failed",
+      retryable: true,
+    })
+  })
+
+  it("treats a 2xx body with an invalid draft as parse_error", async () => {
+    const result = await launchMastraExperienceVariant(INPUT, {
+      ...CALLER,
+      fetchImpl: async () =>
+        jsonResponse(200, { ok: true, personaId: "x", draft: { blocks: [] } }),
+    })
+    expect(result).toEqual({
+      ok: false,
+      reason: "parse_error",
+      retryable: true,
+    })
+  })
+
+  it("maps a non-2xx without a valid envelope to a retryable network_error", async () => {
+    const result = await launchMastraExperienceVariant(INPUT, {
+      ...CALLER,
+      fetchImpl: async () => jsonResponse(500, {}),
+    })
+    expect(result).toEqual({
+      ok: false,
+      reason: "network_error",
+      retryable: true,
+    })
+  })
+
+  it("coerces env-derived timeouts and guards bad values (t3-env skipValidation trap)", () => {
+    expect(_internals.resolveTimeoutMs("200000")).toBe(200_000)
+    expect(_internals.resolveTimeoutMs(120_000)).toBe(120_000)
+    // undefined / 0 / negative / NaN all fall back to the default
+    expect(_internals.resolveTimeoutMs(undefined)).toBe(200_000)
+    expect(_internals.resolveTimeoutMs(0)).toBe(200_000)
+    expect(_internals.resolveTimeoutMs(-5)).toBe(200_000)
+    expect(_internals.resolveTimeoutMs("not-a-number")).toBe(200_000)
+  })
+})

--- a/apps/admin/src/services/experience-ai/mastra-experience-variant-client.ts
+++ b/apps/admin/src/services/experience-ai/mastra-experience-variant-client.ts
@@ -1,0 +1,289 @@
+/**
+ * Caller for the standalone persona-variant route (`/forge-experience-variant`).
+ *
+ * Mirrors `mastra-experience-section-client.ts`: `config_missing` short-circuit
+ * when the caller vars are unset, `POST /forge-experience-variant` with a
+ * `Bearer` (reusing MASTRA_BASE_URL + MASTRA_SERVICE_API_KEY) over `node:http`
+ * (Next's patched global `fetch` fails over Railway private networking), and a
+ * discriminated `{ ok, draft, personaId } | { ok:false, reason, retryable }`
+ * envelope.
+ *
+ * `MASTRA_VARIANTS_TIMEOUT_MS` (default 200s) is deliberately LARGER than
+ * mastra's internal multi-step budget (180s) so the mastra-side timeout wins the
+ * race and returns a clean `{ reason:"timeout" }` envelope rather than a generic
+ * `network_error` retry storm
+ * (`docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md`).
+ *
+ * The response `draft` is re-validated against the single-sourced
+ * `DraftExperienceSchema`; admin's `normalizeExperienceDraft` stays the gate
+ * after this client returns.
+ */
+
+import { request as httpRequest } from "node:http"
+import { request as httpsRequest } from "node:https"
+
+import { env } from "@/config/env"
+import {
+  DraftExperienceSchema,
+  type DraftExperience,
+  type VideoCandidate,
+} from "@forge/experience-schema"
+
+export type MastraExperienceVariantLaunchInput = {
+  topic: string
+  locale: string
+  personaId: string
+  candidates: readonly VideoCandidate[]
+  exemplar?: string
+}
+
+export type MastraExperienceVariantFailureReason =
+  | "config_missing"
+  | "auth_failed"
+  | "network_error"
+  | "parse_error"
+  // The route's own discriminated reasons (experience-variant-route.ts):
+  | "invalid_input"
+  | "timeout"
+  | "generation_failed"
+  | "internal_error"
+
+export type MastraExperienceVariantLaunchResult =
+  | { ok: true; draft: DraftExperience; personaId: string }
+  | {
+      ok: false
+      reason: MastraExperienceVariantFailureReason
+      retryable: boolean
+    }
+
+export type LaunchMastraExperienceVariantOptions = {
+  baseUrl?: string
+  bearer?: string
+  timeoutMs?: number
+  fetchImpl?: typeof fetch
+}
+
+const ROUTE_FAILURE_REASONS = new Set<MastraExperienceVariantFailureReason>([
+  "invalid_input",
+  "timeout",
+  "generation_failed",
+  "internal_error",
+])
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null
+  }
+  return value as Record<string, unknown>
+}
+
+/**
+ * Render an unknown thrown value as a Railway-logsV2-safe plain string (NEVER
+ * JSON.stringify — logsV2 silences stringified payloads from the Next runtime).
+ */
+function describeFetchError(error: unknown): string {
+  const err = error instanceof Error ? error : undefined
+  const cause = err?.cause instanceof Error ? err.cause : undefined
+  const rawCode =
+    (cause as { code?: unknown } | undefined)?.code ??
+    (err as { code?: unknown } | undefined)?.code
+  return (
+    `name=${err?.name ?? "unknown"} ` +
+    `code=${typeof rawCode === "string" ? rawCode : "none"} ` +
+    `cause=${cause?.name ?? "none"} ` +
+    `message=${err?.message ?? String(error)}`
+  )
+}
+
+type RawResponse = { status: number; bodyText: string }
+
+/** Fallback when the env-configured variants timeout is missing/invalid. */
+const DEFAULT_VARIANTS_TIMEOUT_MS = 200_000
+
+/**
+ * Normalize the request timeout to a positive number. `env.MASTRA_VARIANTS_TIMEOUT_MS`
+ * is TYPED `number` but at runtime can arrive `undefined`/string because t3-env's
+ * `skipValidation` path returns raw `process.env` without applying the Zod
+ * default — passing that to a timer API throws `ERR_INVALID_ARG_TYPE`. Takes
+ * `unknown` so the runtime guards aren't elided by the (wrong) static type.
+ */
+function resolveTimeoutMs(value: unknown): number {
+  const ms = typeof value === "string" ? Number(value) : value
+  return typeof ms === "number" && Number.isFinite(ms) && ms > 0
+    ? ms
+    : DEFAULT_VARIANTS_TIMEOUT_MS
+}
+
+/** POST over `node:http` to dodge the Next-patched global `fetch`. */
+function postViaNode(
+  target: URL,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs: number,
+): Promise<RawResponse> {
+  const request = target.protocol === "https:" ? httpsRequest : httpRequest
+  return new Promise<RawResponse>((resolve, reject) => {
+    const req = request(
+      target,
+      {
+        method: "POST",
+        headers: {
+          ...headers,
+          "content-length": Buffer.byteLength(body).toString(),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on("data", (chunk: Buffer) => chunks.push(chunk))
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            bodyText: Buffer.concat(chunks).toString("utf8"),
+          }),
+        )
+        res.on("error", reject)
+      },
+    )
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(
+        Object.assign(new Error("variant request timed out"), {
+          name: "TimeoutError",
+        }),
+      )
+    })
+    req.on("error", reject)
+    req.end(body)
+  })
+}
+
+/** Transport used when a caller injects `fetchImpl` (unit tests / overrides). */
+async function postViaFetch(
+  fetchImpl: typeof fetch,
+  target: URL,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs: number,
+): Promise<RawResponse> {
+  const response = await fetchImpl(target, {
+    method: "POST",
+    headers,
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  })
+  return { status: response.status, bodyText: await response.text() }
+}
+
+function parseVariantRouteResult(
+  value: unknown,
+): MastraExperienceVariantLaunchResult | null {
+  const record = asRecord(value)
+  if (!record || typeof record.ok !== "boolean") return null
+
+  if (record.ok === true) {
+    if (typeof record.personaId !== "string") return null
+    const draft = DraftExperienceSchema.safeParse(record.draft)
+    if (!draft.success) return null
+    return { ok: true, draft: draft.data, personaId: record.personaId }
+  }
+
+  if (
+    typeof record.reason !== "string" ||
+    !ROUTE_FAILURE_REASONS.has(
+      record.reason as MastraExperienceVariantFailureReason,
+    ) ||
+    typeof record.retryable !== "boolean"
+  ) {
+    return null
+  }
+
+  return {
+    ok: false,
+    reason: record.reason as MastraExperienceVariantFailureReason,
+    retryable: record.retryable,
+  }
+}
+
+export async function launchMastraExperienceVariant(
+  input: MastraExperienceVariantLaunchInput,
+  options: LaunchMastraExperienceVariantOptions = {},
+): Promise<MastraExperienceVariantLaunchResult> {
+  const baseUrl = options.baseUrl ?? env.MASTRA_BASE_URL
+  const bearer = options.bearer ?? env.MASTRA_SERVICE_API_KEY
+  if (!baseUrl || !bearer) {
+    return { ok: false, reason: "config_missing", retryable: false }
+  }
+
+  const body = {
+    topic: input.topic,
+    locale: input.locale,
+    personaId: input.personaId,
+    candidates: input.candidates,
+    exemplar: input.exemplar,
+  }
+
+  const target = new URL("/forge-experience-variant", baseUrl)
+  const headers = {
+    authorization: `Bearer ${bearer}`,
+    "content-type": "application/json",
+  }
+  const bodyText = JSON.stringify(body)
+  const timeoutMs = resolveTimeoutMs(
+    options.timeoutMs ?? env.MASTRA_VARIANTS_TIMEOUT_MS,
+  )
+
+  let raw: RawResponse
+  try {
+    raw = options.fetchImpl
+      ? await postViaFetch(
+          options.fetchImpl,
+          target,
+          headers,
+          bodyText,
+          timeoutMs,
+        )
+      : await postViaNode(target, headers, bodyText, timeoutMs)
+  } catch (error) {
+    console.error(
+      `[mastra-experience-variant] event=fetch_failed host=${target.host} ` +
+        `transport=${options.fetchImpl ? "fetch" : "node-http"} ${describeFetchError(error)}`,
+    )
+    return { ok: false, reason: "network_error", retryable: true }
+  }
+
+  if (raw.status === 401) {
+    console.warn(`[mastra-experience-variant] event=auth_failed status=401`)
+    return { ok: false, reason: "auth_failed", retryable: false }
+  }
+
+  let payload: unknown
+  try {
+    payload = raw.bodyText.length > 0 ? JSON.parse(raw.bodyText) : undefined
+  } catch {
+    payload = undefined
+  }
+
+  const parsed = parseVariantRouteResult(payload)
+  if (parsed) return parsed
+
+  if (raw.status < 200 || raw.status >= 300) {
+    console.warn(
+      `[mastra-experience-variant] event=http_error status=${raw.status}`,
+    )
+    return {
+      ok: false,
+      reason: "network_error",
+      retryable: raw.status >= 500 || raw.status === 429,
+    }
+  }
+
+  console.warn(
+    `[mastra-experience-variant] event=parse_error status=${raw.status} ` +
+      `bodyOk=${String(asRecord(payload)?.ok ?? "absent")}`,
+  )
+  return { ok: false, reason: "parse_error", retryable: true }
+}
+
+export const _internals = {
+  parseVariantRouteResult,
+  resolveTimeoutMs,
+}

--- a/apps/mastra/src/config/personas/persona-roster.ts
+++ b/apps/mastra/src/config/personas/persona-roster.ts
@@ -1,0 +1,102 @@
+import type { Persona } from "../../services/persona/persona.schemas"
+
+/**
+ * Starter audience roster — PLACEHOLDER.
+ *
+ * These are provisional personas so engineering can prove persona-tailored
+ * generation. The real roster is a ministry decision (origin requirements R10);
+ * swap this content once the audiences are confirmed. Bump the version when the
+ * roster changes so downstream provenance can notice.
+ */
+export const PERSONA_ROSTER_VERSION = "persona-roster/v1-placeholder"
+
+export const PERSONA_ROSTER: readonly Persona[] = [
+  {
+    id: "seeker-skeptic",
+    name: "Seeker / skeptic",
+    blurb: "Curious but unconvinced — wants honest answers, not a sales pitch.",
+    tone: "Plainspoken, unhurried, non-defensive. Respect doubt; never browbeat.",
+    needs: [
+      "Honest engagement with hard questions",
+      "Reasoning and evidence, not assertion",
+      "Room to decide without pressure",
+    ],
+    scripturePosture:
+      "Use Scripture sparingly and in context; explain it rather than assuming an authority the reader hasn't granted.",
+    emotionalGoal: "Feel respected and intrigued enough to keep exploring.",
+    faithStage: "Outside or on the edge of faith; investigating.",
+    culturalContext:
+      "May be wary of religious institutions; values intellectual honesty.",
+  },
+  {
+    id: "grieving",
+    name: "Grieving",
+    blurb: "Carrying loss — needs comfort and presence before anything else.",
+    tone: "Gentle, warm, slow. No clichés, no fixing, no rushing to resolution.",
+    needs: [
+      "To feel accompanied, not corrected",
+      "Comfort grounded in hope",
+      "Permission to grieve",
+    ],
+    scripturePosture:
+      "Lean on comfort passages (the Psalms, the resurrection hope) offered tenderly — never as an argument.",
+    emotionalGoal: "Feel comforted, less alone, and quietly hopeful.",
+    faithStage:
+      "Anywhere — grief crosses belief; meet the person, not a label.",
+    culturalContext:
+      "Raw and tender; avoid triumphalism or anything that minimises pain.",
+  },
+  {
+    id: "new-believer",
+    name: "New believer",
+    blurb: "Recently started following Jesus — eager, with a lot still new.",
+    tone: "Encouraging, clear, welcoming. Assume little prior knowledge.",
+    needs: [
+      "Simple, concrete next steps",
+      "Reassurance they belong",
+      "Plain explanation of unfamiliar terms",
+    ],
+    scripturePosture:
+      "Introduce Scripture warmly with brief context; favour foundational, hope-filled passages.",
+    emotionalGoal: "Feel welcomed, grounded, and eager to grow.",
+    faithStage: "New to faith; building foundations.",
+    culturalContext:
+      "May feel unsure they fit; avoid insider jargon and assumed background.",
+  },
+  {
+    id: "family",
+    name: "Family with children",
+    blurb:
+      "Parents exploring faith with kids — wants warmth the whole family can share.",
+    tone: "Warm, accessible, hopeful. Suitable to read or watch together.",
+    needs: [
+      "Content the family can engage together",
+      "Simple, vivid storytelling",
+      "A clear, gentle takeaway",
+    ],
+    scripturePosture:
+      "Tell the story plainly; surface Scripture as narrative children and parents can follow together.",
+    emotionalGoal:
+      "Feel this is for them as a family — approachable and hopeful.",
+    faithStage: "Mixed; often parents seeking on behalf of the household.",
+    culturalContext:
+      "Time-poor; values content that is wholesome and easy to share with kids.",
+  },
+  {
+    id: "seasoned-believer",
+    name: "Seasoned believer",
+    blurb:
+      "Long-time follower — wants depth and a fresh way to share the story.",
+    tone: "Thoughtful, substantive, unsentimental. Trust the reader's maturity.",
+    needs: [
+      "Depth beyond the basics",
+      "A fresh angle on a familiar story",
+      "Something worth passing on",
+    ],
+    scripturePosture:
+      "Engage Scripture richly and accurately; draw connections a mature reader will appreciate.",
+    emotionalGoal: "Feel deepened and equipped to share with others.",
+    faithStage: "Established; growing and discipling others.",
+    culturalContext: "Discerning; allergic to thin or sentimental content.",
+  },
+]

--- a/apps/mastra/src/mastra/index.ts
+++ b/apps/mastra/src/mastra/index.ts
@@ -34,6 +34,7 @@ import {
   handleExperienceDraftRouteRequest,
   type DraftWorkflowMastra,
 } from "./workflows/experience-draft-route"
+import { handleExperienceVariantRouteRequest } from "./workflows/experience-variant-route"
 import {
   handleExperienceSectionRouteRequest,
   type SectionAgentMastra,
@@ -326,6 +327,24 @@ export const mastra = new Mastra({
             // all present at runtime; the real Mastra's `getWorkflowById` has a
             // narrower id-union param than `(id: string)`, so the structural
             // types don't unify. Tests inject a fully-typed fake.
+            getMastra: () => mastra as unknown as DraftWorkflowMastra,
+          })
+
+          return new Response(JSON.stringify(outcome.body), {
+            status: outcome.status,
+            headers: { "content-type": "application/json" },
+          })
+        },
+      }),
+      registerApiRoute("/forge-experience-variant", {
+        method: "POST",
+        handler: async (c) => {
+          const outcome = await handleExperienceVariantRouteRequest({
+            authHeader: c.req.header("authorization"),
+            serviceKeys,
+            readJson: () => c.req.json(),
+            // Same narrow workflow surface as the draft route (it delegates to
+            // the draft generation path); the thunk resolves post-construction.
             getMastra: () => mastra as unknown as DraftWorkflowMastra,
           })
 

--- a/apps/mastra/src/mastra/prompts/fill-prompt.ts
+++ b/apps/mastra/src/mastra/prompts/fill-prompt.ts
@@ -39,6 +39,7 @@ Rules:
    - bibleQuotesCarousel: { "t": "bibleQuotesCarousel", "heading": "...", "quotes": [{ "reference": "John 20:19-29", "text": "..." }] }. Use "reference", NOT "verseReference".
    - cta: { "t": "cta", "heading": "...", "body": "...", "buttonLabel": "Watch Video" }
    - mediaCollection: { "t": "mediaCollection", "title": "...", "items": [{ "candidateRef": "v01", "titleOverride": "..." }] }
+   - relatedQuestions: { "t": "relatedQuestions", "heading": "...", "questions": [{ "question": "Did the resurrection really happen?", "answer": "A written, plain-text answer in 1-3 sentences." }] }. Each item needs a written "answer"; questions are text Q&A, NOT video references — NEVER put "candidateRef" on a question.
 
 3. VIDEO + SCRIPTURE REFERENCES. When the block needs a video, call searchVideos and use the candidate "ref" (like "v01") verbatim in "candidateRef" — never invent refs. When the block needs Scripture, call lookupBibleVerse rather than paraphrasing.
 

--- a/apps/mastra/src/mastra/workflows/experience-variant-route.test.ts
+++ b/apps/mastra/src/mastra/workflows/experience-variant-route.test.ts
@@ -37,19 +37,23 @@ function makeMastra(
   }),
 ) {
   const startCalls: Array<{ inputData: unknown }> = []
+  const workflowIds: string[] = []
   const mastra: DraftWorkflowMastra = {
-    getWorkflowById: () => ({
-      createRun: async () => ({
-        start: (args: { inputData: unknown }) => {
-          startCalls.push(args)
-          return start(args)
-        },
-        cancel: async () => {},
-        runId: "run-1",
-      }),
-    }),
+    getWorkflowById: (id: string) => {
+      workflowIds.push(id)
+      return {
+        createRun: async () => ({
+          start: (args: { inputData: unknown }) => {
+            startCalls.push(args)
+            return start(args)
+          },
+          cancel: async () => {},
+          runId: "run-1",
+        }),
+      }
+    },
   }
-  return { mastra, startCalls }
+  return { mastra, startCalls, workflowIds }
 }
 
 function body(topic: string, personaId: string) {
@@ -75,6 +79,20 @@ describe("handleExperienceVariantRouteRequest", () => {
     const inputData = startCalls[0]?.inputData as { prompt?: string }
     expect(inputData.prompt).toContain("Grieving")
     expect(inputData.prompt).toContain("Easter")
+  })
+
+  it("runs the quick-draft workflow, not the 5-step multi-step pipeline", async () => {
+    const { mastra, workflowIds } = makeMastra()
+    const outcome = await handleExperienceVariantRouteRequest({
+      authHeader: AUTH,
+      serviceKeys: SERVICE_KEYS,
+      readJson: async () => body("Easter", "grieving"),
+      getMastra: () => mastra,
+    })
+    expect(outcome.status).toBe(200)
+    // Persona fan-out delegates to quick-draft for reliability on slow models.
+    expect(workflowIds).toContain("quick-draft")
+    expect(workflowIds).not.toContain("multi-step-draft")
   })
 
   it("rejects a missing/invalid bearer with 401", async () => {

--- a/apps/mastra/src/mastra/workflows/experience-variant-route.test.ts
+++ b/apps/mastra/src/mastra/workflows/experience-variant-route.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest"
+
+import type { DraftExperience } from "@forge/experience-schema"
+
+import {
+  handleExperienceVariantRouteRequest,
+  type DraftWorkflowMastra,
+} from "./experience-variant-route"
+
+const SERVICE_KEYS = ["test-service-key"] as const
+const AUTH = "Bearer test-service-key"
+
+const VALID_DRAFT: DraftExperience = {
+  title: "Easter, for a grieving heart",
+  metaDescription: "Comfort and quiet hope in the Easter story.",
+  blocks: [
+    {
+      t: "text",
+      heading: "You are not alone",
+      contentParagraphs: ["Grief is heavy. The Easter story meets it gently."],
+    },
+    {
+      t: "cta",
+      heading: "Sit with the story",
+      body: "Take a moment with the hope of the resurrection.",
+      buttonLabel: "Watch",
+    },
+  ],
+}
+
+type StartResult = { status: string; result?: unknown; error?: unknown }
+
+function makeMastra(
+  start: (args: { inputData: unknown }) => Promise<StartResult> = async () => ({
+    status: "success",
+    result: { draft: VALID_DRAFT },
+  }),
+) {
+  const startCalls: Array<{ inputData: unknown }> = []
+  const mastra: DraftWorkflowMastra = {
+    getWorkflowById: () => ({
+      createRun: async () => ({
+        start: (args: { inputData: unknown }) => {
+          startCalls.push(args)
+          return start(args)
+        },
+        cancel: async () => {},
+        runId: "run-1",
+      }),
+    }),
+  }
+  return { mastra, startCalls }
+}
+
+function body(topic: string, personaId: string) {
+  return { topic, locale: "en", candidates: [], personaId }
+}
+
+describe("handleExperienceVariantRouteRequest", () => {
+  it("generates a variant and carries the personaId back (200)", async () => {
+    const { mastra, startCalls } = makeMastra()
+    const outcome = await handleExperienceVariantRouteRequest({
+      authHeader: AUTH,
+      serviceKeys: SERVICE_KEYS,
+      readJson: async () => body("Easter", "grieving"),
+      getMastra: () => mastra,
+    })
+    expect(outcome.status).toBe(200)
+    expect(outcome.body).toMatchObject({
+      ok: true,
+      personaId: "grieving",
+      draft: { title: VALID_DRAFT.title },
+    })
+    // the persona was composed into the prompt that reaches the workflow
+    const inputData = startCalls[0]?.inputData as { prompt?: string }
+    expect(inputData.prompt).toContain("Grieving")
+    expect(inputData.prompt).toContain("Easter")
+  })
+
+  it("rejects a missing/invalid bearer with 401", async () => {
+    const { mastra, startCalls } = makeMastra()
+    const outcome = await handleExperienceVariantRouteRequest({
+      authHeader: "Bearer wrong",
+      serviceKeys: SERVICE_KEYS,
+      readJson: async () => body("Easter", "grieving"),
+      getMastra: () => mastra,
+    })
+    expect(outcome.status).toBe(401)
+    expect(startCalls).toHaveLength(0)
+  })
+
+  it("rejects invalid input (missing topic) with 400 invalid_input", async () => {
+    const { mastra } = makeMastra()
+    const outcome = await handleExperienceVariantRouteRequest({
+      authHeader: AUTH,
+      serviceKeys: SERVICE_KEYS,
+      readJson: async () => ({ personaId: "grieving" }),
+      getMastra: () => mastra,
+    })
+    expect(outcome.status).toBe(400)
+    expect(outcome.body).toMatchObject({ ok: false, reason: "invalid_input" })
+  })
+
+  it("rejects an unknown persona with 400 without invoking the workflow", async () => {
+    const { mastra, startCalls } = makeMastra()
+    const outcome = await handleExperienceVariantRouteRequest({
+      authHeader: AUTH,
+      serviceKeys: SERVICE_KEYS,
+      readJson: async () => body("Easter", "no-such-persona"),
+      getMastra: () => mastra,
+    })
+    expect(outcome.status).toBe(400)
+    expect(outcome.body).toMatchObject({ ok: false, reason: "invalid_input" })
+    expect(startCalls).toHaveLength(0)
+  })
+
+  it("returns a retryable timeout (504) when generation exceeds the budget", async () => {
+    const { mastra } = makeMastra(() => new Promise<StartResult>(() => {}))
+    const outcome = await handleExperienceVariantRouteRequest({
+      authHeader: AUTH,
+      serviceKeys: SERVICE_KEYS,
+      readJson: async () => body("Easter", "grieving"),
+      getMastra: () => mastra,
+      budgetMs: 20,
+    })
+    expect(outcome.status).toBe(504)
+    expect(outcome.body).toMatchObject({
+      ok: false,
+      reason: "timeout",
+      retryable: true,
+    })
+  })
+})

--- a/apps/mastra/src/mastra/workflows/experience-variant-route.ts
+++ b/apps/mastra/src/mastra/workflows/experience-variant-route.ts
@@ -1,0 +1,149 @@
+/**
+ * Bearer-gated `/forge-experience-variant` entrypoint (persona-variant v1, U4).
+ *
+ * Admin loads candidates once and POSTs `{ topic, locale, candidates,
+ * exemplar?, personaId }` per persona. This handler resolves the persona from
+ * the Mastra-owned library, composes it into the editor prompt (U3), and runs
+ * the SAME `multi-step-draft` generation path the draft route uses — by
+ * delegating to `handleExperienceDraftRouteRequest`. The only additions over a
+ * plain draft are persona resolution and carrying `personaId` back in the
+ * envelope, so the budget, timeout, and error classification stay single-sourced.
+ *
+ * Reuses `MASTRA_SERVICE_API_KEYS` (no new credential). Plain-string logging
+ * only (Railway logsV2 silences JSON.stringify payloads from this runtime path).
+ */
+
+import { z } from "zod"
+
+import type { DraftExperience } from "@forge/experience-schema"
+
+import { TIME_BUDGET_MS } from "../budgets"
+import { isValidServiceBearer } from "../../server/service-bearer"
+import { loadPersona } from "../../services/persona/persona-library"
+import { buildPersonaTopicPrompt } from "../../services/persona/persona-prompt"
+import {
+  handleExperienceDraftRouteRequest,
+  type DraftWorkflowMastra,
+} from "./experience-draft-route"
+
+const candidateSchema = z
+  .object({
+    videoId: z.string().optional(),
+    ref: z.string().optional(),
+    title: z.string().optional(),
+    description: z.string().nullable().optional(),
+    slug: z.string().optional(),
+  })
+  .passthrough()
+
+export const ExperienceVariantRequestSchema = z.object({
+  topic: z.string().min(1),
+  locale: z.string().min(1).default("en"),
+  candidates: z.array(candidateSchema).default([]),
+  exemplar: z.string().optional(),
+  personaId: z.string().min(1),
+})
+export type ExperienceVariantRequest = z.infer<
+  typeof ExperienceVariantRequestSchema
+>
+
+export type ExperienceVariantFailureReason =
+  | "invalid_input"
+  | "timeout"
+  | "generation_failed"
+  | "internal_error"
+
+export type ExperienceVariantRouteResult =
+  | { ok: true; draft: DraftExperience; personaId: string }
+  | {
+      ok: false
+      reason: ExperienceVariantFailureReason
+      retryable: boolean
+      message?: string
+    }
+
+export type ExperienceVariantRouteOutcome = {
+  status: number
+  body: ExperienceVariantRouteResult | { error: string }
+}
+
+// Re-export the narrow Mastra surface so `index.ts` can type the getMastra thunk.
+export type { DraftWorkflowMastra }
+
+function invalidInput(message: string): ExperienceVariantRouteOutcome {
+  return {
+    status: 400,
+    body: { ok: false, reason: "invalid_input", retryable: false, message },
+  }
+}
+
+export type ExperienceVariantRouteHandlerInput = {
+  authHeader: string | null | undefined
+  serviceKeys: readonly string[]
+  readJson: () => Promise<unknown>
+  getMastra: () => DraftWorkflowMastra
+  /** Internal workflow budget; defaults to the multi-step budget. */
+  budgetMs?: number
+}
+
+export async function handleExperienceVariantRouteRequest({
+  authHeader,
+  serviceKeys,
+  readJson,
+  getMastra,
+  budgetMs = TIME_BUDGET_MS.multiStepWorkflow,
+}: ExperienceVariantRouteHandlerInput): Promise<ExperienceVariantRouteOutcome> {
+  if (!isValidServiceBearer({ authHeader, allowlist: serviceKeys })) {
+    return { status: 401, body: { error: "Service bearer required" } }
+  }
+
+  const raw = await readJson().catch(() => undefined)
+  const parsed = ExperienceVariantRequestSchema.safeParse(raw)
+  if (!parsed.success) {
+    console.warn(
+      `[forge-experience-variant] event=invalid_input issues=${parsed.error.issues.length}`,
+    )
+    return invalidInput("request body failed validation")
+  }
+
+  const { topic, locale, candidates, exemplar, personaId } = parsed.data
+  const persona = loadPersona(personaId)
+  if (!persona) {
+    console.warn(
+      `[forge-experience-variant] event=unknown_persona personaId=${personaId}`,
+    )
+    return invalidInput(`unknown persona: ${personaId}`)
+  }
+
+  const prompt = buildPersonaTopicPrompt(topic, persona)
+
+  // Delegate to the shared draft generation path (same budget + error
+  // classification), feeding the persona-composed prompt.
+  const draftOutcome = await handleExperienceDraftRouteRequest({
+    authHeader,
+    serviceKeys,
+    readJson: () =>
+      Promise.resolve({ prompt, locale, candidates, exemplar, mode: "multi" }),
+    getMastra,
+    budgetMs,
+  })
+
+  const body = draftOutcome.body
+  if ("ok" in body) {
+    if (body.ok) {
+      console.warn(
+        `[forge-experience-variant] event=generated personaId=${personaId}`,
+      )
+      return {
+        status: draftOutcome.status,
+        body: { ok: true, draft: body.draft, personaId },
+      }
+    }
+    console.warn(
+      `[forge-experience-variant] event=failed personaId=${personaId} reason=${body.reason} retryable=${body.retryable}`,
+    )
+    return { status: draftOutcome.status, body }
+  }
+  // `{ error }` shape — shouldn't occur after our own bearer check; pass through.
+  return { status: draftOutcome.status, body }
+}

--- a/apps/mastra/src/mastra/workflows/experience-variant-route.ts
+++ b/apps/mastra/src/mastra/workflows/experience-variant-route.ts
@@ -4,10 +4,14 @@
  * Admin loads candidates once and POSTs `{ topic, locale, candidates,
  * exemplar?, personaId }` per persona. This handler resolves the persona from
  * the Mastra-owned library, composes it into the editor prompt (U3), and runs
- * the SAME `multi-step-draft` generation path the draft route uses — by
- * delegating to `handleExperienceDraftRouteRequest`. The only additions over a
- * plain draft are persona resolution and carrying `personaId` back in the
- * envelope, so the budget, timeout, and error classification stay single-sourced.
+ * the `quick-draft` generation path (plan → draft) by delegating to
+ * `handleExperienceDraftRouteRequest` with `mode: "quick"`. Quick-draft is one
+ * short generation rather than the 5-step plan→skeleton→fill→critique→revise
+ * pipeline, so it stays well inside the budget and avoids per-node fill
+ * failures on slower chat models — the right reliability tradeoff for fanning
+ * out one draft per persona. The only additions over a plain draft are persona
+ * resolution and carrying `personaId` back in the envelope, so the budget,
+ * timeout, and error classification stay single-sourced.
  *
  * Reuses `MASTRA_SERVICE_API_KEYS` (no new credential). Plain-string logging
  * only (Railway logsV2 silences JSON.stringify payloads from this runtime path).
@@ -118,12 +122,14 @@ export async function handleExperienceVariantRouteRequest({
   const prompt = buildPersonaTopicPrompt(topic, persona)
 
   // Delegate to the shared draft generation path (same budget + error
-  // classification), feeding the persona-composed prompt.
+  // classification), feeding the persona-composed prompt. `mode: "quick"`
+  // runs the one-shot quick-draft workflow rather than the 5-step pipeline,
+  // for reliable per-persona fan-out on slower chat models.
   const draftOutcome = await handleExperienceDraftRouteRequest({
     authHeader,
     serviceKeys,
     readJson: () =>
-      Promise.resolve({ prompt, locale, candidates, exemplar, mode: "multi" }),
+      Promise.resolve({ prompt, locale, candidates, exemplar, mode: "quick" }),
     getMastra,
     budgetMs,
   })

--- a/apps/mastra/src/mastra/workflows/multi-step-draft.test.ts
+++ b/apps/mastra/src/mastra/workflows/multi-step-draft.test.ts
@@ -910,6 +910,139 @@ describe("multiStepDraftWorkflow (real step bodies)", () => {
         // videoHero's heading threaded forward (coherence).
         expect(sawPriorHeading).toEqual([false, true, true])
       })
+
+      it("titles from the TOPIC line for persona prompts (no steering leak)", async () => {
+        const { mastra } = makeFillMastra()
+        const personaInput = {
+          ...PLAN_INPUT,
+          // Persona-composed prompt: steering instructions FIRST, subject on a
+          // TOPIC line. The synthesized title must be the subject, not the
+          // steering text.
+          prompt:
+            "TARGET AUDIENCE — write this experience specifically for: Grieving\nNeeds comfort before anything else.\n\nTOPIC: Easter",
+        }
+        const skeletonOut = await executeSkeletonStep({
+          inputData: personaInput,
+          mastra: mastra as never,
+          abortSignal: undefined,
+        })
+        const result = await executeFillStep({
+          inputData: skeletonOut,
+          mastra: mastra as never,
+          abortSignal: undefined,
+        })
+        expect(result.draft.title).toBe("Easter")
+        expect(result.draft.title).not.toContain("TARGET AUDIENCE")
+      })
+
+      // A fill mastra whose fill agent returns INVALID (non-JSON) output for
+      // the listed block types and valid JSON otherwise — drives the resilient
+      // per-node retry-then-skip path. Mirrors the real "agent output was not
+      // valid JSON" failure a weak model produces on a block it can't author.
+      function makeResilientFillMastra(badTypes: Set<string>): {
+        mastra: { getAgentById: ReturnType<typeof vi.fn> }
+      } {
+        const fillSpy = vi.fn(async (prompt: string) => {
+          const type = /type "(\w+)"/.exec(prompt)?.[1] ?? ""
+          if (badTypes.has(type)) {
+            return { text: `I cannot produce valid JSON for ${type}.` }
+          }
+          if (type === "videoHero") {
+            return {
+              text: JSON.stringify({
+                t: "videoHero",
+                candidateRef: "v01",
+                heading: "H",
+                subheading: "S",
+              }),
+            }
+          }
+          if (type === "cta") {
+            return {
+              text: JSON.stringify({
+                t: "cta",
+                heading: "C",
+                body: "B",
+                buttonLabel: "Go",
+              }),
+            }
+          }
+          return {
+            text: JSON.stringify({
+              t: "text",
+              heading: "T",
+              contentParagraphs: ["P"],
+            }),
+          }
+        })
+        const mastra = {
+          getAgentById: vi.fn((id: string) => {
+            if (id === "experience-skeleton") {
+              return {
+                generate: vi.fn(async () => ({
+                  text: JSON.stringify(VALID_SKELETON),
+                })),
+              }
+            }
+            if (id === "experience-fill") return { generate: fillSpy }
+            throw new Error(`unexpected agent id ${id}`)
+          }),
+        }
+        return { mastra }
+      }
+
+      it("skips a node that fails all attempts and still assembles a valid draft (resilient fill)", async () => {
+        const warnSpy = vi
+          .spyOn(console, "warn")
+          .mockImplementation(() => undefined)
+        // cta fails every attempt; videoHero + section(text) survive.
+        const { mastra } = makeResilientFillMastra(new Set(["cta"]))
+        const skeletonOut = await executeSkeletonStep({
+          inputData: PLAN_INPUT,
+          mastra: mastra as never,
+          abortSignal: undefined,
+        })
+        const result = await executeFillStep({
+          inputData: skeletonOut,
+          mastra: mastra as never,
+          abortSignal: undefined,
+        })
+        // The bad cta was dropped; the page still validates with the rest.
+        expect(DraftExperienceSchema.safeParse(result.draft).success).toBe(true)
+        expect(result.draft.blocks.map((b) => b.t)).toEqual([
+          "videoHero",
+          "section",
+        ])
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("fill_node_skipped type=cta"),
+        )
+        warnSpy.mockRestore()
+      })
+
+      it("fails the fill step when too many nodes are skipped to meet the block minimum", async () => {
+        const warnSpy = vi
+          .spyOn(console, "warn")
+          .mockImplementation(() => undefined)
+        // videoHero AND cta fail → only the section's text child survives = one
+        // top-level block, below GENERATION_MIN_BLOCKS, so the assembled draft
+        // fails the schema floor rather than emitting a degenerate page.
+        const { mastra } = makeResilientFillMastra(
+          new Set(["videoHero", "cta"]),
+        )
+        const skeletonOut = await executeSkeletonStep({
+          inputData: PLAN_INPUT,
+          mastra: mastra as never,
+          abortSignal: undefined,
+        })
+        await expect(
+          executeFillStep({
+            inputData: skeletonOut,
+            mastra: mastra as never,
+            abortSignal: undefined,
+          }),
+        ).rejects.toMatchObject({ name: "WorkflowStepError", step: "fill" })
+        warnSpy.mockRestore()
+      })
     })
 
     describe("workflow chain symmetry", () => {

--- a/apps/mastra/src/mastra/workflows/multi-step-draft.ts
+++ b/apps/mastra/src/mastra/workflows/multi-step-draft.ts
@@ -727,11 +727,21 @@ function synthesizeScalars(input: PlanStepOutput): {
   metaDescription: string
 } {
   const prompt = input.prompt.trim()
-  const title = (prompt.split(/[.!?\n]/)[0] || prompt || "Untitled experience")
+  // Persona/variant prompts lead with audience-steering instructions and carry
+  // the real subject on a "TOPIC: ..." line (see buildPersonaTopicPrompt).
+  // Prefer that line for the title so the steering text never leaks into the
+  // page title; plain editor prompts (no TOPIC line) fall back to the first line.
+  const topicLine = /^TOPIC:\s*(.+)$/m.exec(prompt)?.[1]?.trim()
+  const titleSource = topicLine || prompt
+  const title = (
+    titleSource.split(/[.!?\n]/)[0] ||
+    titleSource ||
+    "Untitled experience"
+  )
     .trim()
     .slice(0, 120)
   const planFirstSentence = (input.plan || "").trim().split(/[.!?\n]/)[0] || ""
-  const metaSource = planFirstSentence || prompt || title
+  const metaSource = planFirstSentence || titleSource || title
   const metaDescription = metaSource.trim().slice(0, 200) || title
   return {
     title: title || "Untitled experience",
@@ -899,6 +909,56 @@ async function fillSingleNode(
 }
 
 /**
+ * Per-node attempt cap for the resilient fill loop. Each fillable node gets up
+ * to this many fresh generations before it is SKIPPED (dropped from the page)
+ * rather than failing the whole workflow. Env-overridable for experiments;
+ * default 2 (one retry) bounds the extra wall-clock against the workflow budget.
+ */
+const FILL_NODE_ATTEMPTS = Math.max(
+  1,
+  Number(process.env.MASTRA_FILL_NODE_ATTEMPTS) || 2,
+)
+
+/**
+ * Fill one fillable node with bounded retries, returning `null` when every
+ * attempt fails its per-node schema. This is the resilient "generate each task,
+ * keep what succeeds" loop: a weak model that reliably mis-fills one rich block
+ * (e.g. `card` without a title) no longer kills the whole page — that block is
+ * dropped and the blocks it CAN produce still assemble into a valid draft. The
+ * final `DraftExperienceSchema` gate (with `GENERATION_MIN_BLOCKS`) is the floor:
+ * if too many nodes are skipped, the assembled draft legitimately fails there.
+ *
+ * Abort propagates immediately (the run is being cancelled). A non-
+ * `WorkflowStepError` (unexpected code error) also propagates — only the typed,
+ * per-node generation failure is recoverable-by-skip.
+ */
+async function fillNodeWithRetries(
+  ctx: StepContext<SkeletonStepOutput>,
+  node: SkeletonNode,
+  priorBlocks: readonly unknown[],
+): Promise<Record<string, unknown> | null> {
+  for (let attempt = 1; attempt <= FILL_NODE_ATTEMPTS; attempt += 1) {
+    try {
+      return await fillSingleNode(ctx, node, priorBlocks)
+    } catch (error) {
+      if (ctx.abortSignal?.aborted) throw error
+      if (!(error instanceof WorkflowStepError)) throw error
+      if (attempt < FILL_NODE_ATTEMPTS) {
+        console.warn(
+          `[draft-workflow] event=fill_node_retry type=${node.type} attempt=${attempt}/${FILL_NODE_ATTEMPTS}`,
+        )
+        continue
+      }
+      console.warn(
+        `[draft-workflow] event=fill_node_skipped type=${node.type} attempts=${FILL_NODE_ATTEMPTS}`,
+      )
+      return null
+    }
+  }
+  return null
+}
+
+/**
  * Assemble one skeleton node into a Draft block, filling content SEQUENTIALLY
  * in document order. `accumulator` is the running flat list of every block
  * filled so far (top-level + nested), used as coherence context for each
@@ -914,13 +974,17 @@ async function assembleNode(
   ctx: StepContext<SkeletonStepOutput>,
   node: SkeletonNode,
   accumulator: unknown[],
-): Promise<Record<string, unknown>> {
+): Promise<Record<string, unknown> | null> {
   if (node.type === "section") {
     const content: Record<string, unknown>[] = []
     for (const child of node.children ?? []) {
       const childBlock = await assembleNode(ctx, child, accumulator)
-      content.push(childBlock)
+      // Skipped child (failed all attempts) → drop it from this section.
+      if (childBlock !== null) content.push(childBlock)
     }
+    // A section whose every child was skipped has no content to render — drop
+    // the empty shell rather than emit a hollow section.
+    if (content.length === 0) return null
     const shell: Record<string, unknown> = { t: "section", content }
     if (node.sectionRef) shell.sectionRef = node.sectionRef
     return shell
@@ -929,15 +993,18 @@ async function assembleNode(
     const slots: Array<{ content: Record<string, unknown>[] }> = []
     for (const child of node.children ?? []) {
       const childBlock = await assembleNode(ctx, child, accumulator)
-      slots.push({ content: [childBlock] })
+      if (childBlock !== null) slots.push({ content: [childBlock] })
     }
+    if (slots.length === 0) return null
     const shell: Record<string, unknown> = { t: "container", slots }
     if (node.sectionRef) shell.sectionRef = node.sectionRef
     return shell
   }
-  // Leaf — fill its content, threading the running accumulator so this fill can
-  // see every block written before it (coherence).
-  const filled = await fillSingleNode(ctx, node, accumulator)
+  // Leaf — fill its content with bounded retries, threading the running
+  // accumulator so this fill can see every block written before it (coherence).
+  // `null` means every attempt failed its schema: skip this block.
+  const filled = await fillNodeWithRetries(ctx, node, accumulator)
+  if (filled === null) return null
   accumulator.push(filled)
   return filled
 }
@@ -953,7 +1020,8 @@ export async function executeFillStep(
   // blocks filled before it via the shared accumulator.
   for (const node of skeleton.nodes) {
     const block = await assembleNode(ctx, node, accumulator)
-    blocks.push(block)
+    // Skipped top-level node (failed all attempts, or an emptied shell) → drop.
+    if (block !== null) blocks.push(block)
   }
   const scalars = synthesizeScalars(ctx.inputData)
   // Run the assembled draft through the SAME coercion + DraftExperienceSchema

--- a/apps/mastra/src/services/persona/persona-library.test.ts
+++ b/apps/mastra/src/services/persona/persona-library.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { PERSONA_ROSTER } from "../../config/personas/persona-roster"
+import {
+  _internals,
+  listPersonaSummaries,
+  loadPersona,
+} from "./persona-library"
+import { PersonaSchema } from "./persona.schemas"
+
+describe("persona-library", () => {
+  beforeEach(() => {
+    _internals.personaCache.clear()
+  })
+
+  it("loads a known persona that satisfies PersonaSchema", () => {
+    const persona = loadPersona("grieving")
+    expect(persona).toBeDefined()
+    expect(() => PersonaSchema.parse(persona)).not.toThrow()
+    expect(persona?.name).toBe("Grieving")
+    expect(persona?.needs.length).toBeGreaterThan(0)
+  })
+
+  it("returns undefined for an unknown persona without throwing", () => {
+    expect(loadPersona("does-not-exist")).toBeUndefined()
+  })
+
+  it("lists id + name + blurb (only) for every roster entry", () => {
+    const summaries = listPersonaSummaries()
+    expect(summaries).toHaveLength(PERSONA_ROSTER.length)
+    for (const s of summaries) {
+      expect(s.id).toBeTruthy()
+      expect(s.name).toBeTruthy()
+      expect(s.blurb).toBeTruthy()
+      expect(Object.keys(s).sort()).toEqual(["blurb", "id", "name"])
+    }
+  })
+
+  it("validates every committed roster entry and enforces unique ids", () => {
+    for (const raw of PERSONA_ROSTER) {
+      expect(() => PersonaSchema.parse(raw)).not.toThrow()
+    }
+    const ids = PERSONA_ROSTER.map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/apps/mastra/src/services/persona/persona-library.ts
+++ b/apps/mastra/src/services/persona/persona-library.ts
@@ -1,0 +1,43 @@
+import {
+  PERSONA_ROSTER,
+  PERSONA_ROSTER_VERSION,
+} from "../../config/personas/persona-roster"
+import {
+  PersonaSchema,
+  type Persona,
+  type PersonaSummary,
+} from "./persona.schemas"
+
+const personaCache = new Map<string, Persona>()
+
+/**
+ * Build (once) a validated id → persona index. Parsing here fails fast on a
+ * malformed committed roster while keeping unknown-id lookups a graceful miss.
+ */
+function index(): Map<string, Persona> {
+  if (personaCache.size === 0) {
+    for (const raw of PERSONA_ROSTER) {
+      const persona = PersonaSchema.parse(raw)
+      personaCache.set(persona.id, persona)
+    }
+  }
+  return personaCache
+}
+
+/** Returns the persona definition for an id, or undefined if unknown. */
+export function loadPersona(id: string): Persona | undefined {
+  return index().get(id)
+}
+
+/** Compact roster for picker/listing surfaces. */
+export function listPersonaSummaries(): PersonaSummary[] {
+  return [...index().values()].map(({ id, name, blurb }) => ({
+    id,
+    name,
+    blurb,
+  }))
+}
+
+export { PERSONA_ROSTER_VERSION }
+
+export const _internals = { personaCache }

--- a/apps/mastra/src/services/persona/persona-prompt.test.ts
+++ b/apps/mastra/src/services/persona/persona-prompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { loadPersona } from "./persona-library"
+import {
+  buildPersonaTopicPrompt,
+  renderPersonaPromptBlock,
+} from "./persona-prompt"
+
+describe("persona-prompt", () => {
+  it("renders the persona's steering fields into the block", () => {
+    const persona = loadPersona("grieving")
+    expect(persona).toBeDefined()
+    const block = renderPersonaPromptBlock(persona!)
+    expect(block).toContain(persona!.name)
+    expect(block).toContain(persona!.tone)
+    expect(block).toContain(persona!.scripturePosture)
+    expect(block).toContain(persona!.emotionalGoal)
+    for (const need of persona!.needs) expect(block).toContain(need)
+  })
+
+  it("composes topic + persona with persona steering before the topic", () => {
+    const persona = loadPersona("family")!
+    const prompt = buildPersonaTopicPrompt("Easter", persona)
+    expect(prompt).toContain("Easter")
+    expect(prompt).toContain(persona.name)
+    expect(prompt.indexOf(persona.name)).toBeLessThan(prompt.indexOf("Easter"))
+  })
+
+  it("two personas over the same topic yield different prompts (divergence seam)", () => {
+    const grieving = buildPersonaTopicPrompt("Easter", loadPersona("grieving")!)
+    const skeptic = buildPersonaTopicPrompt(
+      "Easter",
+      loadPersona("seeker-skeptic")!,
+    )
+    expect(grieving).not.toEqual(skeptic)
+  })
+})

--- a/apps/mastra/src/services/persona/persona-prompt.ts
+++ b/apps/mastra/src/services/persona/persona-prompt.ts
@@ -1,0 +1,33 @@
+import type { Persona } from "./persona.schemas"
+
+/**
+ * Render a persona into an explicit audience instruction the existing draft
+ * pipeline already honours: the plan/draft prompts say "honour the target
+ * audience the editor named or implied." We thread the persona by composing it
+ * into the editor `prompt` the multi-step workflow already takes — so the
+ * existing no-persona draft path stays untouched.
+ */
+export function renderPersonaPromptBlock(persona: Persona): string {
+  return [
+    `TARGET AUDIENCE — write this experience specifically for: ${persona.name}.`,
+    `Who they are: ${persona.blurb} (${persona.faithStage})`,
+    `Voice & tone: ${persona.tone}`,
+    `What they most need from this page:`,
+    ...persona.needs.map((need) => `  - ${need}`),
+    `How to use Scripture for them: ${persona.scripturePosture}`,
+    `Emotional goal: ${persona.emotionalGoal}`,
+    `Cultural context to honour: ${persona.culturalContext}`,
+    `Shape the framing, tone, Scripture choices, and the questions you answer for THIS audience — while keeping the underlying facts the same as you would for any audience.`,
+  ].join("\n")
+}
+
+/**
+ * Compose the topic + persona into the single editor `prompt` the multi-step
+ * draft workflow consumes. Persona steering goes first so it frames the topic.
+ */
+export function buildPersonaTopicPrompt(
+  topic: string,
+  persona: Persona,
+): string {
+  return `${renderPersonaPromptBlock(persona)}\n\nTOPIC: ${topic.trim()}`
+}

--- a/apps/mastra/src/services/persona/persona.schemas.ts
+++ b/apps/mastra/src/services/persona/persona.schemas.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+/**
+ * Audience persona definition (origin R9). Mastra-owned: the generator threads a
+ * persona into the draft prompts so one topic is shaped for that audience.
+ *
+ * The roster (`apps/mastra/src/config/personas/persona-roster.ts`) is committed,
+ * versioned DATA — editable without a code change (R10). The starter roster is a
+ * placeholder pending a ministry-confirmed audience list.
+ */
+export const PersonaSchema = z
+  .object({
+    /** Stable kebab-case id used in trigger requests and variant slugs. */
+    id: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(/^[a-z][a-z0-9-]*$/, "persona id must be kebab-case"),
+    /** Human-facing audience name, e.g. "Grieving". */
+    name: z.string().min(1).max(120),
+    /** One-line description for picker/listing surfaces. */
+    blurb: z.string().min(1).max(280),
+    /** Voice + register the copy should adopt for this audience. */
+    tone: z.string().min(1),
+    /** What this audience most needs from the page. */
+    needs: z.array(z.string().min(1)).min(1),
+    /** How Scripture should be used (or held back) for this audience. */
+    scripturePosture: z.string().min(1),
+    /** The emotional outcome the page should aim for. */
+    emotionalGoal: z.string().min(1),
+    /** Where this audience tends to be in their faith journey. */
+    faithStage: z.string().min(1),
+    /** Cultural context to honour (or avoid assuming). */
+    culturalContext: z.string().min(1),
+  })
+  .strict()
+
+export type Persona = z.infer<typeof PersonaSchema>
+
+/** Compact persona shape for listing/picker surfaces (no steering detail). */
+export type PersonaSummary = Pick<Persona, "id" | "name" | "blurb">

--- a/docs/brainstorms/2026-06-29-persona-aware-experience-variant-generation-requirements.md
+++ b/docs/brainstorms/2026-06-29-persona-aware-experience-variant-generation-requirements.md
@@ -1,0 +1,177 @@
+---
+date: 2026-06-29
+topic: persona-aware-experience-variant-generation
+---
+
+# Persona-Aware Experience Variant Generation
+
+## Summary
+
+A persona-aware experience-variant generator: an editor picks a topic and a set of curated audience personas, and Mastra produces several well-composed, persona-tailored watch pages — same grounded facts, different framing, scripture, and questions — each scored for audience-fit and carrying a plain "how this lands" note. Personas live as a richer Mastra-owned library. v1 ships manual share-by-link; automatic audience-routing is designed-for but deferred.
+
+---
+
+## Problem Frame
+
+JesusFilm editors today either hand-author an experience block by block, or use the existing video-anchored draft generator, which produces a single, generic page. But the same gospel topic lands very differently for a grieving skeptic, a new believer, a family with children, or a seasoned Christian. There is currently no way to tailor a page to who it's for — and no structured notion of "audience" anywhere in the system (verified: no persona/audience data model exists in schema or production today). An editor who wants to reach a specific audience must rewrite by hand and guess at how the message will land. The cost is generic content that under-serves the very people the ministry is trying to reach, plus editor time spent manually re-framing one topic for different readers.
+
+---
+
+## Shape at a glance
+
+```mermaid
+flowchart LR
+  subgraph Mastra["Mastra — AI engine"]
+    L[Persona library]
+    G[Variant generation\nmulti-persona + critique]
+    C[Persona-fit critique\n+ audience-fit risk labels]
+  end
+  subgraph Admin["Admin — caller + workbench"]
+    T[Trigger: topic + personas]
+    R[Review / edit / publish]
+  end
+  subgraph Web["Web — storefront"]
+    P[Render variant pages]
+    A[(later) Auto-route by signal]
+  end
+  T --> G --> C --> R
+  L --> G
+  R --> P
+  P -. v1: share-by-link .-> Editor((Editor distributes link))
+  P -. later .-> A
+```
+
+> _Directional shape for review, not implementation specification._
+
+---
+
+## Actors
+
+- A1. **Content editor** (admin): picks a topic + a set of personas, reviews/edits the generated variants, publishes the ones they want, distributes links.
+- A2. **Mastra generation engine**: owns the persona library, variant generation, and the persona-fit critique.
+- A3. **Ministry / content lead**: defines and owns the persona roster (each audience's tone, needs, scripture posture, etc.).
+- A4. **Watch-site visitor** (the "audience"): the seeker / grieving / new-believer person who lands on a variant page. Non-interactive in v1 — they receive a shared link; signal-based routing is a later phase.
+
+---
+
+## Key Flows
+
+- F1. **Generate persona variants**
+  - **Trigger:** editor picks a topic and selects a set of personas in admin.
+  - **Actors:** A1, A2.
+  - **Steps:** editor supplies topic + persona set → admin calls Mastra → Mastra generates one tailored experience per persona (shared grounding, divergent framing) → runs the persona-fit critique → returns the variants plus per-variant "how this lands" notes and audience-fit risk flags → admin validates the blocks and stages the variants.
+  - **Outcome:** a grouped set of draft persona-variant pages, each with audience-fit notes, ready for editor review.
+  - **Covered by:** R1, R2, R3, R5, R6, R11.
+
+- F2. **Review, publish, and share**
+  - **Trigger:** editor reviews the generated variants.
+  - **Actors:** A1.
+  - **Steps:** editor reads each variant + its audience-fit note → edits if needed → publishes the ones they want → each variant gets its own URL → editor shares the right link to the right channel.
+  - **Outcome:** published persona pages, each with a shareable URL, grouped under one topic.
+  - **Covered by:** R4, R7, R8, R12.
+
+- F3. **Maintain the persona library**
+  - **Trigger:** ministry lead defines or updates the audience roster.
+  - **Actors:** A3, A2.
+  - **Steps:** ministry lead provides persona definitions (tone, needs, scripture posture, emotional goal, faith-stage, cultural context) → stored in the Mastra-owned library → available to the generator and future features.
+  - **Outcome:** a curated, reusable persona library.
+  - **Covered by:** R9, R10.
+
+---
+
+## Requirements
+
+**Persona library (Mastra-owned)**
+
+- R1. The system maintains a curated library of audience personas, owned by Mastra, reusable by the generator and future features.
+- R9. Each persona definition carries: name, tone, audience needs, scripture posture, emotional goal, faith-stage, and cultural context.
+- R10. The persona roster's content is ministry-sourced; the system treats the roster as data (editable without a code change) and ships a starter roster as a placeholder.
+
+**Variant generation (Mastra)**
+
+- R2. Given a topic and a selected set of personas, the generator produces one tailored experience per persona.
+- R3. All variants for a topic share the same grounded facts but diverge in framing, scripture selection, and the questions they answer.
+- R5. Generation builds on the existing quality pipeline (multi-direction exploration → synthesis → adversarial critique), with the critique judging persona-fit, not only schema validity.
+- R6. The persona-fit critique surfaces named audience-fit risk labels (e.g. "too direct," "may confuse a non-believer," "emotionally off," "culturally off").
+- R11. Generated variants pass the same block-schema validation gate as the existing generator before persistence.
+
+**Admin (caller + editor UX + persistence)**
+
+- R4. Editors select a topic + personas, review the generated variants, edit them, and publish from admin.
+- R7. Each published variant is its own experience page with its own URL (share-by-link distribution in v1).
+- R8. Each variant carries an editor-facing "how this lands for audience X" note.
+- R12. Variants are grouped under one logical topic so they are managed together and a later phase can route among them.
+
+**Division of labor**
+
+- R13. Mastra owns the persona library, variant generation, and persona-fit critique; admin is a thin caller (trigger, editor UX, validate/store/publish, permissions); web owns rendering and, in a later phase, auto-routing. Mastra never owns experience data.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R2, R3.** Given the topic "Easter" and personas {grieving, new believer, family}, when the editor generates, then three separate draft pages are produced that share the core Easter facts but differ in tone, scripture emphasis, and questions asked.
+- AE2. **Covers R6, R8.** Given a generated variant whose copy reads as confrontational for a grieving visitor, when generation completes, then that variant is flagged with an audience-fit risk ("too direct for a grieving reader") and carries a "how this lands" note.
+- AE3. **Covers R7, R12.** Given three published persona variants for one topic, when the editor publishes them, then each has its own URL and all three are grouped under the same logical topic.
+- AE4. **Covers R11.** Given a generated variant containing an invalid block, when admin attempts to persist it, then persistence is rejected by the same schema-validation gate the existing generator uses.
+
+---
+
+## Success Criteria
+
+- An editor can produce several genuinely audience-tailored, well-composed pages for one topic in a single pass — visibly better-fit than one generic page — and can see how each will land before publishing.
+- The persona library is reusable: the same definitions drive this generator and are available to future features without being copied into admin.
+- A downstream implementer can build v1 (persona library + single-topic variant generation + manual links) without inventing product behavior; the ministry-provided persona roster is the only external input required.
+
+---
+
+## Scope Boundaries
+
+### Deferred for later
+
+- Automatic audience-routing: the watch site selecting the right variant by signal (referrer, quiz answer, geo) or A/B. v1 ships manual share-by-link; the persona/variant model is shaped so routing is a clean follow-up, not a rebuild.
+- Visitor-signal capture and per-variant performance analytics.
+- Editor-side "User Mind Reader" chat upgrades (smarter clarification, next-step suggestions) — the existing AI chat already covers editor intent.
+- Persona × locale/translation interaction (how personas combine with the per-locale experience model).
+
+### Outside this product's identity
+
+- A personal communication assistant (email/recipe/thesis review, "write to my supervisor / donor / friend," generic personal cross-cultural etiquette). "Audience" here means the ministry's audience — the watch-site visitor — never the editor's personal correspondents.
+- Adopting the source idea's full ten-layer generic content-pipeline architecture; the relevant ideas map onto the existing Mastra → admin → web split.
+- Real-time per-visitor personalization or live audience detection.
+
+---
+
+## Key Decisions
+
+- **Build on the existing quality pipeline, not a parallel system.** The multi-direction loop becomes multi-persona; the critique becomes persona-fit. Reuses proven machinery and avoids a second generation path.
+- **The persona library lives in Mastra, not admin.** It's shared AI infrastructure the generator and future features draw on, and keeps admin a thin caller per the consolidation contract. This is the concrete answer to "how does admin benefit from Mastra."
+- **Variants are separate pages grouped under one topic** — not one adaptive page, and not N unrelated pages. Supports manual links now and auto-routing later.
+- **Division of labor follows the established consolidation.** Mastra = AI engine; admin = data + UX + permissions; web = rendering + routing. Mastra must not own experience data — moving it there would undo the consolidation (this is the answer to "can it all be in Mastra?": the thinking can, the data/editor/storefront stay put).
+- **Fold in three enrichments from the "audience mind reader" exploration** — audience-fit risk labels, the "how this lands" note, and richer persona definitions — and reject the personal-assistant framing. Keep the useful, drop the identity-blurring.
+
+---
+
+## Dependencies / Assumptions
+
+- **Ministry-provided persona roster** (tone, needs, scripture posture, emotional goal, faith-stage, cultural context per audience). A starter roster (seeker/skeptic, grieving, new believer, family/kids, seasoned believer) is an assumption pending ministry confirmation.
+- Reuses the existing generation grounding (topic / video candidates) and the shared block-schema validation.
+- v1 stays inside Mastra + admin; no public watch-site (`apps/web`) changes until the routing phase.
+- Production deploy is a human gate (loop in Tataihono); this is a product-level, multi-app feature, not a same-day build.
+- No persona/audience data model exists today — verified against the schema and the live database — so this is net-new.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- [Affects R1, R10][User / ministry decision] What is the initial persona roster, and who owns it? The starter set is an assumption; the ministry must confirm the real audiences and their definitions before a build delivers value.
+
+### Deferred to Planning
+
+- [Affects R2, R5][Technical] Generation topology: one Mastra call returns all N variants vs. N independent generations.
+- [Affects R12][Technical] How variants are grouped/related so they're managed together and routable later.
+- [Affects R3][Needs research] How "shared grounding, divergent framing" is enforced so variants stay factually consistent across audiences.
+- [Affects R6, R8][Technical] Where the "how this lands" note and audience-fit risk labels are stored and surfaced to the editor.
+- [Affects "Deferred for later"][Needs research] Persona × locale interaction once routing ships.

--- a/docs/plans/2026-06-29-001-feat-persona-aware-experience-variants-plan.md
+++ b/docs/plans/2026-06-29-001-feat-persona-aware-experience-variants-plan.md
@@ -1,0 +1,338 @@
+---
+title: "feat: Persona-aware experience variant generation (v1)"
+type: feat
+status: active
+date: 2026-06-29
+origin: docs/brainstorms/2026-06-29-persona-aware-experience-variant-generation-requirements.md
+deepened: 2026-06-29
+---
+
+# feat: Persona-aware experience variant generation (v1)
+
+## Summary
+
+**v1 is a generation proof slice.** It adds a Mastra-owned persona library and persona-threaded variant generation, triggered by an operator script: give a topic + a set of persona ids, and it generates one tailored experience per persona (reusing the existing `multi-step-draft` pipeline with the persona threaded into the prompts), re-validates each through the existing block-schema gate, and stages each as a plain experience the editor reviews and publishes in the existing dashboard. No new schema, no UI, no structured critique — those are Phase B, layered on only once the generation is proven worth it.
+
+The point of v1 is to answer one question cheaply: **do persona-tailored variants actually generate well and differ usefully?**
+
+---
+
+## Problem Frame
+
+The same gospel topic lands differently for a grieving skeptic, a new believer, or a family — but today's generator produces one generic page and editors re-frame by hand, with no structured notion of audience anywhere in the system. See origin for the full pain narrative and product decisions (`docs/brainstorms/2026-06-29-persona-aware-experience-variant-generation-requirements.md`).
+
+---
+
+## Requirements
+
+v1 (this plan) advances the core generation requirements; the audience-fit, grouping, and editor-UX requirements are carried but deferred to Phase B (see Scope Boundaries).
+
+- R1. Curated persona library, owned by Mastra, reusable by the generator and future features. _(v1)_
+- R2. Given a topic + selected personas, produce one tailored experience per persona. _(v1)_
+- R3. All variants for a topic share the same grounded facts but diverge in framing/scripture/questions. _(v1)_
+- R5. Build on the existing quality pipeline; persona steers generation. _(v1 — persona-threading; the persona-fit critique is Phase B)_
+- R9. Each persona definition carries: name, tone, needs, scripture posture, emotional goal, faith-stage, cultural context. _(v1)_
+- R10. The persona roster is data (editable without a code change); ship a starter roster placeholder. _(v1)_
+- R11. Generated variants pass the same block-schema validation gate as the existing generator. _(v1)_
+- R13. Mastra owns persona library + variant generation; admin is a thin caller; web owns rendering. Mastra never owns experience data. _(v1)_
+- R4. Editors select topic + personas, review, edit, and publish from admin. _(Phase B — v1 triggers via script; editor reviews/publishes generated experiences in the existing dashboard)_
+- R6. Persona-fit critique surfaces named audience-fit risk labels. _(Phase B)_
+- R7. Each published variant is its own page with its own URL. _(v1 — each variant is a plain experience with its own slug; the grouping that links them is Phase B)_
+- R8. Each variant carries an editor-facing "how this lands" note. _(Phase B)_
+- R12. Variants grouped under one logical topic, routable later. _(Phase B)_
+
+**Origin actors:** A1 (content editor), A2 (Mastra generation engine), A3 (ministry/content lead), A4 (watch-site visitor).
+**Origin flows:** F1 (generate persona variants — v1), F2 (review/publish/share — v1 via existing dashboard), F3 (maintain persona library — v1).
+**Origin acceptance examples:** AE1 (covers R2, R3 — v1), AE4 (covers R11 — v1); AE2 (R6/R8) and AE3-grouping (R12) are Phase B.
+
+---
+
+## Scope Boundaries
+
+### Deferred for later
+
+- Automatic audience-routing on the public site (signal/A-B).
+- Visitor-signal capture; per-variant performance analytics.
+- Editor-side AI-chat "User Mind Reader" upgrades.
+- Persona × locale/translation interaction.
+
+### Outside this product's identity
+
+- A personal communication assistant (email/recipe/"write to my supervisor"). "Audience" = the ministry's audience, never the editor's personal correspondents.
+- Adopting a generic ten-layer content-pipeline architecture; we extend the existing Mastra → admin → web split.
+- Real-time per-visitor personalization.
+
+### Deferred to Follow-Up Work (Phase B — after v1 proves generation)
+
+These were active units in the first draft of this plan; the lean v1 defers them. They keep their U-IDs and are sketched (not fully specified) below under "Phase B units."
+
+- **U9. Persona-fit critique** (structured audience-fit risk labels + "how this lands" note) and **U2. shared audience-fit schema** — the "audience mind reader" overlay. Deferred because it's a quality/safety layer on top of generation, not the generation itself.
+- **U6. Grouping entity + per-variant metadata** (`ExperienceGroup`, `groupId`, `personaKey`, note/labels) — needed for "managed together + routable later," not for proving generation. v1 variants are plain experiences with descriptive slugs.
+- **U8. Editor picker + variant-review UI** (+ the `/forge-personas` list route) — v1 triggers via an operator script and reviews in the existing dashboard; the dedicated UI is the payoff once generation quality is proven.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Generation pipeline (extend):** `apps/mastra/src/mastra/workflows/multi-step-draft.ts` (`multiStepDraftWorkflow`, exported step executors, `WorkflowStepError`), `apps/mastra/src/mastra/workflows/experience-draft-route.ts` (`ExperienceDraftRequestSchema`, `{ ok | reason | retryable }` envelope, `AbortSignal.timeout(TIME_BUDGET_MS.multiStepWorkflow=180s)`, `statusForResult`). Registration seam: the `agents`/`workflows` maps + `registerApiRoute(...)` in `apps/mastra/src/mastra/index.ts`.
+- **Prompt builders + model (extend):** `apps/mastra/src/mastra/agents/specialized-agents.ts` (`buildSpecializedAgents`, `resolveAgentModel`), prompt registry `apps/mastra/src/mastra/prompts/`.
+- **Mastra-owned structured data (pattern for the persona library):** `apps/mastra/src/config/languages/ja.json` + loader `apps/mastra/src/services/subtitle-enrichment/language-config.ts` (committed JSON + cached `import()` loader); versioned dataset `apps/mastra/src/services/offline-search-eval/seed-prompt-set.ts`.
+- **Admin caller (extend) + transport template:** `apps/admin/src/app/dashboard/experiences/generate-draft-action.ts` (flag gate, `config_missing` degrade, `loadExperienceAiVideoCandidates`, normalize gate); `apps/admin/src/services/experience-ai/mastra-experience-section-client.ts` (`node:http` `postViaNode`, `resolveTimeoutMs`); block gate `apps/admin/src/services/experience-ai/experience-ai-normalize.ts` (`normalizeExperienceDraft`).
+- **Persistence (reuse):** `apps/admin/src/services/experience.service.ts` (`create`/`createLocale`/`publishLocale`). v1 needs no schema change — each variant is one `Experience` + one `ExperienceLocale` via the existing path.
+- **Operator-script pattern (follow for the v1 trigger):** `apps/admin/src/scripts/seed-experience.ts`, `apps/admin/src/scripts/apply-experience-from-json.ts`, and the `run-embeds` CLI shape — prod-URL guard, `import { prisma }`, `tsx` invocation.
+- **Shared contract:** `packages/experience-schema/src/experience-ai.schemas.ts` (`DraftExperienceSchema`, `GENERATION_MIN_BLOCKS`).
+- **Fan-out pattern (reuse):** admin's embedding backfills use `pLimit(env.X ?? DEFAULT) + Promise.allSettled`.
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/mastra-launch-timeout-env-string-network-error.md` — t3-env `skipValidation` drops Zod number defaults → `setTimeout(undefined)` throws a 1ms fake network error. Normalize env timeouts at the boundary; regression-test with a numeric **string**.
+- `docs/solutions/best-practices/outbound-timeout-shorter-than-caller-budget-20260506.md` — size the budget chain top-down: trigger per-call timeout > Mastra workflow (180s) > inner call.
+- `docs/solutions/best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md` + `docs/solutions/best-practices/parallel-workflow-error-robustness-20260420.md` — N-variant fan-out is `pLimit + Promise.allSettled`, never bare `Promise.all`; one variant's failure must not abort the batch; classify on typed `instanceof`/`code`, never regex; concurrency default below the shared budget.
+- `docs/solutions/runtime-errors/required-env-var-without-default-broke-railway-deploy-20260511.md` — new flag/URL/key is `.optional()` + runtime `config_missing` degrade; add an env-import-with-var-unset test.
+- `docs/solutions/conventions/single-service-http-client-result-union-convention.md` — new clients are typed no-throw unions with `config_missing` short-circuit, injectable `fetchImpl`, `redirect:"error"`; never log raw upstream reasons.
+- `docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md` — persona-threaded generation needs a real-LLM smoke (catalog membership ≠ live-served).
+- `docs/solutions/tooling-decisions/mastra-dev-tsx-loader-for-raw-ts-workspace-deps.md` — relevant only if Phase B adds multi-file schema to `packages/experience-schema/`; not triggered by lean v1.
+- Consolidation pattern lives in `apps/admin/CLAUDE.md` ("Experience draft/chat — standalone Mastra consolidation") + `docs/plans/2026-06-19-001-feat-mastra-admin-to-standalone-consolidation-plan.md`; consider `/ce-compound`-ing it after this lands.
+
+---
+
+## Key Technical Decisions
+
+- **v1 is a generation proof slice, script-triggered.** The smallest thing that proves the bet is generation, not management. Trigger via an operator script (the `seed-experience`/`run-embeds` pattern), review generated experiences in the existing dashboard. Defers the editor UI, the structured persona-fit critique, and the grouping schema to Phase B. Rationale: prove persona-tailored generation is good and differentiated before investing in the surfaces around it.
+- **Generation topology: N independent per-persona calls.** The script loads candidates once, then fans out one generation call per persona under bounded concurrency. Mastra owns each per-variant generation; the script owns the fan-out + persistence. Each call stays inside the existing 180s budget. Rejected: a single N-variant route (new budget model + concentrates rate-limit risk).
+- **Personas steer the prompt, not the output contract.** All variants emit the same `DraftExperienceSchema`, so the existing block-schema gate validates every variant for free (R11/AE4). "Shared facts, divergent framing" (R3) is structural: every persona call gets the **same topic + same candidates**; only the persona differs.
+- **Persona library stays Mastra-owned.** Committed JSON + cached loader (the `config/languages` pattern). The script sends persona **ids**; Mastra resolves the full definition. v1 needs no persona-list route (that's for the Phase B picker).
+- **No new schema in v1.** Each variant is a plain `Experience` + `ExperienceLocale` with its own descriptive slug (e.g. `easter-grieving`), reusing the existing create/publish path. Grouping (`ExperienceGroup`), persona attribution, and the audience-fit note/labels are additive Phase B columns.
+- **Reuse `MASTRA_SERVICE_API_KEYS`.** Same service → no new credential, no receiver-first deploy ordering. New admin envs (`EXPERIENCE_AI_REMOTE_VARIANTS` + any `MASTRA_VARIANTS_*`) are `.optional()` + `config_missing` degrade.
+- **`node:http` transport, not `fetch`.** Copy `mastra-experience-section-client.ts` to dodge the Next-patched-fetch-over-Railway-private-net failure; guard env timeouts with `resolveTimeoutMs`.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Generation topology → N independent calls, script-orchestrated.
+- v1 trigger → operator script (defer UI).
+- Grouping / critique / metadata → Phase B (not needed to prove generation).
+- New credential? → No; reuse `MASTRA_SERVICE_API_KEYS`.
+
+### Deferred to Implementation
+
+- Default fan-out concurrency value — tune against the shared AI-gateway/OpenRouter + Prisma budget during U7.
+- Exact persona-block prompt shape (how the persona definition is rendered into the plan/skeleton/fill prompts) — settle when wiring U3 against real output.
+- Whether the script writes staged (DRAFT) or published experiences — default to DRAFT so the editor reviews before publishing.
+
+---
+
+## Implementation Units (lean v1)
+
+### U1. Persona library (Mastra-owned)
+
+**Goal:** A committed, versioned, editable-as-data persona roster with a typed loader.
+
+**Requirements:** R1, R9, R10.
+
+**Dependencies:** None.
+
+**Files:**
+
+- Create: `apps/mastra/src/config/personas/` (committed roster — one JSON per persona or a single versioned module)
+- Create: `apps/mastra/src/services/persona/persona-library.ts` (`PersonaSchema`, `loadPersona(id)`, module-level cache)
+- Test: `apps/mastra/src/services/persona/persona-library.test.ts`
+
+**Approach:** Mirror `apps/mastra/src/services/subtitle-enrichment/language-config.ts` (cached loader, graceful `undefined`) and the versioned shape of `seed-prompt-set.ts`. `PersonaSchema` carries the R9 fields + a stable `id`. Ship a starter roster (seeker/skeptic, grieving, new believer, family/kids, seasoned believer), clearly marked as a placeholder pending ministry confirmation.
+
+**Patterns to follow:** `language-config.ts`; `seed-prompt-set.ts`.
+
+**Test scenarios:**
+
+- Happy path: `loadPersona("grieving")` returns a definition satisfying `PersonaSchema`.
+- Edge case: `loadPersona("unknown")` returns `undefined` (no throw).
+- Edge case: every committed roster entry validates against `PersonaSchema`.
+
+**Verification:** Loader returns typed personas; the full starter roster validates.
+
+---
+
+### U3. Persona-threaded generation
+
+**Goal:** Make the existing draft pipeline persona-aware by threading a persona definition into its prompts.
+
+**Requirements:** R3, R5, R9.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- Modify: `apps/mastra/src/mastra/agents/specialized-agents.ts` (thread an optional persona block into the plan/skeleton/fill prompt builders)
+- Modify (as needed): `apps/mastra/src/mastra/prompts/` builders that assemble the generation prompts
+- Test: `apps/mastra/src/mastra/agents/specialized-agents.test.ts` (or colocated)
+
+**Approach:** Pass the persona definition (from U1) into the existing multi-step prompt builders so content is persona-shaped. Do NOT change the output contract (`DraftExperienceSchema` unchanged). The structured persona-fit critique is deferred (U9); v1 relies on persona-threading alone to differentiate variants.
+
+**Execution note:** Add a real-LLM smoke comparing two personas over the same topic+candidates to confirm the outputs genuinely diverge.
+
+**Patterns to follow:** existing prompt builders + `resolveAgentModel`.
+
+**Test scenarios:**
+
+- Covers AE1. Two different personas over the same topic + candidates produce drafts that differ in framing/scripture/questions.
+- Happy path: a persona-threaded generation still produces a draft valid against `DraftExperienceSchema`.
+- Edge case: with no persona supplied, generation behaves exactly as today (no regression to the existing draft path).
+
+**Verification:** Persona-threaded prompts produce persona-shaped, schema-valid copy; the no-persona path is unchanged.
+
+---
+
+### U4. Per-persona variant route (Mastra)
+
+**Goal:** A bearer-gated route that generates one variant for a topic + persona.
+
+**Requirements:** R2, R5, R13.
+
+**Dependencies:** U1, U3.
+
+**Files:**
+
+- Create: `apps/mastra/src/mastra/workflows/experience-variant-route.ts` (request `{ topic/prompt, locale, candidates, exemplar?, personaId }`; discriminated `{ ok, draft, personaId } | { ok:false, reason, retryable }` envelope; internal timeout)
+- Modify: `apps/mastra/src/mastra/index.ts` (register `/forge-experience-variant`; register any new workflow in the maps)
+- Test: `apps/mastra/src/mastra/workflows/experience-variant-route.test.ts`
+
+**Approach:** Mirror `experience-draft-route.ts` (bearer → parse → run-with-internal-timeout → discriminated envelope). Resolve the persona via U1, run the U3 persona-threaded generation reusing the `multi-step-draft` step executors (extract a plain service helper rather than `start()`-ing a sibling workflow). Reuse `MASTRA_SERVICE_API_KEYS` + `isValidServiceBearer`. No persona-list route in v1.
+
+**Patterns to follow:** `experience-draft-route.ts`; the `getMastra` thunk registration seam; `workflow-step-body-calls-service` learning.
+
+**Test scenarios:**
+
+- Happy path: valid `{ topic, personaId, candidates }` → `{ ok:true, draft, personaId }` (200).
+- Error path: missing/invalid bearer → 401.
+- Error path: invalid input → `reason:"invalid_input"` (400).
+- Error path: generation timeout → `reason:"timeout"` retryable (504); inner budget < route budget.
+- Error path: unknown `personaId` → typed `invalid_input` (no throw).
+
+**Verification:** Route responds under bearer; envelope matches the contract; timeouts return the typed retryable reason.
+
+---
+
+### U5. Persona-variant launch client (admin)
+
+**Goal:** A typed no-throw client that calls the Mastra variant route.
+
+**Requirements:** R2, R13.
+
+**Dependencies:** U4.
+
+**Files:**
+
+- Create: `apps/admin/src/services/experience-ai/mastra-experience-variant-client.ts`
+- Modify: `apps/admin/src/config/env.ts` (`EXPERIENCE_AI_REMOTE_VARIANTS` + any `MASTRA_VARIANTS_*` overrides, all `.optional()`)
+- Test: `apps/admin/src/services/experience-ai/mastra-experience-variant-client.test.ts`
+
+**Approach:** Copy the `node:http` transport from `mastra-experience-section-client.ts` (`postViaNode`, `resolveTimeoutMs`); `config_missing` short-circuit when base URL/key unset; re-validate the returned `draft` against `DraftExperienceSchema`; typed failure union; never log raw upstream reasons. Per-call timeout sized above Mastra's inner budget.
+
+**Patterns to follow:** `mastra-experience-section-client.ts`; single-service-http-client-result-union convention.
+
+**Test scenarios:**
+
+- Happy path: a 200 with a valid variant → `{ ok:true, draft }`.
+- Edge case: base URL/key unset → `config_missing` (no throw).
+- Error path: numeric-string timeout env (`"75000"`) is coerced, not passed raw to a timer.
+- Error path: malformed `draft` in the response → typed parse failure (no throw).
+- Error path: non-2xx → typed failure; raw reason not logged.
+
+**Verification:** Client degrades cleanly when unconfigured; coerces env timeouts; returns typed results for success and every failure mode.
+
+---
+
+### U7. Operator script: topic + personas → N staged experiences
+
+**Goal:** A script that generates persona variants for a topic and stages them as plain experiences for review.
+
+**Requirements:** R2, R3, R7, R11.
+
+**Dependencies:** U5.
+
+**Files:**
+
+- Create: `apps/admin/src/scripts/generate-persona-variants.ts`
+- Test: `apps/admin/src/scripts/generate-persona-variants.test.ts` (fan-out + gate behavior with an injected client)
+
+**Approach:** Mirror `apps/admin/src/scripts/seed-experience.ts` (prod-URL guard, `import { prisma }`, `tsx` invocation). Take `--topic` + repeated `--persona` ids. Load video candidates once; fan out one U5 client call per persona with `pLimit(concurrency) + Promise.allSettled` (never `Promise.all`); run each result through `normalizeExperienceDraft` (R11 gate, AE4); create one `Experience` + one `ExperienceLocale` per variant (status DRAFT, descriptive slug like `<topic>-<persona>`) via `ExperienceService`. Print a per-persona outcome summary (succeeded/failed) plus the dashboard URLs for review. One persona's failure must not drop the others.
+
+**Execution note:** Start from a failing test for the fan-out contract (N personas → N outcomes; one failure doesn't drop the others; `observedMaxInFlight` ≤ cap).
+
+**Patterns to follow:** `seed-experience.ts`, `apply-experience-from-json.ts`, the `run-embeds` fan-out; admin's `pLimit + Promise.allSettled` backfill pattern.
+
+**Test scenarios:**
+
+- Covers AE1. 3 personas + topic → 3 staged DRAFT experiences sharing candidates, differing in framing.
+- Covers AE4. A variant with an invalid block is rejected by `normalizeExperienceDraft` and not persisted; the others still persist.
+- Error path (robustness): one persona's generation fails → the others still persist; the failure is reported per-persona.
+- Edge case: `observedMaxInFlight` never exceeds the concurrency cap (exact assertion).
+- Edge case: prod-like `DATABASE_URL` is refused (guard).
+
+**Verification:** Running the script on a topic + personas stages N reviewable DRAFT experiences in the local/admin dashboard; partial failures degrade gracefully; the block gate holds.
+
+---
+
+## Phase B units (deferred — sketched, not specified)
+
+> Pulled out of lean v1. Build only after v1 shows persona-tailored generation is good and differentiated. U-IDs preserved.
+
+### U9. Persona-fit critique + U2. shared audience-fit schema _(deferred)_
+
+A structured persona-fit critic (new Mastra prompt + agent) emitting `{ riskLabels[], howThisLands }`, single-sourced via a shared `AudienceFitSchema` in `@forge/experience-schema`. Surfaces R6/R8/AE2. Adds the "audience mind reader" overlay on top of generation.
+
+### U6. Grouping entity + per-variant metadata _(deferred)_
+
+Additive Prisma migration: `ExperienceGroup` + `Experience.groupId`; `ExperienceLocale.personaKey` + `audienceFitNote` + `audienceFitRisks`. Service helpers to create a group + grouped variants. Delivers R12/R8 and AE3-grouping; the foundation later auto-routing selects among.
+
+### U8. Editor picker + variant-review UI _(deferred)_
+
+Topic + persona multi-select (sourced from a new `/forge-personas` list route), trigger, and a review surface showing each variant with its audience-fit note/labels. Replaces the v1 script trigger; delivers R4 as a first-class editor flow.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** new script → new admin client → new Mastra route → persona library + multi-step pipeline; persistence reuses `ExperienceService` (publish still fires the existing revalidate webhook + manifest refresh per variant). No existing route or read is modified.
+- **Error propagation:** Mastra returns typed `{ ok:false, reason, retryable }`; the client maps to a typed union; the script reports per-persona outcomes; one persona's failure never aborts the batch.
+- **State lifecycle risks:** variants stage as DRAFT; the editor publishes individually (existing path). No new persistent state in v1.
+- **API surface parity:** the new `/forge-experience-variant` route reuses the existing bearer + envelope conventions; existing draft/section/chat routes untouched.
+- **Unchanged invariants:** existing single-draft/section/chat generation, `DraftExperienceSchema`, `normalizeExperienceDraft`, the experience schema, and all experience reads are untouched. Personas steer prompts only; with no persona, behavior is identical to today.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                             | Mitigation                                                                                                                                                        |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| N parallel LLM calls hit AI-gateway / OpenRouter rate limits     | Bounded concurrency (`pLimit`) below the shared budget; per-persona failures isolated via `Promise.allSettled`                                                    |
+| Ministry persona roster not yet confirmed (origin's one blocker) | Ship a committed starter roster as a clearly-marked placeholder (R10) — unblocks v1; swap content when ministry confirms                                          |
+| Variants don't differ enough (persona-threading alone is weak)   | The U3 real-LLM smoke explicitly checks two personas diverge; if weak, the Phase B persona-fit critique + a revise loop is the lever — but prove generation first |
+| Variants drift factually across audiences (R3)                   | Same topic + same candidates fed to every persona; only the persona steers — shared grounding is structural                                                       |
+| t3-env `skipValidation` drops the new timeout/flag defaults      | Normalize env timeouts at the boundary (`resolveTimeoutMs`); numeric-string regression test; new vars `.optional()` + `config_missing` degrade                    |
+
+---
+
+## Phased Delivery
+
+### v1 — Generation proof slice (U1, U3, U4, U5, U7)
+
+Persona library, persona-threaded generation, the variant route, the admin client, and the operator script. Operator runs the script with a topic + personas → reviews staged DRAFT experiences in the existing dashboard. No schema, no UI, no critique. Answers: _do persona variants generate well and differ usefully?_
+
+### Phase B — Productize (U9/U2, U6, U8) — only if v1 proves out
+
+The structured persona-fit critique, the grouping/metadata schema, and the editor picker + review UI. Then (later, already deferred) public-site auto-routing.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-06-29-persona-aware-experience-variant-generation-requirements.md`
+- Consolidation reference: `apps/admin/CLAUDE.md` ("Experience draft/chat — standalone Mastra consolidation"), `docs/plans/2026-06-19-001-feat-mastra-admin-to-standalone-consolidation-plan.md`
+- Operator-script pattern: `apps/admin/src/scripts/seed-experience.ts`, `apps/admin/src/scripts/apply-experience-from-json.ts`
+- Key learnings: `docs/solutions/runtime-errors/mastra-launch-timeout-env-string-network-error.md`, `docs/solutions/best-practices/bounded-parallelism-per-target-workflow-pattern-20260505.md`, `docs/solutions/runtime-errors/required-env-var-without-default-broke-railway-deploy-20260511.md`, `docs/solutions/best-practices/mocked-shape-vs-real-contract-discipline-20260506.md`

--- a/packages/experience-schema/src/coerce-draft.test.ts
+++ b/packages/experience-schema/src/coerce-draft.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest"
 
 import { coerceDraftEnvelope } from "./coerce-draft"
-import { DraftExperienceSchema } from "./experience-ai.schemas"
+import {
+  DraftExperienceSchema,
+  DraftRelatedQuestionsBlockSchema,
+  DraftVideoCarouselBlockSchema,
+} from "./experience-ai.schemas"
 
 /**
  * Unit tests for the deterministic, pure, LOSSY pre-validation coercion
@@ -317,5 +321,129 @@ describe("coerceDraftEnvelope", () => {
     const blocks = (draft as { blocks: Array<{ t: string }> }).blocks
     expect(blocks[0].t).toBe("text")
     expect(DraftExperienceSchema.safeParse(draft).success).toBe(true)
+  })
+})
+
+/**
+ * relatedQuestions `questions[]` item coercion. The block-level unknown-key
+ * strip does NOT recurse into nested item arrays, so a model that misapplies
+ * the video-item pattern to questions (stray `candidateRef`, missing
+ * `answer`) used to slip a `.strict()` item violation past coercion and crash
+ * the fill step. These assert the items are cleaned so the block passes the
+ * SAME fill-gate schema the fill step validates against.
+ */
+describe("coerceDraftEnvelope — relatedQuestions item coercion", () => {
+  // Coerce one block via the envelope, the way the fill step does.
+  function coerceBlock(block: unknown) {
+    const { draft, coercions } = coerceDraftEnvelope({ blocks: [block] })
+    const coercedBlock = (draft as { blocks: unknown[] }).blocks[0]
+    return { coercedBlock, coercions }
+  }
+
+  it("strips a stray candidateRef from a question item, keeping the item valid", () => {
+    const { coercedBlock, coercions } = coerceBlock({
+      t: "relatedQuestions",
+      heading: "Common questions",
+      questions: [
+        {
+          question: "Did the resurrection really happen?",
+          answer: "Yes — multiple eyewitness accounts attest to it.",
+          candidateRef: "v01",
+        },
+      ],
+    })
+
+    expect(coercions.some((c) => c.kind === "unknown_key_stripped")).toBe(true)
+    expect(
+      DraftRelatedQuestionsBlockSchema.safeParse(coercedBlock).success,
+    ).toBe(true)
+    const item = (coercedBlock as { questions: Array<Record<string, unknown>> })
+      .questions[0]
+    expect(item).toEqual({
+      question: "Did the resurrection really happen?",
+      answer: "Yes — multiple eyewitness accounts attest to it.",
+    })
+  })
+
+  it("drops a question item missing its answer (logs invalid_item_dropped), keeps the valid one", () => {
+    const { coercedBlock, coercions } = coerceBlock({
+      t: "relatedQuestions",
+      questions: [
+        { question: "No answer here", candidateRef: "v02" },
+        { question: "Good one", answer: "A real, written answer." },
+      ],
+    })
+
+    expect(coercions.some((c) => c.kind === "invalid_item_dropped")).toBe(true)
+    expect(
+      DraftRelatedQuestionsBlockSchema.safeParse(coercedBlock).success,
+    ).toBe(true)
+    expect((coercedBlock as { questions: unknown[] }).questions).toEqual([
+      { question: "Good one", answer: "A real, written answer." },
+    ])
+  })
+
+  it("leaves a clean relatedQuestions block unchanged (no coercions)", () => {
+    const { coercedBlock, coercions } = coerceBlock({
+      t: "relatedQuestions",
+      questions: [{ question: "Q?", answer: "A." }],
+    })
+
+    expect(coercions).toEqual([])
+    expect(
+      DraftRelatedQuestionsBlockSchema.safeParse(coercedBlock).success,
+    ).toBe(true)
+  })
+})
+
+/**
+ * The same nested-item coercion generalizes to every item-bearing block. This
+ * pins the exact videoCarousel failure observed in live generation: the model
+ * misapplied mediaCollection's `labelOverride` to a videoCarousel item (where
+ * it is not a valid key), which the block-level strip did not reach.
+ */
+describe("coerceDraftEnvelope — videoCarousel item coercion", () => {
+  function coerceBlock(block: unknown) {
+    const { draft, coercions } = coerceDraftEnvelope({ blocks: [block] })
+    const coercedBlock = (draft as { blocks: unknown[] }).blocks[0]
+    return { coercedBlock, coercions }
+  }
+
+  it("strips a stray labelOverride from videoCarousel items, keeping them valid", () => {
+    const { coercedBlock, coercions } = coerceBlock({
+      t: "videoCarousel",
+      heading: "Watch more",
+      items: [
+        { candidateRef: "v01", titleOverride: "Part 1", labelOverride: "New" },
+        { candidateRef: "v02", labelOverride: "Featured" },
+      ],
+    })
+
+    expect(coercions.some((c) => c.kind === "unknown_key_stripped")).toBe(true)
+    expect(DraftVideoCarouselBlockSchema.safeParse(coercedBlock).success).toBe(
+      true,
+    )
+    expect((coercedBlock as { items: unknown[] }).items).toEqual([
+      { candidateRef: "v01", titleOverride: "Part 1" },
+      { candidateRef: "v02" },
+    ])
+  })
+
+  it("drops a videoCarousel item missing its required candidateRef", () => {
+    const { coercedBlock, coercions } = coerceBlock({
+      t: "videoCarousel",
+      items: [
+        { titleOverride: "Orphaned — no candidateRef" },
+        { candidateRef: "v03" },
+      ],
+    })
+
+    expect(coercions.some((c) => c.kind === "invalid_item_dropped")).toBe(true)
+    expect(DraftVideoCarouselBlockSchema.safeParse(coercedBlock).success).toBe(
+      true,
+    )
+    expect((coercedBlock as { items: unknown[] }).items).toEqual([
+      { candidateRef: "v03" },
+    ])
   })
 })

--- a/packages/experience-schema/src/coerce-draft.ts
+++ b/packages/experience-schema/src/coerce-draft.ts
@@ -37,9 +37,15 @@
 import { z } from "zod"
 
 import {
+  DraftBibleQuoteItemSchema,
   DraftBlockSchema,
   DraftContainerContentBlockSchema,
+  DraftInfoBlockItemSchema,
+  DraftMediaCollectionItemSchema,
+  DraftNavigationCarouselItemSchema,
+  DraftRelatedQuestionItemSchema,
   DraftSectionContentBlockSchema,
+  DraftVideoCarouselItemSchema,
 } from "./experience-ai.schemas"
 
 // ---------------------------------------------------------------------------
@@ -53,6 +59,7 @@ export type CoercionKind =
   | "misscoped_block_dropped"
   | "non_object_block_dropped"
   | "default_filled"
+  | "invalid_item_dropped"
 
 export type Coercion = {
   /** Stable kind identifier for log/event grouping. */
@@ -291,6 +298,17 @@ function coerceBlock(
     out.slots = coerceContainerSlots(raw.slots, `${path}.slots`, sink)
   }
 
+  // --- Nested item-array coercion (block-level strip doesn't recurse) ---
+  const itemArray = ITEM_ARRAY_BY_TYPE.get(canonical)
+  if (itemArray && Array.isArray(out[itemArray.field])) {
+    out[itemArray.field] = coerceItemArray(
+      out[itemArray.field] as unknown[],
+      itemArray.itemSchema,
+      `${path}.${itemArray.field}`,
+      sink,
+    )
+  }
+
   // --- Safe default mirrors --------------------------------------------
   applySafeDefaults(canonical, out, path, sink)
 
@@ -343,6 +361,100 @@ function coerceContainerSlots(
     )
     return { ...slot, content: coercedContent }
   })
+}
+
+/**
+ * Blocks that carry a nested array of `.strict()` item objects, keyed by the
+ * canonical block type. The block-level unknown-key strip in `coerceBlock`
+ * does NOT recurse into these arrays, so a model that (mis)applies one block's
+ * item pattern to another — a stray `candidateRef` on a relatedQuestions item,
+ * a `labelOverride` on a videoCarousel item — slips a `.strict()` item
+ * violation past coercion and crashes the fill step. Each entry's `itemSchema`
+ * is the SAME strict schema the fill/draft validator uses, so we never
+ * hand-transcribe the allowed keys.
+ */
+const ITEM_ARRAY_BLOCKS: ReadonlyArray<{
+  type: string
+  field: string
+  itemSchema: z.ZodObject
+}> = [
+  {
+    type: "bibleQuotesCarousel",
+    field: "quotes",
+    itemSchema: DraftBibleQuoteItemSchema,
+  },
+  { type: "infoBlocks", field: "blocks", itemSchema: DraftInfoBlockItemSchema },
+  {
+    type: "mediaCollection",
+    field: "items",
+    itemSchema: DraftMediaCollectionItemSchema,
+  },
+  {
+    type: "navigationCarousel",
+    field: "items",
+    itemSchema: DraftNavigationCarouselItemSchema,
+  },
+  {
+    type: "relatedQuestions",
+    field: "questions",
+    itemSchema: DraftRelatedQuestionItemSchema,
+  },
+  {
+    type: "videoCarousel",
+    field: "items",
+    itemSchema: DraftVideoCarouselItemSchema,
+  },
+]
+
+const ITEM_ARRAY_BY_TYPE = new Map(
+  ITEM_ARRAY_BLOCKS.map((entry) => [entry.type, entry] as const),
+)
+
+/**
+ * Coerce a nested item array against its strict item schema. Strips unknown
+ * keys (derived from the schema's `shape`, no hand-transcription), then drops
+ * any item that still fails the item schema — so one malformed item never
+ * fails the whole block (lossy + logged, like every other coercion). Survivors
+ * are guaranteed to satisfy `itemSchema`.
+ */
+function coerceItemArray(
+  raw: unknown[],
+  itemSchema: z.ZodObject,
+  path: string,
+  sink: Sink,
+): Record<string, unknown>[] {
+  const allowedKeys = new Set(Object.keys(itemSchema.shape))
+  const out: Record<string, unknown>[] = []
+  raw.forEach((item, index) => {
+    const itemPath = `${path}[${index}]`
+    if (!isPlainObject(item)) {
+      sink.push({
+        kind: "invalid_item_dropped",
+        detail: `dropped non-object item at ${itemPath}`,
+      })
+      return
+    }
+    const cleaned: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(item)) {
+      if (allowedKeys.has(key)) {
+        cleaned[key] = value
+      } else {
+        sink.push({
+          kind: "unknown_key_stripped",
+          detail: `stripped unknown key '${key}' from item at ${itemPath}`,
+        })
+      }
+    }
+    if (!itemSchema.safeParse(cleaned).success) {
+      sink.push({
+        kind: "invalid_item_dropped",
+        detail: `dropped item failing its schema at ${itemPath}`,
+      })
+      return
+    }
+    out.push(cleaned)
+  })
+  return out
 }
 
 /**


### PR DESCRIPTION
# feat: persona-aware experience variants + "Create persona version" button

## Summary

Adds **audience-tailored Experience generation**: produce a version of a topic
or an existing page re-toned for a specific audience persona (grieving,
seeker/skeptic, new believer, family, seasoned believer). The headline new
surface is a **"Create persona version" button** in the Experience editor —
click it, pick an audience, and it generates a persona-adapted **DRAFT**
duplicate seeded by the source page's structure and voice.

Also lands the generation-robustness work that makes this reliable: a
**resilient per-block fill** (a weak model now completes a page by skipping the
blocks it can't author instead of failing the whole page), plus fixes for the
relatedQuestions/nested-item coercion crash and a persona-prompt title leak.

## What's included

**Persona generation core (Mastra)**
- Persona roster + library (`persona-roster.ts`, `persona-library.ts`,
  `persona.schemas.ts`) — 5 audience personas, `v1-placeholder`.
- Persona steering composed into the existing plan/draft prompts (`persona-prompt.ts`).
- Bearer-gated `POST /forge-experience-variant` route — resolves the persona,
  delegates to the **quick-draft** workflow, accepts an optional `exemplar`.

**"Create persona version" button (admin)**
- `generate-variant-action.ts` — server-action core: load source + ABAC →
  sanitized exemplar (`buildExemplarOutline`, video ids stripped) → candidate
  retrieval → `launchMastraExperienceVariant` → `normalizeExperienceDraft` →
  persist a new DRAFT (`<topic>-<persona>`) → return its editor href.
- `persona-variant-button.tsx` — button + audience picker; navigates to the new
  draft on success.
- Wired through `[id]/page.tsx` (`"use server"` thunk) + `experience-editor-with-chat.tsx`.

**Operator script (admin)** — `generate-persona-variants.ts` for batch fan-out
(one topic → N persona pages), with bounded per-persona retry.

**Generation robustness**
- `fix(mastra)`: resilient per-block fill — each node retries
  `MASTRA_FILL_NODE_ATTEMPTS` (default 2) then SKIPs; survivors assemble, with
  `GENERATION_MIN_BLOCKS` as the floor. Turns a 0-for-6 weak model into a
  page-completing one.
- `fix(mastra)`: title leak — synthesize the title from the `TOPIC:` line, not
  the audience-steering prefix.
- `fix(experience-schema)`: strip stray keys from nested item arrays
  (relatedQuestions/videoCarousel/mediaCollection/infoBlocks/etc.) so one
  malformed item no longer fails the whole block.

## Key technical decisions

- **Reuses the existing variant backend** — the button is "Phase B's button":
  it assembles `launchMastraExperienceVariant` + `normalizeExperienceDraft` +
  `ExperienceService.create`. No new generation pipeline.
- **Exemplar steers structure/voice only** — the source page is sanitized to an
  outline (video ids/urls/colors stripped, ~4k cap); the persona drives content,
  copy is freshly written, videos come only from candidate retrieval. So a
  duplicate is a *persona adaptation*, not a verbatim copy.
- **Create, never delete** — duplicates are new DRAFTs; drafts may share a
  `(locale, slug)` (the partial unique index is published-only), so we never
  delete-by-slug from a user-facing action.
- **quick-draft for fan-out** — fewer LLM calls / fewer failure points than the
  5-step pipeline. (Open question: prod's Gemini handles multi-step fine, so we
  could revisit using the richer pipeline there — see caveats.)
- **ABAC** — `canEditExperienceLocale` on the source + `write:experiences` on create.

## Testing

- experience-schema: 48 ✓ · mastra: 773 ✓ · admin: 250 files ✓
- New unit tests: `generate-variant-action` (7), resilient-fill skip + floor (2),
  title-from-TOPIC (1), quick-draft route pin (1), coercion (5).
- **Verified live** end-to-end in the admin UI (button → picker → generate →
  navigate to the new draft) on the gateway Gemma 4 + resilient fill. Demo GIF
  attached.

## Config / deploy notes

Uses the existing admin→mastra wiring (`MASTRA_BASE_URL` +
`MASTRA_SERVICE_API_KEY`); `config_missing` degrades to `NOT_CONFIGURED`. New
optional knobs (all defaulted): `MASTRA_FILL_NODE_ATTEMPTS` (2),
`VARIANT_GENERATION_ATTEMPTS` (3), `MASTRA_VARIANTS_TIMEOUT_MS` (200s).
No schema/migration changes; no GraphQL SDL changes.

## Caveats / follow-ups

- **Personas are `v1-placeholder`** — pending ministry confirmation; surfaced in
  a hardcoded admin-side list (admin must not import from apps/mastra).
- **Model** — locally this runs on the JesusFilm gateway (Gemma 4) + resilient
  fill; production defaults to **Gemini**, which handles strict structured output
  even better.
- **quick-draft vs multi-step** for the variant route — worth revisiting on prod
  Gemini (richer output).
- Persona picker uses a native `<select>` (functional, minimal styling) — could
  move into the chat panel alongside the other AI actions later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
