### PR TITLE
docs(chat-auth): finalize feat-207 plan + correct auth facts

### DIFF
--- a/docs/plans/2026-06-30-002-feat-chat-auth-plan.md
+++ b/docs/plans/2026-06-30-002-feat-chat-auth-plan.md
@@ -1,0 +1,152 @@
+---
+title: "Chat App Authentication - Plan"
+type: feat
+date: 2026-06-30
+topic: chat-auth
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: requirements-only
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Chat App Authentication - Plan
+
+## Goal Capsule
+
+- **Objective:** Let end users of `apps/chat` sign in and sign out, by wiring in the existing `apps/auth` (Better Auth OIDC) provider. Authentication only — establish _who_ the user is, gate nothing.
+- **Product authority:** jian wei (feat-207).
+- **Open blockers:** A chat OAuth client must be registered in `apps/auth` (client id/secret + env vars) **and requested with the `openid` scope** before this can run in any environment. There is no separate "issue an id_token" configuration step: `apps/auth`'s oauth-provider issues an `id_token` automatically whenever `openid` is among the granted scopes (`isIdToken = scopes.includes("openid")` in `@better-auth/oauth-provider`). R9 establishes sessions only from the id_token, so client registration plus the `openid` scope is the hard prerequisite. This lands outside the chat codebase.
+
+---
+
+## Product Contract
+
+### Summary
+
+Add optional sign-in / sign-out to `apps/chat`, reusing admin's redirect-based OAuth client pattern against `apps/auth`. Chat stays fully usable anonymously; signing in establishes the user's identity and offers sign-out, with nothing blocked, gated, or role-checked.
+
+### Problem Frame
+
+`apps/chat` has no concept of a user today — conversations are client-only and every visitor is anonymous. As the chat surface moves toward features that need to know who someone is (history, preferences, per-user behavior down the line), the foundational gap is identity: there is no way to sign in. `apps/auth` already issues identities for the org and `apps/admin` already consumes it, so the missing piece is the integration into chat, not a new auth system.
+
+### Key Decisions
+
+- **Optional sign-in, not a login wall.** Anonymous use stays first-class; the seeker route and the chat UI remain reachable without a session. Sign-in is offered, never required.
+- **Cookie-only session, no database.** Chat must display the signed-in user's identity (R4) but has no database to load it from, so the session is the user's verified identity claims — subject, name, email, picture — read from the ID token at callback and held in a signed, app-local cookie. Chat writes no user record. This matches chat's existing no-persistence boundary and keeps the work to authentication only.
+- **Reuse admin's redirect OAuth flow shape; treat its code as a reference, not a template.** Two distinct things are being decided here. (1) **Flow topology — mirror it.** Chat follows the same authorization-code + PKCE redirect → callback → signed session-cookie _shape_ `apps/admin` uses, run against the same `apps/auth` provider it's already proven against in production. Do not invent a new topology. (2) **Implementation mechanism — hand-adapt admin's routes with `jose`, not an OIDC client library** (see Outstanding Questions for the rationale and rejected alternative). What is _not_ shared regardless of mechanism: chat omits admin's authorization layer entirely (Prisma user lookup, roles, permission checks) — chat needs identity, not authorization; and the session-cookie _payload_ deliberately differs — admin stores `{id, role, scopes}` and displays no identity, whereas chat stores the identity claims because it must display them (R4) and has no database to hold them. R9 also diverges from admin's verifier on purpose (dropping the `idToken ?? accessToken` fallback, which is safe in admin only because it additionally gates on the `admin:access` scope) — see that requirement.
+- **Sign-in is foundational, with no functional payoff in v1.** A signed-in user gains only the display of their own identity; every downstream feature that needs identity (history, preferences) is deferred. This is an accepted bootstrap — the work exists to establish identity, not to reward it yet.
+- **Sign-in / sign-out controls live in the sidebar.** The existing left rail is the home for the signed-out "Sign in" affordance and the signed-in identity + sign-out control.
+- **Defer a shared auth-client package.** No shared package exists today; chat adapts the pattern within its own codebase for now — hand-rolled with `jose` directly (see the mechanism decision above and in Outstanding Questions) — rather than extracting a shared package prematurely. Extraction is revisited only if a second consumer appears.
+
+### Actors
+
+- A1. End user — a visitor to the chat app, anonymous by default, who may choose to sign in.
+- A2. Chat app — initiates the redirect, handles the callback, holds the local session.
+- A3. `apps/auth` — the OIDC provider that authenticates the user and issues identity tokens.
+
+### Key Flows
+
+- F1. Sign in
+  - **Trigger:** A1 activates the sign-in control while signed out.
+  - **Steps:** Chat (A2) redirects the browser to `apps/auth` (A3); the user authenticates with a configured provider; A3 redirects back to chat; chat verifies the identity and establishes a local session.
+  - **Outcome:** The user lands back in chat, signed in, with their identity displayed.
+  - **Covered by:** R1, R4, R5, R8, R9, R10
+
+- F2. Sign out
+  - **Trigger:** A1 activates the sign-out control while signed in.
+  - **Steps:** Chat clears its local session.
+  - **Outcome:** The user is returned to chat as anonymous; chat remains fully usable.
+  - **Covered by:** R2, R6
+
+### Requirements
+
+**Authentication**
+
+- R1. A signed-out user can sign in through `apps/auth` and return to chat authenticated.
+- R2. A signed-in user can sign out.
+- R3. Chat is fully usable without signing in — no surface is gated on auth state, including the seeker route.
+
+**Identity and session**
+
+- R4. When signed in, chat displays the user's identity: the provider's name when present, else the email, else a generic label; and the avatar when the provider supplies one, else initials or a generic icon. Neither name nor avatar is guaranteed by the identity scopes, so both fallbacks are required.
+- R5. A signed-in session is established from verified identity claims and persists across navigation and page refresh until it expires or the user signs out.
+- R6. Signing out ends chat's local session and returns the user to chat as anonymous.
+
+**Boundary**
+
+- R7. Auth state changes identity only — it never changes what a user is allowed to do; chat performs no role or permission checks.
+
+**Auth flow security**
+
+- R8. Sign-in uses authorization-code + PKCE plus a per-request `state` value bound to a short-lived cookie; chat rejects any callback whose returned `state` does not match. The transient cookie(s) carrying `state` and the PKCE `code_verifier` carry the same baseline hardening as the session cookie (R11): HttpOnly, Secure in production, host-only (no `Domain`), `SameSite=Lax` (see R11 — the callback is a top-level cross-site GET return), a short TTL, and cleared on callback. The PKCE `code_verifier` in particular must never be readable by client JS.
+- R9. A session is established only from a present ID token whose signature verifies against the issuer's JWKS and whose issuer, audience (chat's client id), and expiry all check out; an absent, unverifiable, or expired ID token establishes no session. Verification must pin the issuer's expected asymmetric signing algorithm and reject `alg:none` and symmetric-algorithm confusion — signature verification against the JWKS is not complete without an algorithm allowlist. `apps/auth` signs id_tokens with **`EdDSA`** today (better-auth's `jwt()` default; no `keyPairConfig` override in `apps/auth/src/auth/config.ts`), but the allowlist **must be derived from the issuer's published JWKS `alg` at startup**, not hardcoded to `['EdDSA']`. The default only holds while the JWKS key omits an explicit `alg`: better-auth resolves `alg = key.alg ?? keyPairConfig?.alg ?? "EdDSA"`, so a future key rotation or `keyPairConfig` change on `apps/auth`'s side that carries a non-EdDSA `alg` would make a literal `['EdDSA']` pin reject **every** id_token — and because chat gates nothing, that failure surfaces only as "every sign-in silently becomes anonymous," with no error and no cross-repo alarm. Resolving the allowlist from JWKS at startup (restricted to the `alg` values actually present) keeps the pin correct across rotation; if a literal pin is ever kept for simplicity, it must carry an explicit cross-repo coupling note plus a smoke test that fetches JWKS and asserts the expected `alg`. Chat never falls back to the opaque access token for identity — this deliberately diverges from admin's `verifyAdminIdToken`, which verifies `idToken ?? accessToken` and, notably, calls `jwtVerify` with **no** `algorithms` pin; that fallback must be dropped when adapting admin's client, and the algorithm allowlist must be added — admin is safe without either only because it additionally gates on the `admin:access` scope, which chat does not, so R9's signature check is chat's sole barrier. Note: because these two changes (id-token-only, no access-token fallback; algorithm allowlist) are exactly what R9 diverges from admin on, they are **net-new relative to admin's production-proven verifier** — the reused PKCE/state/JWKS-fetch plumbing is proven, but this verifier logic is not, so it must carry its own tests: reject an access token presented as identity, reject `alg:none`, and reject a token signed with a non-allowlisted algorithm.
+- R10. The post-sign-in redirect target is validated against chat's own origin; any untrusted or unparseable target falls back to chat's home, on both the success and failure paths.
+- R11. The session cookie is HttpOnly, Secure in production, **`SameSite=Lax`** (not `Strict`: the cookie is set at the `/callback` route, which is reached via a top-level cross-site redirect back from `apps/auth`, and `SameSite=Strict` would withhold the cookie on exactly that navigation — leaving a freshly signed-in user appearing anonymous; `Lax` sends the cookie on the top-level cross-site GET return while still blocking cross-site subrequests, matching `apps/auth`'s own `sameSite: "lax"`), and host-only — no `Domain` attribute, scoped to chat's own host and never the parent `.jesusfilm.org` domain (per `apps/auth`'s no-shared-parent-cookie rule), `Path=/` — with a bounded lifetime chosen for chat's shared-device exposure (explicitly not inheriting admin's 7-day staff-tool value); its payload is signature-verified on read, and a cookie that fails verification or is past its embedded expiry yields the anonymous state. The cookie's own bounded lifetime is authoritative: the ID token's `exp` is verified once at callback (proving the claims were fresh at sign-in), after which the app-local cookie lifetime governs — chat does not bound the session to the ID token's `exp` (which `apps/auth` sets to 1 hour). Rationale: chat performs no authorization (R7), so ongoing token freshness buys nothing; the claims are a display-only snapshot and the only exposure of a stale snapshot is a briefly out-of-date name/avatar, not any capability. This is the same lifetime knob as the shared-device mitigation below — one short value serves both. Only the concrete number is open (see Outstanding Questions). The verified identity claims (subject, name, email, picture) are protected at rest as well as in transit: they, and any caught ID-token-verification error (which can embed token or claim fragments), must never be written to logs, error responses, or the R12 notice — the callback logs only non-PII outcome codes (matching admin's callback discipline and `apps/auth`'s "no unnecessary PII in stdout logs" posture).
+- R12. When a sign-in attempt returns control to chat without a verified session — cancelled, failed, or refused by the provider — chat shows the user as anonymous with a brief notice, and the sign-in affordance stays available to retry. The notice carries no identity-claim values and no raw verification-error detail (per R11's no-PII-in-logs-or-surfaces posture); it conveys only that sign-in did not complete. A fully abandoned redirect that never returns to chat is out of chat's reach; the affordance simply reappears on the user's next visit.
+
+### Acceptance Examples
+
+- AE1. Anonymous use
+  - **Given** a visitor who is not signed in,
+  - **When** they open chat and send messages,
+  - **Then** chat works exactly as today and a sign-in affordance is visible. **Covers R3.**
+
+- AE2. Sign-in mid-conversation (accepted loss)
+  - **Given** a signed-out user with an in-progress conversation,
+  - **When** they start a sign-in attempt,
+  - **Then** the outbound full-page redirect discards the in-progress conversation immediately, regardless of outcome; if control later returns to chat they are signed in on success or anonymous otherwise, and if they abandon the attempt (close the tab, browser Back) they do not return at all — in every case with no conversation restored. **Covers R1, R5.**
+
+- AE3. Session expiry
+  - **Given** a signed-in user whose session has expired,
+  - **When** they continue using chat,
+  - **Then** chat treats them as anonymous and remains fully usable. **Covers R5, R3, R11.**
+
+- AE4. Sign-in fails, is cancelled, or is refused
+  - **Given** a visitor who attempts to sign in but obtains no verified session (cancelled or an error),
+  - **When** control returns to chat,
+  - **Then** chat shows them as anonymous with a brief notice and keeps the sign-in affordance available to retry. **Covers R10, R12.**
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- A chat-side datastore. This is a deliberate v1 cut with a bounded reversal cost: the deferred features below (history, preferences) will each need a datastore keyed by the authenticated subject, but adding one later reuses the sign-in / OAuth work unchanged — only the datastore is net-new (a server-side, revocable session is additional, and only if revocation is wanted). So identity is a reusable foundation; the no-storage decision is the part later work reverses.
+- Conversation persistence, user-facing history, and cross-device continuity.
+- Per-user preferences or settings.
+- Preserving an in-progress conversation across any sign-in redirect — completed, failed, or cancelled (accepted as lost in v1 — see AE2, AE4).
+- Extracting a shared auth-client package for admin and chat.
+- Inbound auth / rate-limiting on the seeker proxy (tracked separately as its own hardening).
+
+**Outside this work's identity**
+
+- Authorization of any kind — roles, permissions, or gating any surface (including the seeker route) on who the user is. This is authentication only.
+
+### Dependencies / Assumptions
+
+- This feature is feat-207; it depends on feat-205, assumed complete.
+- **Chat authenticates whoever `apps/auth` authenticates — no org-only guarantee.** Chat gates nothing (R7), so who may sign in is `apps/auth`'s policy, not a chat requirement; a signed-in user gains only identity display and could already use chat anonymously. Chat imposes no membership check and treats every authenticated user as first-class. (`apps/auth`'s social / Okta providers set `disableSignUp: true` while its email/password path is open, so the population that can sign in is whatever `apps/auth` currently allows — chat neither depends on nor constrains it. That open email/password path is documented by `apps/auth` as a temporary migration artifact — its CLAUDE.md / AGENTS.md state "No public signup while migration fallback exists" — so the sign-in population is expected to narrow when the Firebase migration fallback is removed.) The "Sign in" affordance is shown to everyone. **Forward flag:** this is safe in v1 because chat persists no per-user state (cookie-only, no datastore), so no self-provisioned account can hold durable data. Any future feature that keys durable per-user state on the authenticated subject (the deferred history / preferences) must first decide whether a membership gate is required before trusting the subject as a stable principal — the id_token already carries a `https://jesusfilm.org/claims/membership_status` claim for exactly that purpose, so the gate is a claim check, not new infrastructure.
+- **Prerequisite (out-of-codebase):** a chat OAuth client registered in `apps/auth` — client id/secret plus the issuer and chat-base-URL env values chat will read. **Sequencing:** because `apps/auth` requires redirect URLs to be exact-match per environment (see its CLAUDE.md security posture), the client registration (with the exact redirect URI for that environment) must land and be verified **before** chat's auth path is enabled there — mirroring the repo's documented receiver-registers-first cross-app discipline. Chat's env is entirely `.optional()`, so when the auth env vars are absent chat must degrade to anonymous-only (hide the sign-in affordance) rather than expose a sign-in that dead-ends in a `redirect_uri` mismatch at the provider with no chat-side signal.
+- **Cookie-signing secret.** R11's "signature-verified on read" guarantee requires a signing secret that chat does not have today — `apps/chat/src/config/env.ts` is entirely `.optional()` so a default-off deploy boots clean, and there is no session secret (contrast admin's mandatory `ADMIN_SESSION_SECRET` in `apps/admin/src/auth/auth-session.ts`). The secret is a per-environment value that is **required on the auth path only** (the default-off anonymous deploy stays zero-prerequisite), and cookie verification MUST fail closed — yield the anonymous state, never sign or accept with a missing/placeholder secret. Rotating the secret invalidates all outstanding sessions (acceptable given the short R11 lifetime). Concrete env-var name and wiring are for planning.
+- Assumes `apps/auth` is reachable from chat's deployment and from local dev (admin uses production auth for local dev; chat is expected to do the same).
+- Assumes sign-out clears chat's local session only; the provider's own SSO session is untouched (matching admin), so a subsequent sign-in may not re-prompt at the provider.
+- **OIDC `nonce` is intentionally omitted.** The ID token is retrieved over the back channel under authorization-code + PKCE with audience binding (R9), so front-channel ID-token replay is out of the threat model; admin's reference uses no nonce either. Nonce stays available as hardening if the flow ever moves to a front channel.
+- **No server-side session / revocation — considered and rejected for v1.** apps/auth itself runs a revocable Better Auth session, but chat cannot share it cross-origin (admin's no-shared-cookie rule), so a revocable session would require chat's own session store (the deferred datastore) or per-request introspection against apps/auth — both are the complexity this MVP defers. Cookie validity governs session lifetime; the short R11 lifetime is the accepted mitigation. **Precondition on that acceptance:** the single R11 lifetime knob is the _sole_ mitigation for both shared-device lingering and the absence of revocation, and it is acceptable **only while the session is display-only** (R7 — no authorization, no durable per-user state). The first feature to trust the authenticated subject for durable or authorization decisions (the deferred history / preferences) must introduce revocation — a server-side session store or per-request introspection — **before** relying on the subject; this safety gate must not be left implicit in the deferred-datastore note.
+- **Accepted risk:** with no revocation and an HttpOnly cookie, a session left signed-in on a shared device cannot be ended early from anywhere — a short R11 lifetime is the only mitigation, and until it expires the next user of that browser may be treated as the previous one (the provider's SSO session also persists, so a re-sign-in may not re-prompt).
+
+### Outstanding Questions
+
+**Deferred to planning**
+
+- The exact session-cookie lifetime value and cookie naming. R11 resolves the expiry-authority question (the app-local cookie lifetime governs, not the ID token's 1-hour `exp`), so only the concrete number is open: short and audience-appropriate for shared-device exposure (not admin's 7 days), and — since it doubles as the shared-device mitigation — short enough to bound how long a session lingers on a shared browser while long enough to stay useful.
+- The R12 sign-in-failure notice: its wording and placement, whether an org-less / unprovisioned-account refusal gets a distinct, actionable message (request access / contact admin) rather than a generic one, and whether a silent session expiry (AE3) surfaces a notice or downgrades quietly.
+- Which OAuth scopes chat requests (identity-only: `openid` / `profile:read` / `email:read`; no `admin:access`). Note: `apps/auth`'s registered scope keys are `profile:read` / `email:read` (see `apps/auth/src/auth/config.ts` `clientRegistrationDefaultScopes`, and admin's proven authorize request in `apps/admin/src/auth/oauth-client.ts`), so request the registered `:read` keys rather than the bare OIDC `profile` / `email` names. This is consent/scope hygiene, **not** an R4-display dependency: the identity claim values reach the id*token via `apps/auth`'s `customIdTokenClaims: ({ user }) => firstPartyUserClaims(user)` (`apps/auth/src/auth/config.ts`), which emits them independent of the requested `profile:read` / `email:read` scopes and whose values override the scope-gated defaults — so R4's display is populated as long as `openid` is granted, regardless of the profile/email scope. The per-claim presence differs by column, though: `name` is DB-guaranteed (the `user.name` column is `NOT NULL` in `apps/auth/prisma/schema.prisma`) so it is effectively always present, while `picture` derives from the nullable `user.image` (`picture: user.image ?? undefined`, which drops from the token when null) and is therefore absent for users without an avatar — a normal case R4's `avatar → initials → icon` fallback already covers. **Forward flag:** the claim \_mechanism* breaks (and R4 loses its data source) only if that `customIdTokenClaims` callback is ever removed or stops emitting these fields; a per-user absent avatar is expected and handled by R4's fallback chain, not a break.
+
+**Resolved during review**
+
+- **Client mechanism: hand-adapt admin's routes (`jose`-based JWKS + id_token verify, per-request state / PKCE), not an OIDC client library.** Rationale: chat needs a single id_token verification at callback (no refresh / renewal / userinfo), the ~150-line surface is `jose`-backed and already proven against `apps/auth` in production, and R9's no-fallback rule is a targeted adaptation rather than a reason to abstract behind a library. The library route was considered and rejected — revisit only if a shared auth-client package (deferred above) is extracted. This mechanism choice is a planning direction, not a requirement: the binding safety net stays in R8 (state / PKCE), R9 (id_token signature + iss / aud / expiry, no access-token fallback), R10 (return-target validation), and R11 (cookie hardening), so any conforming implementation is correct regardless of mechanism.
+
+### Sources / Research
+
+- `apps/admin` OAuth client pattern (the reference to adapt): `apps/admin/src/app/api/auth/login/route.ts`, `apps/admin/src/app/api/auth/callback/route.ts`, `apps/admin/src/auth/oauth-client.ts`, `apps/admin/src/auth/auth-session.ts`, `apps/admin/src/auth/session.ts`. Chat omits the authorization layer in `apps/admin/src/auth/permissions.ts`.
+- `apps/auth` provider config (providers, scopes, token claims): `apps/auth/src/auth/config.ts`; routes under `apps/auth/src/app/api/auth/[...all]/route.ts`.
+- `apps/chat` current state: `apps/chat/src/config/env.ts` (zod, all `.optional()`); no middleware, no auth wiring, no database today.

--- a/docs/roadmap/ai-chat/README.md
+++ b/docs/roadmap/ai-chat/README.md
@@ -11,12 +11,12 @@ from the main DS Year 1 roadmap.
 > index, and nothing regenerates or overwrites it. See `CLAUDE.md` in this
 > folder for the maintenance rules and why the lane is unregistered.
 
-## Status (June 29, 2026)
+## Status (July 1, 2026)
 
 - **Total tickets:** 12
 - ✅ **Complete:** 9
-- 🟡 **In progress:** 0
-- 🔵 **Not started:** 2
+- 🟡 **In progress:** 1
+- 🔵 **Not started:** 1
 - 🔴 **Blocked:** 1
 
 ## Feature Index
@@ -32,6 +32,6 @@ from the main DS Year 1 roadmap.
 | [feat-204](feat-204-expose-seeker-mastra-service-route.md)   | Expose Seeker agent via internal Mastra SSE service route   | jian wei | P2       | 2026-06-24 | 3    | ✅ complete    | #1371   |
 | [feat-205](feat-205-chat-wire-seeker-route.md)               | Wire chat app to the Seeker Mastra route                    | jian wei | P1       | 2026-06-27 | 3    | ✅ complete    | #1384   |
 | [feat-206](feat-206-chat-introduce-react-testing-library.md) | Introduce React Testing Library to the chat app             | jian wei | P2       | 2026-07-03 | 2    | ✅ complete    | #1372   |
-| [feat-207](feat-207-chat-auth.md)                            | Chat app authentication                                     | jian wei | P1       | 2026-07-07 | 5    | 🔵 not-started | —       |
+| [feat-207](feat-207-chat-auth.md)                            | Chat app authentication                                     | jian wei | P1       | 2026-07-07 | 5    | 🟡 in-progress | —       |
 | [feat-208](feat-208-seeker-postgres-memory.md)               | Postgres-persisted Seeker memory + conversation persistence | jian wei | P2       | 2026-07-10 | 5    | 🔵 not-started | —       |
 | [feat-209](feat-209-chat-per-conversation-urls.md)           | Per-conversation URLs + sidebar history                     | jian wei | P2       | 2026-07-15 | 3    | 🔴 blocked     | —       |

--- a/docs/roadmap/ai-chat/feat-207-chat-auth.md
+++ b/docs/roadmap/ai-chat/feat-207-chat-auth.md
@@ -15,37 +15,6 @@ tags:
   - "infrastructure"
 ---
 
-> **Thin stub — not yet investigated.** Needs its own brainstorm/plan before
-> implementation. It captures the auth follow-on surfaced during the feat-205
-> brainstorm. Read
-> `docs/brainstorms/2026-06-25-chat-wire-seeker-route-requirements.md`
-> (Key Decisions, Dependencies / Assumptions, Scope Boundaries) first.
-
 ## Problem
 
-`apps/chat` has no auth (Intentionally Absent). feat-205 ships Seeker wiring whose
-v1 safety boundary is only URL obscurity + a small trusted audience — not an
-access gate — and whose `threadId` is the browser's `Conversation.id` forwarded
-verbatim (a conscious relaxation safe only while the deployment is non-public and
-has no per-conversation URL). Auth is the gate that lets the chat app widen its
-audience and harden Seeker access.
-
-## What this unlocks (carried over from the feat-205 brainstorm)
-
-- A real **inbound access gate** on the chat backend (the feat-205 R5 prerequisite
-  before any public reachability), replacing obscurity-as-boundary.
-- **`resourceId = userId`**, which makes Mastra's thread-owner check fire — turning
-  the inert v1 isolation into genuine per-user isolation, and letting feat-205's
-  throwaway `threadId` be re-plumbed server-minted + user-bound.
-- **Per-user feature-flag targeting** (e.g. LaunchDarkly) so Seeker can be enabled
-  for specific users rather than the whole deployment.
-
-## Constraints
-
-- Auth must be built on `apps/auth` (the shared auth app), not a chat-local
-  implementation.
-- Do not relocate Mastra-side responsibility here.
-
-## Verification
-
-- To be defined in this ticket's own brainstorm/plan.
+`apps/chat` has no auth. Integrate `apps/auth` into the chat app so that users can sign in and log out.

--- a/docs/roadmap/ai-chat/feat-207-chat-auth.md
+++ b/docs/roadmap/ai-chat/feat-207-chat-auth.md
@@ -3,7 +3,7 @@ id: "feat-207"
 title: "Chat app authentication"
 owner: "jian wei"
 priority: "P1"
-status: "not-started"
+status: "in-progress"
 start_date: "2026-07-07"
 duration: 5
 depends_on:
@@ -17,4 +17,60 @@ tags:
 
 ## Problem
 
-`apps/chat` has no auth. Integrate `apps/auth` into the chat app so that users can sign in and log out.
+`apps/chat` has no concept of a user — every visitor is anonymous and conversations are client-only. Integrate the existing `apps/auth` (Better Auth OIDC) provider into the chat app so end users can sign in and sign out. This is **authentication only**: establish _who_ the user is. It does not add authorization, roles, permissions, or gating of any surface (including the `/api/seeker` route).
+
+Full requirements + scope in `docs/plans/2026-06-30-002-feat-chat-auth-plan.md`.
+
+## Entry Points — Read These First
+
+1. `apps/admin/src/app/api/auth/login/route.ts` — the redirect-to-authorize entry of admin's OAuth flow (authorization-code + PKCE). The pattern chat adapts.
+2. `apps/admin/src/app/api/auth/callback/route.ts` — code exchange + ID-token verification + session-cookie creation. Chat mirrors the shape, **minus** the Prisma user lookup / role resolution.
+3. `apps/admin/src/auth/oauth-client.ts` — `buildAuthorizeUrl` / `exchangeAuthorizationCode` / `verifyIdToken` logic to adapt for chat. **Caution when adapting `verifyIdToken`:** admin's version verifies `idToken ?? accessToken` — do NOT copy that fallback. It is safe in admin only because admin _additionally_ gates on the `admin:access` scope; chat has no such gate, so accepting the opaque access token as identity would be a real hole (R9 forbids it). **Second caution:** admin's `jwtVerify` call passes no `algorithms` allowlist — chat must add one (R9), but **derive it from the issuer's published JWKS `alg` at startup rather than hardcoding a value.** `apps/auth` signs with `EdDSA` today (better-auth's bare `jwt()` default, no `keyPairConfig` override in `apps/auth/src/auth/config.ts`), but better-auth resolves `alg = key.alg ?? keyPairConfig?.alg ?? "EdDSA"`, so a future key rotation carrying an explicit non-EdDSA `alg` would make a hardcoded `['EdDSA']` pin reject every real id_token — surfacing only as silent all-anonymous, since chat gates nothing. A JWKS-derived allowlist stays correct across rotation (and an assumed RSA/EC default is wrong today). See R9.
+4. `apps/admin/src/auth/auth-session.ts` + `session.ts` — signed-cookie create/read + `requireSession()`. Chat needs the create/read; it does **not** need a redirecting `requireSession()` (chat is anonymous-OK).
+5. `apps/admin/src/auth/permissions.ts` — admin's role/permission layer. **Reference only — chat does NOT replicate this.**
+6. `apps/auth/src/auth/config.ts` — provider config, advertised scopes, ID-token claims (`name`, `email`, `picture`). Source of the identity chat displays.
+7. `apps/chat/src/config/env.ts` — zod env validation, all `.optional()`; where chat's new auth env vars get added (keep them optional so the app still boots unconfigured).
+8. `apps/chat/src/components/shell/sidebar.tsx` (+ `sidebar-header.tsx`, the `sidebar-*` sub-components) — the left rail that hosts the signed-out "Sign in" affordance and the signed-in identity + sign-out control.
+
+## Grep These
+
+- `oauth` / `OAuth` / `pkce` / `codeVerifier` / `codeChallenge` in `apps/admin/src/auth/` — the flow primitives to port.
+- `requireSession` / `Principal` in `apps/admin/src/auth/` — session-reading shape (chat keeps reading, drops the role/redirect parts).
+- `AUTH_ISSUER_URL` / `AUTH_ADMIN_CLIENT_ID` / `AUTH_COOKIE_PREFIX` in `apps/admin` — the env var names to model chat's after (`AUTH_CHAT_CLIENT_ID`, `CHAT_BASE_URL`, etc.).
+- `SignJWT` / cookie name constants in `apps/admin/src/auth/auth-session.ts` — signed app-local session cookie creation.
+- `'use client'` in `apps/chat/src/components/shell/` — which sidebar components can hold the sign-in/out control vs stay presentational.
+
+## What To Build
+
+A redirect-based OAuth client in `apps/chat` that authenticates against `apps/auth` and holds the result in a signed, app-local session cookie — **no database**. **Mechanism is decided, not open:** hand-adapt admin's routes using `jose` directly (JWKS + id*token verify, per-request state / PKCE) — do \_not* pull in an OIDC client library. Chat needs only a single id_token verification at callback (no refresh / renewal / userinfo), the surface is small and already proven against `apps/auth` in prod, and the safety net lives in the R8–R11 requirements regardless of mechanism. See the plan's "Resolved during review" note for the rejected-library rationale. Concretely:
+
+- Login + callback route handlers in chat (adapted from admin) implementing authorization-code + PKCE: redirect to `apps/auth`, verify the returned ID token, set a signed session cookie carrying the verified identity claims (name, email, picture). Request identity-only scopes — `openid`, `profile:read`, `email:read` (these are `apps/auth`'s registered scope keys — request them rather than the unregistered bare OIDC `profile` / `email` names) — never `admin:access`. The identity display does **not** depend on the profile/email scope: `apps/auth`'s `customIdTokenClaims` emits `name` / `email` / `picture` into the id_token independent of scope, so the display is populated as long as `openid` is granted (see the plan's scopes note).
+- A logout route handler that clears chat's session cookie and returns the user to chat (anonymous).
+- Server-side session reading that exposes the current identity to components **without redirecting** when absent (anonymous is a valid state).
+- Sidebar UI: signed-out shows a "Sign in" control; signed-in shows the user's name (and avatar when present) plus a "Sign out" control.
+- New `.optional()` auth env vars in `apps/chat/src/config/env.ts` (issuer URL, chat client id/secret, chat base URL, optional cookie prefix, and a **cookie-signing secret** — chat has none today, contrast admin's mandatory `ADMIN_SESSION_SECRET`) + `.env.example` entries. Keep them `.optional()` so the default-off deploy still boots, but cookie verification MUST fail closed to the anonymous state when the signing secret is absent/placeholder — never sign or accept with a missing secret.
+- Carry over admin's auth-flow security controls (these are committed requirements, not optional): per-request OAuth `state` (CSRF) alongside PKCE; full ID-token verification (JWKS signature + issuer + audience + expiry) before any session is established, with **no fallback to the opaque access token** for identity; an origin allowlist on the post-login redirect (success and failure paths); and a short-lived (audience-appropriate, not admin's 7 days) HttpOnly + Secure-in-prod + **`SameSite=Lax`** (not `Strict` — the cookie is set on the cross-site `/callback` return and `Strict` would withhold it there) + **host-only** (no `Domain`, never `.jesusfilm.org` — apps/auth's no-shared-parent-cookie rule) session cookie that is signature-verified on read and treated as anonymous when expired/invalid. Apply the same baseline hardening (HttpOnly, Secure-in-prod, host-only, `SameSite=Lax`, short TTL, cleared on callback) to the transient `state` / PKCE `code_verifier` cookie(s).
+- Handle the no-session path: when a cancelled, failed, or provider-refused sign-in (including an org-less account) returns control to chat, show the user as anonymous with a brief notice, affordance still available. A fully abandoned redirect that never returns is out of reach — the affordance just reappears on the next visit.
+
+Detailed requirements (R1–R12), flows (F1–F2), and acceptance examples (AE1–AE4) live in `docs/plans/2026-06-30-002-feat-chat-auth-plan.md`. Run `/ce-plan` against that doc to produce the implementation plan.
+
+## Constraints
+
+- **Authentication only.** No roles, no permissions, no gating. Do not gate the `/api/seeker` route or any other surface on auth state.
+- **Anonymous stays first-class.** Chat must remain fully usable signed out. Session-reading must not redirect unauthenticated users.
+- **No database / no Prisma in chat.** The signed session cookie is the entire session. Do not add a user table or replicate admin's `resolveUser` / `permissions.ts`.
+- **New env vars must be `.optional()`** so chat still boots with none set (matches the existing `env.ts` convention; avoids bricking Railway deploys).
+- **Accepted limitation:** signing in mid-conversation discards the in-progress (client-only) conversation via the full-page redirect. Do not build conversation-preservation to work around it (out of scope).
+- **Prerequisite (out-of-codebase):** a chat OAuth client must be registered in `apps/auth` (client id/secret) and requested with the `openid` scope before this runs in any environment. `apps/auth` issues an `id_token` automatically whenever `openid` is granted (there is no separate "issue id_token" toggle), and R9 establishes sessions only from it. Because `apps/auth` requires exact-match redirect URIs per environment, the registration must land and be verified **before** chat's auth path is enabled there; when the auth env vars are absent chat degrades to anonymous-only (hides the sign-in affordance) rather than exposing a sign-in that dead-ends at a `redirect_uri` mismatch.
+- **Chat authenticates whoever `apps/auth` authenticates — no org-only guarantee, no membership check.** Chat gates nothing (auth-only), so who may sign in is `apps/auth`'s policy, not a chat concern; an authenticated outsider gains only identity display and could already use chat anonymously. Treat every authenticated user as first-class. Do not build a signup path or a membership gate. Show the "Sign in" affordance to everyone. (`apps/auth`'s open email/password path is documented there as a temporary migration artifact. Safe for v1 because chat persists no per-user state; **forward flag** for the deferred history/preferences work — keying durable state on the subject must first decide whether a membership gate is needed, and the id_token already carries a `membership_status` claim for exactly that, so it's a claim check not new infra.)
+- **No PII in logs or surfaces (R11/R12).** The verified identity claims (subject, name, email, picture) and any caught id_token-verification error (which can embed token/claim fragments) must never be written to logs, error responses, or the R12 failure notice — the callback logs only non-PII outcome codes (matches admin's callback discipline and `apps/auth`'s no-unnecessary-PII-in-stdout posture).
+- Identity display (R4) needs fallbacks: name → email → generic label; avatar → initials → generic icon (`picture` derives from the nullable `user.image`, so it's absent for avatar-less users; `name` is DB-guaranteed via a `NOT NULL` column but the fallback still covers empty/edge values). OIDC `nonce` is intentionally omitted (back-channel code+PKCE, audience-bound); a server-side/revocable session is considered-and-rejected for v1 (short cookie lifetime is the mitigation) — but that short-lifetime knob is the sole mitigation for both shared-device lingering and no-revocation, so the first feature to trust the subject for durable/authz decisions must add revocation before relying on it.
+
+## Verification
+
+- `pnpm --filter @forge/chat build` / `lint` / `typecheck` / `test` all pass.
+- App still boots with **no** auth env vars set, and chat is fully usable anonymously (send messages, no sign-in required).
+- With chat's OAuth client configured: sign-in redirects to `apps/auth`, returns authenticated, and the sidebar shows the user's identity.
+- Sign-out clears the session and returns the user to an anonymous, still-usable chat.
+- The `/api/seeker` route behaves identically signed-in and signed-out (no gating).
+- Colocated tests cover the OAuth callback (token verification + cookie set) and the signed-out/anonymous path.

--- a/docs/roadmap/ai-chat/feat-208-seeker-postgres-memory.md
+++ b/docs/roadmap/ai-chat/feat-208-seeker-postgres-memory.md
@@ -15,46 +15,6 @@ tags:
   - "infrastructure"
 ---
 
-> **Thin stub — not yet investigated.** Needs its own brainstorm/plan before
-> implementation. It captures the persistence follow-on surfaced during the
-> feat-205 brainstorm. Read
-> `docs/brainstorms/2026-06-25-chat-wire-seeker-route-requirements.md`
-> (Scope Boundaries, Dependencies / Assumptions) first.
-
 ## Problem
 
-Seeker memory is an in-memory singleton today (lost on Mastra restart), and the
-chat app keeps conversation history client-side (lost on browser refresh). So
-multi-turn recall is fragile and there is no sidebar of past conversations. This is
-a documented deferred release gate in `apps/mastra/CLAUDE.md` and feat-204.
-
-## What this unlocks (carried over from the feat-205 brainstorm)
-
-- **Durable Seeker memory** on Postgres (admin already proves the path for the
-  experience-chat agent), keyed by `(resourceId, threadId)`.
-- **Conversation persistence** — because Mastra's persisted memory is a queryable
-  per-`(resourceId, threadId)` message store (`getThreadById`, list-threads-by-
-  resource), it can double as the store that rebuilds a user's sidebar of past
-  conversations and restores a conversation on load — likely with no separate
-  chat-side database.
-- Resolves the feat-205 multi-turn-recall contingency (the never-created-thread
-  throw + Mastra-restart-drops-thread failure modes) by giving threads a durable
-  home.
-
-## Constraints
-
-- Mastra-owned generation/storage split stays as documented; admin/Mastra ownership
-  boundaries unchanged.
-- Genuinely useful only once `resourceId = userId` exists — pairs with feat-207
-  (auth), though it can land technically under the shared default resource first.
-- **Consider (non-binding):** decide whether seeker memory needs a retention/prune
-  policy at all (thread TTL and/or per-thread message cap) — or whether we simply
-  keep all conversations indefinitely, which is a valid choice. This is the residue
-  of feat-202's deferred in-memory eviction (item ②): moving to Postgres eliminates
-  the heap-OOM risk, leaving only ordinary table growth. Not a release gate — flag
-  the question for this ticket's own brainstorm. See
-  `docs/brainstorms/2026-06-29-seeker-rag-runtime-hardening-requirements.md`.
-
-## Verification
-
-- To be defined in this ticket's own brainstorm/plan.
+Seeker memory is in-memory and conversation history is client-side, so both are lost on restart or refresh. Persist them to Postgres for durable multi-turn recall and conversation history.

--- a/docs/roadmap/ai-chat/feat-209-chat-per-conversation-urls.md
+++ b/docs/roadmap/ai-chat/feat-209-chat-per-conversation-urls.md
@@ -14,36 +14,6 @@ tags:
   - "web"
 ---
 
-> **Thin stub — not yet investigated.** Needs its own brainstorm/plan before
-> implementation. It captures the deep-linking follow-on surfaced during the
-> feat-205 brainstorm. Read
-> `docs/brainstorms/2026-06-25-chat-wire-seeker-route-requirements.md`
-> (Scope Boundaries, Dependencies / Assumptions) first.
-
 ## Problem
 
-Conversations are client-only and have no URL, so they can't be deep-linked,
-restored on refresh, or shared — and there's no sidebar of past conversations like
-Claude/ChatGPT/Gemini. A per-conversation URL is only meaningful once there's a
-durable store to restore from and an identity to scope conversations to.
-
-## What this unlocks (carried over from the feat-205 brainstorm)
-
-- **Deep-linkable, restorable conversations** (`/c/<id>`-style routing) that survive
-  refresh and can be reopened.
-- A **sidebar of the signed-in user's past conversations**, read from durable
-  per-user threads.
-
-## Constraints
-
-- **Depends on both** feat-207 (auth → `resourceId = userId` so conversations are
-  owned and listable per user) and feat-208 (durable threads to restore from). A URL
-  without persistence is a link to nothing; a per-user sidebar without auth has no
-  owner to scope to.
-- Adding a URL that carries the `threadId` before auth would place the memory key in
-  a shareable link — this is exactly the feat-205 tripwire, so URLs must not ship
-  ahead of auth.
-
-## Verification
-
-- To be defined in this ticket's own brainstorm/plan.
+Conversations are client-only with no URL, so they can't be deep-linked, restored, or shared, and there's no sidebar of past conversations. Add per-conversation URLs and a history sidebar.


### PR DESCRIPTION
## What

Finalizes the **feat-207 chat authentication** requirements plan after a multi-persona doc review, and brings the roadmap ticket into agreement. Docs-only — no code changes.

## Why

The review (7 personas) surfaced two **codebase-verified factual errors** in the plan plus several under-specified auth-security requirements. A `/ce-plan` run against the doc would otherwise inherit the wrong facts.

## Plan changes (`docs/plans/2026-06-30-002-feat-chat-auth-plan.md`)

- **Fix (factual):** `id_token` is issued automatically when `openid` is granted — there is no "configure to issue id_token" toggle. Prerequisite is client registration + `openid` scope.
- **Fix (factual):** R4 identity claims flow from `apps/auth`'s `customIdTokenClaims` **unconditionally**, not from the `profile:read`/`email:read` scopes. `name` is `NOT NULL`; `picture` derives from nullable `user.image` (R4's avatar fallback covers absence).
- **R8:** harden the transient `state`/PKCE cookie like the session cookie.
- **R9:** derive the JWKS algorithm allowlist at startup (not a hardcoded `['EdDSA']` pin); flag the no-fallback + allowlist verifier as net-new vs admin's, needs own tests.
- **R11:** pin `SameSite=Lax` (`Strict` would drop the session on the OAuth callback return).
- **Dependencies:** registration-before-enable sequencing + degrade-to-anonymous; revocation precondition for the first subject-trusting feature.

## Roadmap changes

- `docs/roadmap/ai-chat/feat-207-chat-auth.md`: aligned with the corrected plan; status → `in-progress`.
- `docs/roadmap/ai-chat/README.md`: updated lane counts (in-progress 0→1, not-started 2→1) and date.

## Not changed (deliberate)

The "build identity now with no v1 payoff" sequencing premise — the product authority has accepted a display-only sign-in/sign-out V1 as a deliberate bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)